### PR TITLE
drivedb: Add Phison MSD210 Series SSD under Phison Driven SSDs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,7 @@ image: Ubuntu2204
 init:
   # as its not possible to use docker as source image, we will install everything in init step
   - >
-    sudo apt-get update &&
+    sudo apt-get update --allow-releaseinfo-change &&
     sudo apt-get install -y g++-mingw-w64-x86-64 g++-mingw-w64-i686 unzip wget man2html-base groff
   # NSIS 3.08-3 from Debian 12 generates bogus relocation information (regression).
   # The fixed version 3.09-1 is still only available from Ubuntu 23.10 (mantic, devel).

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,9 +14,9 @@ init:
   # Manually install this version.  The warning about outdated libstdc++6 could be
   # safely ignored.
   - >
-    wget http://mirrors.kernel.org/ubuntu/pool/universe/n/nsis/nsis_3.09-1_amd64.deb -O /tmp/nsis_3.09-1_amd64.deb &&
-    wget http://mirrors.kernel.org/ubuntu/pool/universe/n/nsis/nsis-common_3.09-1_all.deb -O /tmp/nsis-common_3.09-1_all.deb
-    && sudo dpkg --install --force-all /tmp/nsis-common_3.09-1_all.deb /tmp/nsis_3.09-1_amd64.deb
+    wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/n/nsis/nsis_3.09-4ubuntu1_amd64.deb -O /tmp/nsis_3.09-4ubuntu1_amd64.deb &&
+    wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/n/nsis/nsis-common_3.09-4ubuntu1_all.deb -O /tmp/nsis-common_3.09-4ubuntu1_all.deb
+    && sudo dpkg --install --force-all /tmp/nsis-common_3.09-4ubuntu1_all.deb /tmp/nsis_3.09-4ubuntu1_amd64.deb
 
 build_script:
 - cd smartmontools

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,16 @@ init:
   # as its not possible to use docker as source image, we will install everything in init step
   - >
     sudo apt-get update --allow-releaseinfo-change &&
-    sudo apt-get install -y g++-mingw-w64-x86-64 g++-mingw-w64-i686 unzip wget man2html-base groff nsis
+    sudo apt-get install -y g++-mingw-w64-x86-64 g++-mingw-w64-i686 unzip wget man2html-base groff
+
+# we are building nsis 3.10 because one from ububtu 22.04 is impacted by 
+# https://linux.debian.bugs.dist.narkive.com/x9BPoQjZ/bug-1050288-nsis-3-08-3-bookworm-generates-bogus-relocation-information-regression
+before_build:
+- cd $HOME
+- wget 'https://downloads.sourceforge.net/project/libpng/zlib/1.2.8/zlib128-dll.zip' && unzip -d zlib zlib128-dll.zip
+- wget https://prdownloads.sourceforge.net/nsis/nsis-3.10-src.tar.bz2 && tar -xf nsis-3.10-src.tar.bz2
+- sudo apt-get install -y scons binutils-mingw-w64-i686 zlib1g-dev libcppunit-dev
+- cd nsis-3.10-src && sudo scons -j `nproc` ZLIB_W32=$HOME/zlib SKIPUTILS="NSIS Menu" NSIS_CONFIG_LOG=yes build install && cd $APPVEYOR_BUILD_FOLDER
 
 build_script:
 - cd smartmontools
@@ -25,11 +34,9 @@ build_script:
 - cd ../build && dest="smartmontools-win32-setup-${SM_VER}-r${SVNREV}.exe"
 - make BUILD_INFO="$BUILD_INFO" builddir_win64=../build64 distinst_win32="$dest" installer-win32
 - sha256sum *.exe
-# - cd /home/appveyor/projects/smartmontools-fork/ && zip build.zip smartmontools -r
 
 artifacts:
 - path: smartmontools/build/smartmontools-win32-setup-*.exe
-# - path: build.zip
 
 deploy:
 - provider: Webhook

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,15 +8,7 @@ init:
   # as its not possible to use docker as source image, we will install everything in init step
   - >
     sudo apt-get update --allow-releaseinfo-change &&
-    sudo apt-get install -y g++-mingw-w64-x86-64 g++-mingw-w64-i686 unzip wget man2html-base groff
-  # NSIS 3.08-3 from Debian 12 generates bogus relocation information (regression).
-  # The fixed version 3.09-1 is still only available from Ubuntu 23.10 (mantic, devel).
-  # Manually install this version.  The warning about outdated libstdc++6 could be
-  # safely ignored.
-  - >
-    wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/n/nsis/nsis_3.09-4ubuntu1_amd64.deb -O /tmp/nsis_3.09-4ubuntu1_amd64.deb &&
-    wget http://mirrors.edge.kernel.org/ubuntu/pool/universe/n/nsis/nsis-common_3.09-4ubuntu1_all.deb -O /tmp/nsis-common_3.09-4ubuntu1_all.deb
-    && sudo dpkg --install --force-all /tmp/nsis-common_3.09-4ubuntu1_all.deb /tmp/nsis_3.09-4ubuntu1_amd64.deb
+    sudo apt-get install -y g++-mingw-w64-x86-64 g++-mingw-w64-i686 unzip wget man2html-base groff nsis
 
 build_script:
 - cd smartmontools

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -149,7 +149,7 @@ references:
 
   sm_compile_freebsd13: &sm_compile_freebsd13
     run:
-      name: Creating static FreeBSD-13.2/amd64 binaries
+      name: Creating static FreeBSD-13.4/amd64 binaries
       command: |
         SM_VER=`cat ~/SM_VER` && SVNREV=`cat ~/SVNREV` &&
         SOURCE_DATE_EPOCH=`cat ~/SOURCE_DATE_EPOCH` &&
@@ -165,12 +165,12 @@ references:
         make -j3 BUILD_INFO="$BUILD_INFO" &&
         mkdir inst && make DESTDIR="$(pwd)/inst" install &&
         (cd inst && tar --sort=name --mtime=@${SOURCE_DATE_EPOCH} \
-         -czf "/artefacts/smartmontools-freebsd13.2-amd64-static-${SM_VER}-r${SVNREV}.tar.gz" *) &&
+         -czf "/artefacts/smartmontools-freebsd13.4-amd64-static-${SM_VER}-r${SVNREV}.tar.gz" *) &&
         rm -rf ~/build
 
   sm_compile_freebsd14: &sm_compile_freebsd14
     run:
-      name: Creating static FreeBSD-14.0/amd64 binaries
+      name: Creating static FreeBSD-14.1/amd64 binaries
       command: |
         SM_VER=`cat ~/SM_VER` && SVNREV=`cat ~/SVNREV` &&
         SOURCE_DATE_EPOCH=`cat ~/SOURCE_DATE_EPOCH` &&
@@ -186,7 +186,7 @@ references:
         make -j3 BUILD_INFO="$BUILD_INFO" &&
         mkdir inst && make DESTDIR="$(pwd)/inst" install &&
         (cd inst && tar --sort=name --mtime=@${SOURCE_DATE_EPOCH} \
-         -czf "/artefacts/smartmontools-freebsd14.0-amd64-static-${SM_VER}-r${SVNREV}.tar.gz" *) &&
+         -czf "/artefacts/smartmontools-freebsd14.1-amd64-static-${SM_VER}-r${SVNREV}.tar.gz" *) &&
         rm -rf ~/build
 
   sm_run_cppcheck: &sm_run_cppcheck

--- a/drivedb.h
+++ b/drivedb.h
@@ -1,0 +1,6959 @@
+/*
+ * drivedb.h - smartmontools drive database file
+ *
+ * Home page of code is: https://www.smartmontools.org
+ *
+ * Copyright (C) 2003-11 Philip Williams, Bruce Allen
+ * Copyright (C) 2008-25 Christian Franke
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+/*
+ * Structure used to store drive database entries:
+ *
+ * struct drive_settings {
+ *   const char * modelfamily;
+ *   const char * modelregexp;
+ *   const char * firmwareregexp;
+ *   const char * warningmsg;
+ *   const char * presets;
+ * };
+ *
+ * The elements are used in the following ways:
+ *
+ *  modelfamily     Informal string about the model family/series of a
+ *                  device. Set to "" if no info (apart from device id)
+ *                  known.  The entry is ignored if this string starts with
+ *                  a dollar sign.  Must not start with "USB:", see below.
+ *  modelregexp     POSIX extended regular expression to match the model of
+ *                  a device.  This should never be "".
+ *  firmwareregexp  POSIX extended regular expression to match a devices's
+ *                  firmware.  This is optional and should be "" if it is not
+ *                  to be used.  If it is nonempty then it will be used to
+ *                  narrow the set of devices matched by modelregexp.
+ *  warningmsg      A message that may be displayed for matching drives.  For
+ *                  example, to inform the user that they may need to apply a
+ *                  firmware patch.
+ *  presets         String with vendor-specific attribute ('-v') and firmware
+ *                  bug fix ('-F') options.  Same syntax as in smartctl command
+ *                  line.  The user's own settings override these.
+ *
+ * The regular expressions for drive model and firmware must match the full
+ * string.  The effect of "^FULLSTRING$" is identical to "FULLSTRING".
+ * The form ".*SUBSTRING.*" can be used if substring match is desired.
+ *
+ * The table will be searched from the start to end or until the first match,
+ * so the order in the table is important for distinct entries that could match
+ * the same drive.
+ *
+ *
+ * Format for USB ID entries:
+ *
+ *  modelfamily     String with format "USB: DEVICE; BRIDGE" where
+ *                  DEVICE is the name of the device and BRIDGE is
+ *                  the name of the USB bridge.  Both may be empty
+ *                  if no info known.
+ *  modelregexp     POSIX extended regular expression to match the USB
+ *                  vendor:product ID in hex notation ("0x1234:0xabcd").
+ *                  This should never be "".
+ *  firmwareregexp  POSIX extended regular expression to match the USB
+ *                  bcdDevice info.  Only compared during search if other
+ *                  entries with same USB vendor:product ID exist.
+ *  warningmsg      Not used yet.
+ *  presets         String with one device type ('-d') option.
+ *
+ */
+
+/*
+const drive_settings builtin_knowndrives[] = {
+ */
+  { "VERSION: 7.5 $Id$",
+    "-", "-",
+    "Version information",
+    ""
+  },
+  { "DEFAULT",
+    "-", "-",
+    "Default settings",
+    "-v 1,raw48,Raw_Read_Error_Rate "
+    "-v 2,raw48,Throughput_Performance "
+    "-v 3,raw16(avg16),Spin_Up_Time "
+    "-v 4,raw48,Start_Stop_Count "
+    "-v 5,raw16(raw16),Reallocated_Sector_Ct "
+    "-v 6,raw48,Read_Channel_Margin,HDD "
+    "-v 7,raw48,Seek_Error_Rate,HDD "
+    "-v 8,raw48,Seek_Time_Performance,HDD "
+    "-v 9,raw24(raw8),Power_On_Hours "
+    "-v 10,raw48,Spin_Retry_Count,HDD "
+    "-v 11,raw48,Calibration_Retry_Count,HDD "
+    "-v 12,raw48,Power_Cycle_Count "
+    "-v 13,raw48,Read_Soft_Error_Rate "
+    //  14-21 Unknown_Attribute
+    "-v 22,raw48,Helium_Level,HDD " // WDC (HGST)
+    "-v 23,raw48,Helium_Condition_Lower,HDD " // ] Toshiba
+    "-v 24,raw48,Helium_Condition_Upper,HDD " // ]
+    //  25-174 Unknown_Attribute
+    "-v 175,raw48,Program_Fail_Count_Chip,SSD "
+    "-v 176,raw48,Erase_Fail_Count_Chip,SSD "
+    "-v 177,raw48,Wear_Leveling_Count,SSD "
+    "-v 178,raw48,Used_Rsvd_Blk_Cnt_Chip,SSD "
+    "-v 179,raw48,Used_Rsvd_Blk_Cnt_Tot,SSD "
+    "-v 180,raw48,Unused_Rsvd_Blk_Cnt_Tot,SSD "
+    "-v 181,raw48,Program_Fail_Cnt_Total "
+    "-v 182,raw48,Erase_Fail_Count_Total,SSD "
+    "-v 183,raw48,Runtime_Bad_Block "
+    "-v 184,raw48,End-to-End_Error "
+    //  185-186 Unknown_Attribute
+    "-v 187,raw48,Reported_Uncorrect "
+    "-v 188,raw48,Command_Timeout "
+    "-v 189,raw48,High_Fly_Writes,HDD "
+    "-v 190,tempminmax,Airflow_Temperature_Cel "
+    "-v 191,raw48,G-Sense_Error_Rate,HDD "
+    "-v 192,raw48,Power-Off_Retract_Count "
+    "-v 193,raw48,Load_Cycle_Count,HDD "
+    "-v 194,tempminmax,Temperature_Celsius "
+    "-v 195,raw48,Hardware_ECC_Recovered "
+    "-v 196,raw16(raw16),Reallocated_Event_Count "
+    "-v 197,raw48,Current_Pending_Sector "
+    "-v 198,raw48,Offline_Uncorrectable "
+    "-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 200,raw48,Multi_Zone_Error_Rate,HDD " // Seagate Helium HDDs: "Pressure_Limit"
+    "-v 201,raw48,Soft_Read_Error_Rate,HDD "
+    "-v 202,raw48,Data_Address_Mark_Errs,HDD "
+    "-v 203,raw48,Run_Out_Cancel "
+    "-v 204,raw48,Soft_ECC_Correction "
+    "-v 205,raw48,Thermal_Asperity_Rate "
+    "-v 206,raw48,Flying_Height,HDD "
+    "-v 207,raw48,Spin_High_Current,HDD "
+    "-v 208,raw48,Spin_Buzz,HDD "
+    "-v 209,raw48,Offline_Seek_Performnce,HDD "
+    //  210-219 Unknown_Attribute
+    "-v 220,raw48,Disk_Shift,HDD "
+    "-v 221,raw48,G-Sense_Error_Rate,HDD "
+    "-v 222,raw48,Loaded_Hours,HDD "
+    "-v 223,raw48,Load_Retry_Count,HDD "
+    "-v 224,raw48,Load_Friction,HDD "
+    "-v 225,raw48,Load_Cycle_Count,HDD "
+    "-v 226,raw48,Load-in_Time,HDD "
+    "-v 227,raw48,Torq-amp_Count,HDD "
+    "-v 228,raw48,Power-off_Retract_Count "
+    //  229 Unknown_Attribute
+    "-v 230,raw48,Head_Amplitude,HDD "
+    "-v 231,raw48,Temperature_Celsius,HDD "
+    "-v 232,raw48,Available_Reservd_Space "
+    "-v 233,raw48,Media_Wearout_Indicator,SSD "
+    //  234-239 Unknown_Attribute
+    "-v 240,raw24(raw8),Head_Flying_Hours,HDD "
+    "-v 241,raw48,Total_LBAs_Written "
+    "-v 242,raw48,Total_LBAs_Read "
+    //  243-249 Unknown_Attribute
+    "-v 250,raw48,Read_Error_Retry_Rate "
+    //  251-253 Unknown_Attribute
+    "-v 254,raw48,Free_Fall_Sensor,HDD"
+  },
+  { "Swissbit C440 Industrial CompactFlash Card",
+    // spec v1.23 found at http://www.farnell.com/datasheets/1821167.pdf
+    // tested with SFCF4096H2BU4TO-I-MS-527-STD
+    "SFCF(2048|4096|8192|16GB|32GB|64GB)H[0-9]BU[24]TO-(C|I)-(MS|QT|NU)-5[0-9]7-STD",
+    "", "",
+    "-v 196,raw24/raw24,Spare_Blocks "
+    "-v 213,raw24/raw24,Spare_Blocks_Worst_Chip "
+    "-v 229,raw48,Erase_Count "
+    "-v 203,raw48,Total_ECC_Errors "
+    "-v 232,raw48,Total_Number_of_Reads "
+    "-v 214,raw48,Reserved_Attribute " // Spec says "to be determined"
+    "-v 215,raw48,Current_TRIM_Percent "
+  },
+  { "Swissbit X-600m Series Industrial mSATA SSD",
+    // spec v1.06 found at https://www.mouser.com/pdfdocs/Swissbit_X-600m_Datasheet.pdf
+    // tested with SFSA016GU1AA2TO-I-DB-216-STD
+    "SFSA(008|016|032|064|128)GU[0-9]AA[124]TO-(C|I)-(DB|QC|NC)-2[0-9]6-STD",
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 160,raw48,Uncorrectable_Error_Cnt "
+    "-v 161,raw48,Spare_Blocks_Remaining "
+    "-v 163,raw48,Initial_Bad_Block_Count "
+    "-v 164,raw48,Total_Erase_Count "
+    "-v 165,raw48,Max_Erase_Count "
+    "-v 166,raw48,Min_Erase_Count "
+    "-v 167,raw48,Average_Erase_Count "
+    "-v 168,raw48,Max_Erase_Count_of_Spec "
+    "-v 169,raw48,Power_On_Uncorr_Err_Cnt "
+    "-v 192,raw48,Init_Spare_Blocks_Avail "
+    "-v 193,raw48,Dynamic_Remaps "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 195,raw48,Hardware_ECC_Recovered "
+  //"-v 196,raw16(raw16),Reallocated_Event_Count "
+  //"-v 198,raw48,Offline_Uncorrectable "
+    "-v 199,raw48,SATA_CRC_Error_Count "
+    "-v 215,raw48,TRIM_Count "
+    "-v 235,hex56,Flash_Writes_LBAs_Low "
+    "-v 237,hex48,Flash_Writes_LBAs_High "
+    "-v 241,hex56,Total_LBAs_Written_Low "
+    "-v 242,hex56,Total_LBAs_Read_Low "
+    "-v 243,hex48,Total_LBAs_Written_High "
+    "-v 244,hex48,Total_LBAs_Read_High "
+    "-v 248,raw48,Perc_Rated_Life_Remain "
+    "-v 249,raw48,Spares_Remaining_Perc "
+  },
+  { "Swissbit X-7x Family SATA SSD", // tested with
+      // SFSA060GM2AK1TO-C-6B-536-STD/SBR11007, SFSA020GU2AK1TO-I-6B-22P-STD/SBR15004,
+      // SFSA160GM2AK1TA-I-8C-11P-STD/SBR15103, SFSA320GM2AK2TA-I-8C-21P-STD/SBR15103
+    "SFSA....[MQSUV].AK.T[ABO].............",
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 16,raw48,Avg_Erase_Count_pSLC "
+    "-v 17,raw48,Rated_Erase_Count_pSLC "
+    "-v 160,raw48,UECC_Sector_Count "
+    "-v 161,raw48,Spare_Block_Count "
+    "-v 163,raw48,Initial_Bad_Block_Count "
+    "-v 164,raw48,Total_Erase_Count "
+    "-v 165,raw48,Maximum_Erase_Count "
+    "-v 166,raw48,Minimum_Erase_Count "
+    "-v 167,raw48,Average_Erase_Count "
+    "-v 168,raw48,Rated_Erase_Count "
+    "-v 169,raw48,Power_On_UECC_Err_Cnt "
+    "-v 193,raw48,Dynamic_Remaps "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 195,raw48,Hardware_ECC_Recovered "
+  //"-v 196,raw16(raw16),Reallocated_Event_Count "
+  //"-v 198,raw48,Offline_Uncorrectable "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 215,raw48,Number_of_TRIM_Commands  "
+    "-v 231,raw48,Life_Remaining_Percent "
+    "-v 235,raw48,Flash_LBAs_Written "
+    "-v 237,raw48,Flash_LBAs_Written_Exp "
+  //"-v 241,raw48,Total_LBAs_Written "
+  //"-v 242,raw48,Total_LBAs_Read "
+    "-v 243,raw48,Host_LBA_Write_Exp "
+    "-v 244,raw48,Host_LBA_Read_Exp "
+    "-v 248,raw48,SSD_Remaining_Life_Perc "
+  },
+  { "Swissbit X-8x Family SATA SSD", // tested with
+    // SFSA080GM1AO1TO-C-8C-11P-STD/AOR20008, SFSA020GM1AO1TO-I-6B-11P-STD/AOR20008
+    "SFSA....M.AO.TO.............",
+    "", "",
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 165,raw48,Maximum_Erase_Count "
+    "-v 167,raw48,Average_Erase_Count "
+    "-v 168,raw48,Rated_Erase_Count "
+    "-v 169,raw48,Power_On_Data_Repairs "
+  //"-v 184,raw48,End-to-End_Error "
+    "-v 185,raw48,E2E_ErrCnt_SATA-Flash "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 195,raw48,Hardware_ECC_Recovered "
+    "-v 196,raw48,Total_Spare_Block_Cnt "
+  //"-v 198,raw48,Offline_Uncorrectable "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 200,raw48,SATA_COM_Reset "
+    "-v 213,raw48,Spare_Block_Cnt_Worst "
+    "-v 215,raw48,Trim_Status "
+    "-v 229,raw48,Total_Flash_Blk_Erases "
+    "-v 232,raw48,Total_Read_Cnt "
+    "-v 241,raw48,Total_Host_LBA_Written "
+    "-v 242,raw48,Total_Host_LBA_Read "
+    "-v 248,raw48,Remaining_Life "
+  },
+  { "Apacer SDM4 Series SSD Module",
+    "(2|4|8|16|32|64)GB SATA Flash Drive", // tested with APSDM002G15AN-CT/SFDDA01C and SFI2101D
+    "SF(DDA01C|I2101D)",
+    "",
+    "-v 160,raw48,Initial_Bad_Block_Count "
+    "-v 161,raw48,Bad_Block_Count "
+    "-v 162,raw48,Spare_Block_Count "
+    "-v 163,raw48,Max_Erase_Count "
+    "-v 164,raw48,Average_Erase_Count "
+    "-v 165,raw48,Average_Erase_Count " // could be wrong
+  },
+  { "Apacer SDM5/5A/5A-M Series SSD Module",
+    "(1|2|4|8|16|32|64)GB SATA Flash Drive", // tested with APSDM016GA2AN-PTM1/SFDK004A,
+      // APSDM016GA3AN-ATM/SFDE001A, APSDM004G13AN-AT/SFDE001A
+    "SF(DK004A|DE001A)",
+    "",
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 163,raw48,Max_Erase_Count "
+    "-v 164,raw48,Average_Erase_Count "
+    "-v 166,raw48,Grown_Bad_Block_Count "
+    "-v 167,raw48,SSD_Write_Protect_Mode "
+    "-v 168,raw48,SATA_PHY_Err_Ct "
+    "-v 175,raw48,Bad_Cluster_Table_Count "
+    "-v 192,raw48,Unexpect_Power_Loss_Ct "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 241,raw48,Total_LBAs_Written "
+  },
+  { "Apacer AS340/350 SSDs",
+    "Apacer AS3[45]0 ((12[08]|240|256|480|512|960)G|1T)B", // tested with
+      // Apacer AS340 120GB/AP612PE0, Apacer AS350 1TB/AP613PE0
+    "", "",
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 163,raw48,Max_Erase_Count "
+    "-v 164,raw48,Average_Erase_Count "
+    "-v 166,raw48,Later_Bad_Block_Count "
+    "-v 167,raw48,SSD_Protect_Mode "
+    "-v 168,raw48,SATA_PHY_Error_Count "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 175,raw48,Bad_Cluster_Table_Count "
+    "-v 192,raw48,Unexpect_Power_Loss_Ct "
+  //"-v 194,tempminmax,Temperature_Celsius "
+    "-v 231,raw48,Lifetime_Left "
+  //"-v 241,raw48,Total_LBAs_Written "
+  },
+  { "Apacer SSDs",
+    "([1248]|1[056]|20|3[02]|40|60|64|80|12[08]|160|240|256|320|480|512|640|960|1024|1280|1920|2048|3840|4096)(GB|TB) SATA Flash Drive|"
+    "1TB SATA SSD|" // tested with 1TB SATA SSD/AP613PE0 (AP1TPPSS25-R)
+    "S[GHTV]250-(M2[48][02]|25) ([1248]|1[056]|20|3[02]|40|60|64|80|12[08]|160|240|256|320|480|512|640|960|1024|1280|1920|2048|3840|4096)(GB|TB) SSD",
+      // tested with 120GB SATA Flash Drive/SFMB6130, SH250-M242 128GB SSD/SFMB8120, ST250-M280 256GB SSD/SFMD6110
+    "AP613PE0|SFM[BCDEGHJ][0-9A-Z][0-9A-Z][1-9A-Z][0-9A-Z]",
+    "",
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 163,raw48,Maximum_Erase_Count "
+    "-v 164,raw48,Average_Erase_Count "
+    "-v 166,raw48,Total_Later_Bad_Blk_Ct "
+    "-v 167,raw48,SSD_Protect_Mode "
+    "-v 168,raw48,SATA_PHY_Error_Count "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 175,raw48,Bad_Cluster_Table_Ct "
+    "-v 192,raw48,Unexpect_Power_Loss_Ct "
+  //"-v 194,tempminmax,Temperature_Celsius "
+    "-v 231,raw48,Lifetime_Left "
+  //"-v 241,raw48,Total_LBAs_Written "
+  },
+  { "Apple MacBook Air SSD", // probably Toshiba
+    "APPLE SSD TS(064|128)E", // tested with APPLE SSD TS064E/TQAABBF0
+    "", "",
+    "-v 173,raw48,Wear_Leveling_Count " //  ]
+    "-v 241,raw48,Host_Writes_GiB "     //  ]  guessed (ticket #655)
+    "-v 242,raw48,Host_Reades_GiB "     //  ]
+  },
+  { "Apple SD/SM/TS...E/F/G SSDs", // SanDisk/Samsung/Toshiba?
+    "APPLE SSD (S[DM]|TS)0?(128|256|512|768|1024)[EFG]", // tested with APPLE SSD SD256E/1021AP, SD0128F/A223321
+      // APPLE SSD SM768E/CXM90A1Q, SM0512F/UXM2JA1Q, TS0256F/109L0704, SM0512G/BXW1SA0Q, SM1024G/BXW1SA0Q
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 169,raw48,Unknown_Apple_Attrib "
+    "-v 173,raw48,Wear_Leveling_Count " // ]
+    "-v 174,raw48,Host_Reads_MiB "      // ] guessed (ticket #342), S[DM]*F only
+    "-v 175,raw48,Host_Writes_MiB "     // ]
+  //"-v 192,raw48,Power-Off_Retract_Count "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 197,raw48,Current_Pending_Sector "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+  //"-v 240,raw48,Unknown_SSD_Attribute "
+  },
+  { "ATP SATA III Value Line SSDs",
+    "ATP SATA III (M.2 (2242|2280)|mSATA|mSATA SSD|2.5 inch)",
+      // tested M.2 2280 with firmware version SBFMBB.3 (Value Line),
+      // ATP SATA III M.2 2280/SBFMBB.3
+    "SBFMB1.1|SBFMBB.3|SBFMT1.3",
+    "",
+    "-v 1,raw48,Raw_Read_Error_Count "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 168,raw48,SATA_PHY_Error_Count "
+    "-v 170,raw16,Bad_Bl_Ct_LATER_0_EARLY " // Raw value: Byte [5~4] Later bad block count
+                                            //            Byte [3~2] 0
+                                            //            Byte [1~0] Early bad block count (meaning see ticket #1642)
+    "-v 173,raw16,Erase_Count_0_AVG_MAX "   // Raw value: Byte [5~4] 0
+                                            //            Byte [3~2] Average erase count
+                                            //            Byte [1~0] Max erase count
+    "-v 192,raw48,Unexpected_Power_Loss "
+  //"-v 194,tempminmax,Device_Temperature "
+    "-v 218,raw48,CRC_Errors "
+    "-v 231,raw48,Percent_Lifetime_Remain "
+    "-v 241,raw48,Host_Writes_GiB "
+  },
+  { "ATP SATA III Superior Line SSDs",
+    "ATP (SATA III|SATAIII|I-Temp. SATA III|I-Temp. SATAIII) (M.2 (2242|2280)|mSATA|2.5 inch) SSD",
+      // tested M.2 2242 & 2280 with firmware version T0205B (Superior Line with PLP),
+      // ATP SATA III M.2 2280 SSD/T0205B
+    "T0205B|U0316B",
+    "",
+    "-v 1,raw48,Raw_Read_Error_Count "
+    "-v 5,raw16(raw16),Realloc_Flash_Blocks_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 14,raw48,Device_Raw_Capacity "
+    "-v 15,raw48,Device_User_Capacity "
+    "-v 16,raw48,Initial_Spare_Blocks "
+    "-v 17,raw48,Remaining_Spare_Blocks "
+    "-v 100,raw48,Total_Erease_Count "
+    "-v 160,raw48,Uncorrectable_Sectors "
+    "-v 172,raw48,Block_Erase_Failures "
+    "-v 173,raw48,Maximum_Erase_Count "
+    "-v 174,raw48,Unexpected_Power_Loss "
+    "-v 175,raw48,Average_Erase_Count "
+    "-v 181,raw48,Block_Program_Failures "
+    "-v 187,raw48,Reported_Uncorr_Errors "
+  //"-v 194,tempminmax,Device_Temperature "
+  //"-v 195,raw48,Hardware_ECC_Recovered "
+    "-v 197,raw48,Current_Pending_ECC_Cnt " // Like Crucial MX500: May flip 0 <> 1 (ticket #1227)
+    "-v 198,raw48,Offline_UErr_Media_Scan "
+    "-v 199,raw48,SATA_FIS_CRC_Errors "
+    "-v 202,raw48,Percent_Lifetime_Used "
+    "-v 205,raw48,Thermal_Asperity_Rate "
+    "-v 231,tempminmax,Controller_Temperature "
+    "-v 234,raw48,Sectors_Read_from_NAND "
+    "-v 235,raw48,Sectors_Written_to_SSD "
+    "-v 241,raw48,Sectors_Written_to_NAND "
+    "-v 242,raw48,Sectors_Read_from_SSD "
+    "-v 248,raw48,Percent_Lifetime_Remain "
+    "-v 249,raw48,Spare_Blocks_Remaining " // same as ID 17 (Remaining_Spare_Blocks)
+  },
+  { "ATP SATA III aMLC M.2 2242/80 Embedded SSDs",
+    "ATP I-Temp M\\.2 22(42|80)", // tested with ATP I-Temp M.2 2242/R0822A,
+      // ATP I-Temp M.2 2280/R0822A
+    "","",
+    "-v 1,raw48,Raw_Read_Error_Count "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 14,raw48,Device_Raw_Capacity "
+    "-v 15,raw48,Device_User_Capacity "
+    "-v 16,raw48,Initial_Spare_Blocks "
+    "-v 17,raw48,Remaining_Spare_Blocks "
+    "-v 100,raw48,Total_Erease_Count "
+    "-v 160,raw48,Uncorrectable_Sectors "
+    "-v 172,raw48,Block_Erase_Failure "
+    "-v 173,raw48,Max_Erase_Count "
+    "-v 174,raw48,Unexpected_Power_Cycle "
+    "-v 175,raw48,Average_Erase_Count "
+    "-v 181,raw48,Program_Fail_Blocks "
+    "-v 187,raw48,Reported_UE_Counts "
+    "-v 194,raw48,Device_Temperature "
+  //"-v 195,raw48,Hardware_ECC_Recovered "
+  //"-v 197,raw48,Current_Pending_Sector "
+  //"-v 198,raw48,Offline_Uncorrectable "
+    "-v 199,raw48,SATA_CRC_Error_Count "
+    "-v 202,raw48,Percent_Lifetime_Used "
+    "-v 205,raw48,Thermal_Asperity_Rate "
+    "-v 231,raw48,Controller_Temperature "
+    "-v 234,raw48,Nand_Sectors_Read "
+    "-v 235,raw48,Device_Sectors_Written "
+    "-v 241,raw48,Nand_Sectors_Written "
+    "-v 242,raw48,Device_Bytes_Read "
+    "-v 248,raw48,PCT_Life_Remaining "
+    "-v 249,raw48,Spare_Block_Remaining "
+  },
+  { "Crucial/Micron RealSSD C300/P300", // Marvell 88SS9174
+    "C300-CTFDDA[AC](064|128|256)MAG|" // tested with C300-CTFDDAC128MAG/0002,
+      // C300-CTFDDAC064MAG/0006
+    "(C300-)?MTFDBAK(064|128|256)MAG(-1G1)?|" // tested with
+      // C300-MTFDBAK128MAG/0006 (attr 9 only), MTFDBAK256MAG-1G1/0007
+    "P300-MTFDDAC(050|100|200)SAL", // tested with P300-MTFDDAC100SAL/0003
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 170,raw48,Grown_Failing_Block_Ct "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 173,raw48,Wear_Leveling_Count "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+    "-v 181,raw16,Non4k_Aligned_Access "
+    "-v 183,raw48,SATA_Iface_Downshift "
+  //"-v 184,raw48,End-to-End_Error "
+  //"-v 187,raw48,Reported_Uncorrect "
+  //"-v 188,raw48,Command_Timeout "
+    "-v 189,raw48,Factory_Bad_Block_Ct "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 195,raw48,Hardware_ECC_Recovered "
+  //"-v 196,raw16(raw16),Reallocated_Event_Count "
+  //"-v 197,raw48,Current_Pending_Sector "
+  //"-v 198,raw48,Offline_Uncorrectable "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 202,raw48,Percent_Lifetime_Used "
+    "-v 206,raw48,Write_Error_Rate "
+  },
+  { "Crucial/Micron RealSSD m4/C400/P400", // Marvell 9176, fixed firmware
+    "C400-MTFDDA[ACK](064|128|256|512)MAM|"
+      // M4-CT032M4SSD3/04MH
+    "M4-CT(032|064|128|256|512)M4SSD[123]|" // tested with M4-CT512M4SSD2/0309
+    "MTFDDA[AK](064|128|256|512|050|100|200|400)MA[MNR]-1[JKS]1.*", // tested with
+      // MTFDDAK256MAR-1K1AA/MA52, MTFDDAK256MAM-1K12/08TH,
+      // MTFDDAA064MAR-1J1AB  49Y5835 49Y5838IBM/MA49 (P400e)
+    "030[9-Z]|03[1-Z].|0[4-Z]..|[1-Z]....*", // >= "0309"
+    "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 170,raw48,Grown_Failing_Block_Ct "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 173,raw48,Wear_Leveling_Count "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+    "-v 181,raw16,Non4k_Aligned_Access "
+    "-v 183,raw48,SATA_Iface_Downshift "
+  //"-v 184,raw48,End-to-End_Error "
+  //"-v 187,raw48,Reported_Uncorrect "
+  //"-v 188,raw48,Command_Timeout "
+    "-v 189,raw48,Factory_Bad_Block_Ct "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 195,raw48,Hardware_ECC_Recovered "
+  //"-v 196,raw16(raw16),Reallocated_Event_Count "
+  //"-v 197,raw48,Current_Pending_Sector "
+  //"-v 198,raw48,Offline_Uncorrectable "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 202,raw48,Perc_Rated_Life_Used "
+    "-v 206,raw48,Write_Error_Rate "
+    "-v 225,raw48,Unknown_Marvell_Attr " // P400e
+    "-v 231,raw48,Unknown_Marvell_Attr " // P400e
+    "-v 242,raw48,Host_Reads" // P400e: 2MiB?
+  },
+  { "Crucial/Micron RealSSD m4/C400", // Marvell 9176, buggy or unknown firmware
+    "C400-MTFDDA[ACK](064|128|256|512)MAM|" // tested with C400-MTFDDAC256MAM/0002
+    "M4-CT(032|064|128|256|512)M4SSD[123]", // tested with M4-CT064M4SSD2/0002,
+      // M4-CT064M4SSD2/0009, M4-CT256M4SSD3/000F
+    "",
+    "This drive may hang after 5184 hours of power-on time:\n"
+    "https://www.tomshardware.com/news/Crucial-m4-Firmware-BSOD,14544.html\n"
+    "See the following web page for firmware updates:\n"
+    "http://www.crucial.com/usa/en/support-ssd",
+    "-v 170,raw48,Grown_Failing_Block_Ct "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 173,raw48,Wear_Leveling_Count "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+    "-v 181,raw16,Non4k_Aligned_Access "
+    "-v 183,raw48,SATA_Iface_Downshift "
+    "-v 189,raw48,Factory_Bad_Block_Ct "
+    "-v 202,raw48,Perc_Rated_Life_Used "
+    "-v 206,raw48,Write_Error_Rate"
+  },
+  { "Crucial/Micron Client SSDs", // MX100, MX200, BX300, MX300, BX500, MX500, M500, M600, 1100, 1300
+      // See also tnfd22_client_ssd_smart_attributes.pdf Rev. E from 2018-09-28
+      // (covers M500 FW>=MU03, M510, M550, MX100, M600, MX200, 1100, MX300, 1300)
+    "Crucial_CT(128|256|512)MX100SSD1|"// Marvell 88SS9189, tested with Crucial_CT256MX100SSD1/MU01
+    "Crucial_CT(200|250|256|500|512|1000|1024)MX200SSD[1346]|" // Marvell 88SS9189, tested with
+      // Crucial_CT500MX200SSD1/MU01, Crucial_CT1024MX200SSD1/MU01, Crucial_CT250MX200SSD3/MU01,
+      // Crucial_CT250MX200SSD1/MU03
+    "Crucial_CT(275|525|750|1050|2050)MX300SSD[14]|" // Marvell 88SS1074, tested with
+      // Crucial_CT275MX300SSD1/M0CR040, Crucial_CT525MX300SSD1/M0CR021, Crucial_CT750MX300SSD1/M0CR011,
+      // Crucial_CT2050MX300SSD1/M0CR031
+    "Crucial_CT(120|240|480|960)M500SSD[134]|" // Marvell 88SS9187, tested with
+      // Crucial_CT120M500SSD1/MU02, Crucial_CT120M500SSD3/MU02, Crucial_CT240M500SSD1/MU03,
+      // Crucial_CT480M500SSD1/MU03, Crucial_CT960M500SSD1/MU03, Crucial_CT240M500SSD4/MU05
+    "Crucial_CT(128|256|512|1024)M550SSD[134]|" // tested with Crucial_CT512M550SSD3/MU01,
+      // Crucial_CT1024M550SSD1/MU01, Crucial_CT128M550SSD4/MU02
+    "CT(120|240|480)BX300SSD1|" // Silicon Motion SM2258, same attributes as Marvell-based Crucial SSDs,
+      // tested with CT240BX300SSD1/M2CR010
+    "CT(120|240|480|960|[12]000)BX500SSD1|" // Silicon Motion SM2258XT, tested with CT120BX500SSD1/M6CR013,
+      // CT1000BX500SSD1/M6CR030, CT2000BX500SSD1/M6CR030
+    "CT(250|500|[124]000)MX500SSD[14]|" // Silicon Motion SM2258, tested with CT250MX500SSD1/M3CR010
+      // CT500MX500SSD1/M3CR010, CT1000MX500SSD1/M3CR010, CT2000MX500SSD1/M3CR010,
+      // CT500MX500SSD1/M3CR020, CT250MX500SSD4/M3CR022, CT500MX500SSD1/M3CR022,
+      // CT500MX500SSD1/M3CR023, CT1000MX500SSD1/M3CR032, CT4000MX500SSD1/M3CR044
+    "Micron_M500_MTFDDA[KTV](120|240|480|960)MAV|"// tested with Micron_M500_MTFDDAK960MAV/MU05
+    "Micron_M500DC_(EE|MT)FDDA[AK](120|240|480|800)MBB|" // tested with Micron_M500DC_EEFDDAA120MBB/129,
+      // Micron_M500DC_MTFDDAK800MBB/0129
+    "(Micron[_ ])?M500IT[_ ]MTFDDA[KTY](032|050|060|064|120|128|240|256)[MS]BD|" // tested with M500IT_MTFDDAK240MBD/MG02
+    "(Micron_)?M510[_-]MTFDDA[KTV](128|256)MAZ|" // tested with M510-MTFDDAK256MAZ/MU01
+    "MICRON_M510DC_(EE|MT)FDDAK(120|240|480|800|960)MBP|" // tested with Micron_M510DC_MTFDDAK240MBP/0005
+    "(Micron_)?M550[_-]MTFDDA[KTV](064|128|256|512|1T0)MAY|" // tested with M550-MTFDDAK256MAY/MU01
+    "(Micron_M600_)?(EE|MT)FDDA[KTV](128|256|512|1T0)MBF[25Z]?(-.*)?|" // tested with Micron_M600_MTFDDAK1T0MBF/MU01,
+      // MTFDDAK256MBF-1AN1ZABHA/M603
+    "(Micron_1100_)?MTFDDA[KV](256|512|1T0|2T0)TBN(-.*)?|" // Marvell 88SS1074, tested with
+      // Micron_1100_MTFDDAK256TBN/M0MU020, MTFDDAK256TBN/M0MA020 (OEM), MTFDDAV256TBN-1AR15ABHA/HPC0T14
+    "Micron 1100 SATA (256G|512G|1T|2T)B|" // tested with Micron 1100 SATA 256GB/M0DL022
+    "(Micron_1300_)?(EE|MT)FDDA[KV](256|512|1T0|2T0)TDL(-.*)?", // tested with Micron_1300_MTFDDAK256TDL/M5MU000,
+      // Micron_1300_MTFDDAK1T0TDL/M5MU000, MTFDDAK2T0TDL/M5MU030, MTFDDAK256TDL-1AW1ZABFA/M5MA030
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+    "-v 5,raw48,Reallocate_NAND_Blk_Cnt "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 170,raw48,Reserved_Block_Count "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 173,raw48,Ave_Block-Erase_Count "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+    "-v 180,raw48,Unused_Reserve_NAND_Blk "
+    "-v 183,raw48,SATA_Interfac_Downshift "
+    "-v 184,raw48,Error_Correction_Count "
+  //"-v 187,raw48,Reported_Uncorrect "
+  //"-v 194,tempminmax,Temperature_Celsius "
+    "-v 195,raw48,Cumulativ_Corrected_ECC "
+  //"-v 196,raw16(raw16),Reallocated_Event_Count "
+    "-v 197,raw48,Current_Pending_ECC_Cnt " // MX500: May flip 0 <> 1 (ticket #1227)
+  //"-v 198,raw48,Offline_Uncorrectable "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 202,raw48,Percent_Lifetime_Remain " // norm = max(100-raw,0); raw = percent_lifetime_used
+    "-v 206,raw48,Write_Error_Rate "
+    "-v 210,raw48,Success_RAIN_Recov_Cnt "
+    "-v 223,raw48,Unkn_CrucialMicron_Attr " // M6CR030
+    "-v 246,raw48,Total_LBAs_Written "
+    "-v 247,raw48,Host_Program_Page_Count "
+    "-v 248,raw48,FTL_Program_Page_Count "
+    "-v 249,raw48,Unkn_CrucialMicron_Attr " // M6CR030
+  //"-v 250,raw48,Read_Error_Retry_Rate "   // M6CR030
+    "-v 251,raw48,Unkn_CrucialMicron_Attr " // M6CR030
+    "-v 252,raw48,Unkn_CrucialMicron_Attr " // M6CR030
+    "-v 253,raw48,Unkn_CrucialMicron_Attr " // M6CR030
+    "-v 254,raw48,Unkn_CrucialMicron_Attr"  // M6CR030
+  },
+  { "Lexar 128GB SSD", // for other Lexar drives see ticket #1529
+    "Lexar 128GB SSD", // Lexar 128GB SSD/H190117D
+    "", "",
+    "-v 5,raw48,New_Bad_Blk_Cnt "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 167,raw48,SSD_Protect_mode "
+    "-v 168,raw48,SATA_PHY_Error_Cnt "
+    "-v 169,raw48,Bad_Block_Cnt "
+    "-v 171,raw48,Program_Fail_Cnt "
+    "-v 172,raw48,Erase_Fail_Cnt "
+    "-v 173,raw48,Erase_Cnt "
+    "-v 175,raw48,Bad_Cluster_Cnt "
+    "-v 177,raw48,Read_Retry_Cnt "
+    "-v 180,raw48,Spare_Blk_Cnt_Left "
+  //"-v 187,raw48,Reported_Uncorrect "
+  //"-v 192,raw48,Power-Off_Retract_Count "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 206,raw48,Min_Erase_Cnt "
+    "-v 207,raw48,Max_Erase_Cnt "
+    "-v 208,raw48,Avg_Erase_Cnt "
+    "-v 209,raw48,SLC_Min_Erase_Cnt "
+    "-v 210,raw48,SLC_Max_Erase_Cnt "
+    "-v 211,raw48,SLC_Avg_Erase_Cnt "
+    "-v 231,raw48,SSD_Life_Left "
+  //"-v 241,raw48,Total_LBAs_Written "
+  //"-v 242,raw48,Total_LBAs_Read "
+    "-v 245,raw48,Bit_Error_Cnt "
+  },
+  // Reference: https://www.micron.com/resource-details/feec878a-265e-49a7-8086-15137c5f9011
+  // TN-FD-34: 5100 SSD SMART Implementation
+  { "Micron 5100 / 52x0 / 5300 / 5400 SSDs",
+    "(Micron_5100_)?(EE|MT)FDDA[KV](240|480|960|1T9|3T8|7T6)T(BY|CB|CC)|" // Matches both stock and Dell OEM
+      // tested with Micron_5100_MTFDDAK3T8TCB/D0MU410, MTFDDAK3T8TCB/D0MU410
+    "(Micron_5200_)?MTFDDAK(240|480|960|1T9|3T8|7T6)TD(C|D|N)|" // tested with Micron_5200_MTFDDAK240TDN/D1MU005,
+      // Micron_5200_MTFDDAK3T8TDD/D1MU505
+    "Micron_5210_MTFDDAK(480|960|1T9|3T8|7T6)QDE|" // tested with Micron_5210_MTFDDAK7T6QDE/D2MU804
+    "(Micron_5300(HC)?_)?MTFDDA[KV](240|480|960|1T9|3T8|7T6)TD[STU]|" // tested with Micron_5300_MTFDDAK1T9TDS/D3MU001
+      // Micron_5300HC_MTFDDAK960TDS/D3MN010, MTFDDAK1T9TDT/D3MU001
+    "(Micron_5400_)?(EE|MT)FDDA[KV](240|480|960|1T9|3T8|7T6)TG[ABC](_SED)?", // tested with
+      // Micron_5400_MTFDDAK1T9TGB/D4MU001, Micron_5400_MTFDDAK960TGA_SED/D4CS001
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "  // raw24(raw8)??
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 170,raw48,Reserved_Block_Pct " // Percentage of remaining reserved blocks available
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 173,raw48,Avg_Block-Erase_Count "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+  //"-v 180,raw48,Unused_Rsvd_Blk_Cnt_Tot " // absolute count of remaining reserved blocks available
+    "-v 183,raw48,SATA_Int_Downshift_Ct " // SATA speed downshift count
+  //"-v 184,raw48,End-to-End_Error "
+  //"-v 187,raw48,Reported_Uncorrect " // Number of UECC correction failures
+  //"-v 188,raw48,Command_Timeout "
+  //"-v 194,tempminmax,Temperature_Celsius " // 100 - degrees C, wraps: 101 reported as 255
+  //"-v 195,raw48,Hardware_ECC_Recovered "
+  //"-v 196,raw16(raw16),Reallocated_Event_Count "
+  //"-v 197,raw48,Current_Pending_Sector " // Use the raw value
+  //"-v 198,raw48,Offline_Uncorrectable "  // Use the raw value
+  //"-v 199,raw48,UDMA_CRC_Error_Count "   // Use the raw value
+    "-v 202,raw48,Percent_Lifetime_Remain " // Remaining endurance, trips at 10%
+    "-v 206,raw48,Write_Error_Rate "
+    "-v 210,raw48,RAIN_Success_Recovered "  // Total number of NAND pages recovered by RAIN
+    "-v 211,raw48,Integ_Scan_Complete_Cnt "  // Number of periodic data integrity scans completed
+    "-v 212,raw48,Integ_Scan_Folding_Cnt "   // Number of blocks reallocated by integrity scans
+    "-v 213,raw48,Integ_Scan_Progress "      // Current is percentage, raw is absolute number of superblocks scanned by the current integrity scan
+    "-v 246,raw48,Total_LBAs_Written "
+    "-v 247,raw48,Host_Program_Page_Count "
+    "-v 248,raw48,Bckgnd_Program_Page_Cnt"
+  },
+  { "Micron M500DC/M510DC Enterprise SSDs",
+    "Micron_M500DC_(EE|MT)FDDA[AK](120|240|480|800)MBB|" // tested with
+      // Micron_M500DC_EEFDDAA120MBB/129, Micron_M500DC_MTFDDAK800MBB/0129
+    "MICRON_M510DC_(EE|MT)FDDAK(120|240|480|800|960)MBP", // tested with
+      // Micron_M510DC_MTFDDAK240MBP/0005
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+    "-v 5,raw48,Reallocated_Block_Count "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 170,raw48,Reserved_Block_Count "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 173,raw48,Ave_Block-Erase_Count "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+    "-v 184,raw48,Error_Correction_Count "
+  //"-v 187,raw48,Reported_Uncorrect "
+    "-v 188,raw48,Command_Timeouts "
+  //"-v 194,tempminmax,Temperature_Celsius "
+    "-v 195,raw48,Cumulativ_Corrected_ECC "
+  //"-v 197,raw48,Current_Pending_Sector "
+  //"-v 198,raw48,Offline_Uncorrectable "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 202,raw48,Percent_Lifetime_Remain "
+    "-v 206,raw48,Write_Error_Rate "
+    "-v 247,raw48,Host_Program_Page_Count "
+    "-v 248,raw48,Bckgnd_Program_Page_Cnt"
+  },
+  { "SandForce Driven SSDs", // Corsair Force LS with buggy firmware only
+    "Corsair Force LS SSD", // tested with Corsair Force LS SSD/S9FM01.8
+    "S9FM01\\.8",
+    "A firmware update is available for this drive.\n"
+    "It is HIGHLY RECOMMENDED for drives with specific serial numbers.\n"
+    "See the following web pages for details:\n"
+    "https://www.corsair.com/en-us/force-series-ls-60gb-sata-3-6gb-s-ssd\n"
+    "https://www.smartmontools.org/ticket/628",
+    "-v 1,raw24/raw32,Raw_Read_Error_Rate "
+    "-v 5,raw48,Retired_Block_Count "
+    "-v 9,msec24hour32,Power_On_Hours_and_Msec "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 162,raw48,Unknown_SandForce_Attr "
+    "-v 170,raw48,Reserve_Block_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 173,raw48,Unknown_SandForce_Attr "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+    "-v 181,raw48,Program_Fail_Count "
+  //"-v 187,raw48,Reported_Uncorrect "
+  //"-v 192,raw48,Power-Off_Retract_Count "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 196,raw16(raw16),Reallocated_Event_Count "
+    "-v 218,raw48,Unknown_SandForce_Attr "
+    "-v 231,raw48,SSD_Life_Left "
+    "-v 241,raw48,Lifetime_Writes_GiB "
+    "-v 242,raw48,Lifetime_Reads_GiB"
+  },
+  { "SandForce Driven SSDs",
+    "SanDisk SDSSDA(120|240|480)G|" // SanDisk SSD Plus, tested with SanDisk SDSSDA240G/U21010RL
+    "SanDisk SD8S[BFN]AT128G1(00|12)2", // SanDisk Z400s, tested with 
+      // SanDisk SD8SFAT128G1122/Z2333000, SanDisk SD8SNAT128G1002/Z2317002
+      // SanDisk SD8SBAT128G1002/Z2317002
+    "", "",
+    "-v 5,raw48,Retired_Block_Count "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 166,raw48,Min_PE_Cycles "
+    "-v 167,raw48,Max_Bad_Blocks_Per_Die "
+    "-v 168,raw48,Max_PE_Cycles "
+    "-v 169,raw48,Total_Bad_Blocks "
+    "-v 170,raw48,Grown_Bad_Blocks "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 173,raw48,Average_PE_Cycles "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+  //"-v 187,raw48,Reported_Uncorrect "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 230,raw48,Media_Wearout_Indicator "
+  //"-v 232,raw48,Available_Reservd_Space "
+    "-v 233,raw48,NAND_GiB_Written "
+    "-v 241,raw48,Lifetime_Writes_GiB "
+    "-v 242,raw48,Lifetime_Reads_GiB"
+  },
+  { "SandForce Driven SSDs",
+    "SandForce 1st Ed\\.|" // Demo Drive, tested with firmware 320A13F0
+    "ADATA SSD S(396|510|599) .?..GB|" // tested with ADATA SSD S510 60GB/320ABBF0,
+      // ADATA SSD S599 256GB/3.1.0, 64GB/3.4.6
+    "ADATA SP[389]00|" // tested with ADATA SP300/5.0.2d, SP800/5.0.6c,
+      // ADATA SP900/5.0.6 (Premier Pro, SF-2281)
+    "ADATA SSD S[PX]900 (64|128|256|512)GB-DL2|" // tested with ADATA SSD SP900 256GB-DL2/5.0.6,
+      // ADATA SSD SX900 512GB-DL2/5.8.2
+    "ADATA XM11 (128|256)GB|" // tested with ADATA XM11 128GB/5.0.1
+    "ATP Velocity MIV (60|120|240|480)GB|" // tested with ATP Velocity MIV 480GB/110719
+    "Comay BladeDrive E28 (800|1600|3200)GB|" // LSI SF-2581, tested with Comay BladeDrive E28 800GB/2.71
+    "Corsair CSSD-F(40|60|80|115|120|160|240)GBP?2.*|" // Corsair Force, tested with
+      // Corsair CSSD-F40GB2/1.1, Corsair CSSD-F115GB2-A/2.1a
+    "Corsair Voyager GTX|" // Corsair Voyager GTX/S9FM02J6
+    "Corsair Force ((3 |LS )?SSD|GS|GT)|" // SF-2281, tested with
+      // Corsair Force SSD/5.05, 3 SSD/1.3.2, GT/1.3.3, GS/5.03,
+      // Corsair Force LS SSD/S8FM06.5, S9FM01.8, S9FM02.0
+    "FM-25S2S-(60|120|240)GBP2|" // G.SKILL Phoenix Pro, SF-1200, tested with
+      // FM-25S2S-240GBP2/4.2
+    "FTM(06|12|24|48)CT25H|" // Supertalent TeraDrive CT, tested with
+      // FTM24CT25H/STTMP2P1
+    "KINGSTON SE50S37?(100|240|480)G|" // tested with KINGSTON SE50S3100G/KE1ABBF0,
+      // KINGSTON SE50S37100G/61AABBF0 (E50)
+    "KINGSTON SH10[03]S3(90|120|240|480)G|" // HyperX (3K), SF-2281, tested with
+      // SH100S3240G/320ABBF0, SH103S3120G/505ABBF0
+    "KINGSTON SKC(300S37A|380S3)(60|120|180|240|480)G|" // KC300, SF-2281, tested with
+      // SKC300S37A120G/KC4ABBF0, SKC380S3120G/507ABBF0
+    "KINGSTON SVP200S3(7A)?(60|90|120|240|480)G|" // V+ 200, SF-2281, tested with
+      // SVP200S37A480G/502ABBF0, SVP200S390G/332ABBF0
+    "KINGSTON SMS200S3(30|60|120)G|" // mSATA, SF-2241, tested with SMS200S3120G/KC3ABBF0
+    "KINGSTON SMS450S3(32|64|128)G|" // mSATA, SF-2281, tested with SMS450S3128G/503ABBF0
+    "KINGSTON (SV300|SKC100|SE100)S3.*G|" // other SF-2281
+    "KINGSTON SHFS37A(120|240|480)G|" // HyperX Fury, SF-2281, tested with KINGSTON SHFS37A240G/608ABBF0
+    "KINGSTON SNS4151S316GD|" // KINGSTON SNS4151S316GD/S9FM01.6
+    "MKNSSDCR(45|60|90|120|180|240|360|480)GB(-(7|DX7?|MX|G2))?|" // Mushkin Chronos (7mm/Deluxe/MX/G2),
+      // SF-2281, tested with MKNSSDCR120GB, MKNSSDCR120GB-MX/560ABBF0, MKNSSDCR480GB-DX7/603ABBF0
+    "MKNSSDEC(60|120|240|480|512)GB|" // Mushkin Enhanced ECO2, tested with MKNSSDEC120GB/604ABBF0
+    "MKNSSDAT(30|40|60|120|180|240|480)GB(-(DX|V))?|" // Mushkin Atlas (Deluxe/Value), mSATA, SF-2281,
+      // tested with MKNSSDAT120GB-V/540ABBF0
+    "Mushkin MKNSSDCL(40|60|80|90|115|120|180|240|480)GB-DX2?|" // Mushkin Callisto deluxe,
+      // SF-1200/1222, Mushkin MKNSSDCL60GB-DX/361A13F0
+    "MXSSD3MDSF-(60|120)G|" // MX-DS FUSION, tested with MXSSD3MDSF-60G/2.32
+    "OCZ[ -](AGILITY2([ -]EX)?|COLOSSUS2|ONYX2|VERTEX(2|-LE))( [123]\\..*)?|" // SF-1200,
+      // tested with OCZ-VERTEX2/1.11, OCZ-VERTEX2 3.5/1.11
+    "OCZ-NOCTI|" // mSATA, SF-2100, tested with OCZ-NOCTI/2.15
+    "OCZ-REVODRIVE3?( X2)?|" // PCIe, SF-1200/2281, tested with
+      // OCZ-REVODRIVE( X2)?/1.20, OCZ-REVODRIVE3 X2/2.11
+    "OCZ-REVODRIVE350|"
+    "OCZ[ -](VELO|VERTEX2[ -](EX|PRO))( [123]\\..*)?|" // SF-1500, tested with
+      // OCZ VERTEX2-PRO/1.10 (Bogus thresholds for attribute 232 and 235)
+    "D2[CR]STK251...-....(\\.C)?|" // OCZ Deneva 2 C/R, SF-22xx/25xx,
+      // tested with D2CSTK251M11-0240/2.08, D2CSTK251A10-0240/2.15, D2RSTK251M11-0100.C/3.22
+    "OCZ-(AGILITY3|SOLID3|VERTEX3(\\.20| LT| MI)?)|" // SF-2200, tested with OCZ-VERTEX3/2.02,
+      // OCZ-AGILITY3/2.11, OCZ-SOLID3/2.15, OCZ-VERTEX3 MI/2.15, OCZ-VERTEX3 LT/2.22, OCZ-VERTEX3.20/2.60
+    "OCZ Z-DRIVE R4 [CR]M8[48]|" // PCIe, SF-2282/2582, tested with OCZ Z-DRIVE R4 CM84/2.13
+      // (Bogus attributes under Linux)
+    "OCZ Z-DRIVE 4500|"
+    "OCZ-VELO DRIVE|" // VeloDrive R, PCIe, tested with OCZ-VELO DRIVE/1.33
+    "TALOS2|" // OCZ Talos 2 C/R, SAS (works with -d sat), 2*SF-2282, tested with TALOS2/3.20E
+    "(APOC|DENC|DENEVA|FTNC|GFGC|MANG|MMOC|NIMC|TMSC).*|" // other OCZ SF-1200,
+      // tested with DENCSTE251M11-0120/1.33, DENEVA PCI-E/1.33
+    "(DENR|DRSAK|EC188|NIMR|PSIR|TRSAK).*|" // other OCZ SF-1500
+    "OWC Aura Pro( 6G SSD)?|" // tested with OWC Aura Pro 6G SSD/507ABBF0, OWC Aura Pro/603ABBF0
+    "OWC Mercury Electra (Pro )?[36]G SSD|" // tested with
+      // OWC Mercury Electra 6G SSD/502ABBF0, OWC Mercury Electra Pro 3G SSD/541ABBF0
+    "OWC Mercury E(xtreme|XTREME) Pro (6G |RE )?SSD|" // tested with
+      // OWC Mercury Extreme Pro SSD/360A13F0, OWC Mercury EXTREME Pro 6G SSD/507ABBF0
+    "Patriot Pyro|" // tested with Patriot Pyro/332ABBF0
+    "SanDisk SDSSDX(60|120|240|480)GG25|" // SanDisk Extreme, SF-2281, tested with
+      // SDSSDX240GG25/R201
+    "SuperSSpeed S301 [0-9]*GB|" // SF-2281, tested with SuperSSpeed S301 128GB/503
+    "SG9XCS2D(0?50|100|200|400)GESLT|" // Smart Storage Systems XceedIOPS2, tested with
+      // SG9XCS2D200GESLT/SA03L370
+    "SSD9SC(120|240|480)GED[EA]|" // PNY Prevail Elite, tested with SSD9SC120GEDA/334ABBF0
+    "(TX32|TX31C1|VN0.?..GCNMK).*|" // Smart Storage Systems XceedSTOR
+    "(TX22D1|TX21B1).*|" // Smart Storage Systems XceedIOPS2
+    "TX52D1.*|" // Smart Storage Systems Xcel-200
+    "TS(64|128|256|512)GSSD[37]20|" // Transcend SSD320/720, SF-2281, tested with
+      // TS128GSSD320, TS256GSSD720/5.2.0
+    "UGB(88P|99S)GC...H[BF].|" // Unigen, tested with
+      // UGB88PGC100HF2/MP Rev2, UGB99SGC100HB3/RC Rev3
+    "SG9XCS(1F|2D)(50|100|200|400)GE01|" // XceedIOPS, tested with SG9XCS2D50GE01/SA03F34V
+    "VisionTek GoDrive (60|120|240|480)GB", // tested with VisionTek GoDrive 480GB/506ABBF0
+    "", "",
+    "-v 1,raw24/raw32,Raw_Read_Error_Rate "
+    "-v 5,raw48,Retired_Block_Count "
+    "-v 9,msec24hour32,Power_On_Hours_and_Msec "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 13,raw24/raw32,Soft_Read_Error_Rate "
+    "-v 100,raw48,Gigabytes_Erased "
+    "-v 162,raw48,Unknown_SandForce_Attr " // Corsair Force LS SSD/S9FM01.8, *2.0
+    "-v 170,raw48,Reserve_Block_Count "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 173,raw48,Unknown_SandForce_Attr " // Corsair Force LS SSD/S9FM01.8, *2.0
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+    "-v 177,raw48,Wear_Range_Delta "
+    "-v 181,raw48,Program_Fail_Count "
+    "-v 182,raw48,Erase_Fail_Count "
+    "-v 184,raw48,IO_Error_Detect_Code_Ct "
+  //"-v 187,raw48,Reported_Uncorrect "
+    "-v 189,tempminmax,Airflow_Temperature_Cel "
+  //"-v 192,raw48,Power-Off_Retract_Count "
+  //"-v 194,tempminmax,Temperature_Celsius "
+    "-v 195,raw24/raw32,ECC_Uncorr_Error_Count "
+  //"-v 196,raw16(raw16),Reallocated_Event_Count "
+    "-v 198,raw24/raw32:210zr54,Uncorrectable_Sector_Ct " // KINGSTON SE100S3100G/510ABBF0
+    "-v 199,raw48,SATA_CRC_Error_Count "
+    "-v 201,raw24/raw32,Unc_Soft_Read_Err_Rate "
+    "-v 204,raw24/raw32,Soft_ECC_Correct_Rate "
+    "-v 218,raw48,Unknown_SandForce_Attr " // Corsair Force LS SSD/S9FM01.8, *2.0
+    "-v 230,raw48,Life_Curve_Status "
+    "-v 231,raw48,SSD_Life_Left "
+  //"-v 232,raw48,Available_Reservd_Space "
+    "-v 233,raw48,SandForce_Internal "
+    "-v 234,raw48,SandForce_Internal "
+    "-v 235,raw48,SuperCap_Health "
+    "-v 241,raw48,Lifetime_Writes_GiB "
+    "-v 242,raw48,Lifetime_Reads_GiB"
+  },
+  { "StorFly CFast SATA 6Gbps SSDs",
+    // http://datasheet.octopart.com/VSFCS2CC060G-100-Virtium-datasheet-82287733.pdf
+    // tested with StorFly VSFCS2CC060G-100/0409-000
+    "StorFly VSFCS2C[CI](016|030|060|120|240)G-...",
+    // C - commercial, I industrial
+    "", "",
+    "-v 192,raw48,Unsafe_Shutdown_Count "
+    "-v 160,raw48,Uncorrectable_Error_Cnt "
+    // 0729 - remaining in block life. In 0828  remaining is normalized to 100% then decreases
+    "-v 161,raw48,Spares_Remaining "
+    "-v 241,raw48,Host_Writes_32MiB "
+    "-v 242,raw48,Host_Reads_32MiB "
+    "-v 169,raw48,Lifetime_Remaining% "
+    "-v 248,raw48,Lifetime_Remaining% " //  later then 0409 FW.
+    "-v 249,raw48,Spares_Remaining_Perc " //  later then 0409 FW.
+  },  
+{ "Phison Driven SSDs", // see MKP_521_Phison_SMART_attribute.pdf
+    "BP4 mSATA SSD|" // MyDigital BP4, tested with BP4 mSATA SSD/S8FM06.9
+    "Corsair Force LE(200)? SSD|" // tested with Corsair Force LE SSD/SAFC11.0,
+      // Corsair Force LE200 SSD/SBFM10, .../SBFM60.9
+    "DGSR2(128|256|512)GP13T|"  // tested with DGSR2512GP13T/SBFM61.5
+    "GIGABYTE GP-GSTFS31((120|240|256|480)G|100T)NTD|" // tested with GIGABYTE GP-GSTFS31120GNTD/SBFM61.3
+    "GOODRAM IRIDIUM PRO|" // tested with GOODRAM IRIDIUM PRO/SAFM01.5
+    "IRP?-SSDPR-S25[AC]-(120|240|256|480|512|960|0[12]T)|" // Goodram IRIDM (PRO), tested with
+      // IR-SSDPR-S25A-120/SBFM91.3, IR-SSDPR-S25A-240/SBFM91.2, IRP-SSDPR-S25C-512/SCFM13.3,
+      // IRP-SSDPR-S25C-02T/SCFM13.2
+    "KINGSTON O(C|M[48S])P0S3(64|128|256|512)B-[0A]0|" // tested with KINGSTON OCP0S364B-A0/SBFK62A3,
+      // KINGSTON OM4P0S3256B-A0/SBFK62A3, KINGSTON OM8P0S364B-A0/SBFK62A3,
+      // KINGSTON OMSP0S3128B-00/SBFK62A3
+    "KINGSTON RBUSNS(4|8)180S3(32|64|128|256|512)GJ|" // RBU-SNSx180S3, tested with
+      // KINGSTON RBUSNS4180S3256GJ/SBFK61D1, KINGSTON RBUSNS8180S3512GJ/SBFK61D1
+    "KINGSTON SEDC400S37(400|480|800|960|1600|1800)G|" // DC400, tested with
+      // KINGSTON SEDC400S37480G/SAFM02.[GH], KINGSTON SEDC400S37960G/SAFM32.I
+    "KINGSTON SEDC(450R|500[MR]|600M)(480|960|1920|3840|7680)G|" // DC450R, DC500M/R, DC600M, tested with
+      // KINGSTON SEDC450R480G/SCEKH3. KINGSTON SEDC500M1920G/SCEKJ2.3,
+      // KINGSTON SEDC500R480G/SCEKJ2.3, KINGSTON SEDC450R7680G/SCEKH3.4,
+      // KINGSTON SEDC600M7680G/SCEKH5.1
+    "KINGSTON SM2280S3G2(120)G|" // KINGSTON SM2280S3G2120G/SAFM01.R
+    "KINGSTON SUV300S37A(120|240|480)G|" // UV300 SSD, tested with KINGSTON SUV300S37A120G/SAFM11.K
+    "KINGSTON SKC310S3B?7A960G|" // SSDNow KC310, KINGSTON SKC310S37A960G/SAFM00.r
+    "KINGSTON SKC400S37(128G|256G|512G|1T)|" // SSDNow KC400, KINGSTON SKC400S37128G
+    "KINGSTON SV310S3(7A|D7|N7A|B7A)960G|" // SSDNow V310
+    "KINGSTON SHSS3B?7A(120|240|480|960)G|" // HyperX Savage
+    "KINGSTON SS200S330G|" // SSDNow S200, tested with KINGSTON SS200S330G/S8FM06.A
+    "KINGSTON  ?SA400(M8|S37)(120|240|480|960)G|" // Kingston A400 SSD, Phison S11 or
+      // Silicon Motion controller (see ticket #801), tested with
+      // KINGSTON SA400S37240G/SBFK10D7, KINGSTON SA400S37120G/SBFK71E0, */SBFKB1D1
+      // KINGSTON  SA400S37480G/SBFK10D7 (two spaces), KINGSTON SA400M8240G/SBFK61E1
+    "Patriot (Blast|Blaze|Flare|Ignite)|" // tested with Patriot Blast/SAFM11.3,
+      // Patriot Blaze/S9FM02, Patriot Flare/SBFM91.2, Patriot Ignite/SAFM01.7
+    "Patriot Burst( (120|240|480|960)GB)?|" // tested with Patriot Burst/SBFM11.2,
+      // Patriot Burst 480GB/SBFMLA.5
+    "PNY CS(900|1311|2211) (120G|240G|480G|960G|1T|2T)B SSD|" // tested with PNY CS900 120GB SSD/CS900612,
+      // PNY CS900 240GB SSD/CS900613, PNY CS900 500GB SSD/CS900Y13, PNY CS900 1TB SSD/CS900615,
+      // PNY CS1311 120GB SSD/CS131122, PNY CS2211 240GB SSD/CS221016
+    "PNY ELITE PSSD|" // tested with PNY ELITE PSSD/CS105P13 (240G)
+    "S11-(128|256|512)G-PHISON-SSD-B27|" // tested with: S11-512G-PHISON-SSD-B27/SBFMJ1.3
+    "SSD Smartbuy (60|64|120|128|240|256|480|512|960|1024|2000)GB|" // PS3111-S11, tested with
+      // SSD Smartbuy 240GB/SBFM91.1, SSD Smartbuy 64GB/SBFM21.1
+    "SSD PHISON (128|256)GB PS3110-S10C|" // tested with SSD PHISON 128GB PS3110-S10C/SAFM12.2,
+      // SSD PHISON 256GB PS3110-S10C/SAFM12.2
+    "SSDPR-CX400-(128|256|512|1024)|" // Goodram CX400, tested with SSDPR-CX400-512/SBFM61.3
+    "TEAM L3 EVO SSD (120|240|480|960)GB|" // TEAM L3 EVO SSD 120GB/SBFM11.0
+    "SSM28(128|256|512)GPTCB3B-S11[24]61[123]|" // tested with SSM28256GPTCB3B-S112612/SBFM61.2
+    "SVM2S46(128|256|512)GNPI51UF", // tested with SVM2S46128GNPI51UF/SBFMH1.2
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+    "-v 2,raw48,Not_In_Use "
+    "-v 3,raw48,Not_In_Use "
+    "-v 5,raw48,Retired_Block_Count "
+    "-v 7,raw48,Not_In_Use "
+    "-v 8,raw48,Not_In_Use "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+    "-v 10,raw48,Not_In_Use "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 167,raw48,Write_Protect_Mode " // DC500
+    "-v 168,raw48,SATA_Phy_Error_Count "
+    "-v 169,raw48,Bad_Block_Rate " // DC500
+    "-v 170,raw24/raw24:z54z10,Bad_Blk_Ct_Lat/Erl " // Later bad block/Early bad block (see #1642)
+    "-v 172,raw48,Erase_Fail_Count " // DC500
+    "-v 173,raw16(avg16),MaxAvgErase_Ct "
+    "-v 175,raw48,Not_In_Use "
+    "-v 181,raw48,Program_Fail_Count " // DC500
+    "-v 182,raw48,Erase_Fail_Count " // DC500
+    "-v 183,raw48,Unknown_Phison_Attr "
+  //"-v 187,raw48,Reported_Uncorrect "
+    "-v 192,raw48,Unsafe_Shutdown_Count "
+    "-v 193,raw48,Power_Fail_Uncompl_Cnt "
+  //"-v 194,tempminmax,Temperature_Celsius "
+    "-v 195,raw48,Power_Fail_Health "
+  //"-v 196,raw16(raw16),Reallocated_Event_Count "
+    "-v 197,raw48,Not_In_Use "
+    "-v 199,raw48,SATA_CRC_Error_Count "
+    "-v 207,raw48,Thermal_Throttling_Cnt "
+    "-v 218,raw48,CRC_Error_Count "
+    "-v 231,raw48,SSD_Life_Left "
+    "-v 232,raw48,Read_Fail_Count "
+    "-v 233,raw48,Flash_Writes_GiB "
+    "-v 240,raw48,Not_In_Use "
+    "-v 241,raw48,Lifetime_Writes_GiB "
+    "-v 242,raw48,Lifetime_Reads_GiB "
+    "-v 244,raw48,Average_Erase_Count "
+    "-v 245,raw48,Max_Erase_Count "
+    "-v 246,raw48,Total_Erase_Count "
+  },
+  // this is a copy of the Phison bases record for the OEM drives with a very
+  // weak information in the model. Detection is based on Firmware.
+  { "Phison MSD210 Series SSD",
+  "MSD210-M(4096|3840|2048|1920|1280|1024|960|512|480|320|256|128)GPSCB5UFI-S12[12]"
+  "|MST360-M8PS(4096|3840|2048|1920|1280|1024|960|512|480|320|256|128)GWB5UFI-S17T2"
+  "|M8(4096|3840|2048|1920|1280|1024|960|512|480|320|256|128)GB5UFI-S171",
+  "S[CH]F[DMI][0-9T][0-9]\\.[0-9]",
+  "",
+  "-v 2,raw48,Not_In_Use "
+  "-v 5,raw48,Retired_Block_Count "
+  "-v 168,raw48,SATA_Phy_Error_Count "
+  "-v 170,raw24/raw24:z54z10,Bad_Blk_Ct_Lat/Erl "
+  "-v 173,raw24/raw24:z10z32,Erase_Ct_Max/Avg "
+  "-v 192,raw48,Unsafe_Shutdown_Count "
+  "-v 199,raw48,CRC_Error_Count "
+  "-v 231,raw48,SSD_Life_Left "
+  "-v 233,raw48,Flash_Writes_GiB "
+  "-v 241,raw48,Lifetime_Writes_GiB "
+  "-v 242,raw48,Lifetime_Reads_GiB "
+},
+{ "Phison Driven OEM SSDs", // see MKP_521_Phison_SMART_attribute.pdf
+    "Gigastone SSD|" // tested with GSTB512G (Gigastone SSD/SHFM20.2)
+    "GOODRAM|" // tested with GOODRAM CX200 (GOODRAM/SAFM12.2)
+    "Hoodisk SSD|" // tested with Hoodisk SSD/SBFM01.3, Hoodisk SSD/SBFMJ1.3
+    "INTENSO|" // tested with Intenso SSD SATA III Top (INTENSO/S9FM02.6, .../SAFM01.6)
+    "INTENSO SATA III SSD|" // tested with INTENSO SATA III SSD/SBFM11.2, .../SBFM81.3
+    "Kingmax SATA SSD (120|240|480|960)GB|" // tested with Kingmax SATA SSD 240GB/SBFMY1.3
+    "SATA SSD|" // tested with Supermicro SSD-DM032-PHI (SATA SSD/S9FM02.1),
+      // PC Engines msata16d (SATA SSD/S9FM02.3), FoxLine flssd240x4s(SATA SSD/SBFM10.5)
+    "SPCC Solid State Disk|" // Silicon Power, tested with SPCC Solid State Disk/SBFD00.3,
+      // SPCC Solid State Disk/SBFM61.2, SPCC Solid State Disk/SBFMT1.3
+    "SSDPR-CX400-(128|256|512|1024|2028)-G2", // Goodram CX400 G2, tested with
+      // SSDPR-CX400-512-G2/SBFMLA.5 (SSDPR-CX400-128-G2/SN07373 differs, see ticket #1689)
+    "S[89ABH]F[DM][0-9JLTY][0-9A]\\.[0-9]",
+    "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+    "-v 2,raw48,Not_In_Use "
+    "-v 3,raw48,Not_In_Use "
+    "-v 5,raw48,Retired_Block_Count "
+    "-v 7,raw48,Not_In_Use "
+    "-v 8,raw48,Not_In_Use "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+    "-v 10,raw48,Not_In_Use "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 168,raw48,SATA_Phy_Error_Count "
+    "-v 170,raw24/raw24:z54z10,Bad_Blk_Ct_Lat/Erl " // Later bad block/Early bad block (see #1642)
+    "-v 173,raw16(avg16),MaxAvgErase_Ct "
+    "-v 175,raw48,Not_In_Use "
+    "-v 183,raw48,Unknown_Attribute "
+  //"-v 187,raw48,Reported_Uncorrect "
+    "-v 192,raw48,Unsafe_Shutdown_Count "
+  //"-v 194,tempminmax,Temperature_Celsius "
+    "-v 196,raw48,Not_In_Use "
+    "-v 197,raw48,Not_In_Use "
+    "-v 199,raw48,CRC_Error_Count "
+    "-v 218,raw48,CRC_Error_Count "
+    "-v 231,raw48,SSD_Life_Left "
+    "-v 233,raw48,Flash_Writes_GiB "
+    "-v 240,raw48,Not_In_Use "
+    "-v 241,raw48,Lifetime_Writes_GiB "
+    "-v 242,raw48,Lifetime_Reads_GiB "
+    "-v 244,raw48,Average_Erase_Count "
+    "-v 245,raw48,Max_Erase_Count "
+    "-v 246,raw48,Total_Erase_Count "
+  },
+  { "Indilinx Barefoot based SSDs",
+    "Corsair CSSD-V(32|60|64|128|256)GB2|" // Corsair Nova, tested with Corsair CSSD-V32GB2/2.2
+    "Corsair CMFSSD-(32|64|128|256)D1|" // Corsair Extreme, tested with Corsair CMFSSD-128D1/1.0
+    "CRUCIAL_CT(64|128|256)M225|" // tested with CRUCIAL_CT64M225/1571
+    "G.SKILL FALCON (64|128|256)GB SSD|" // tested with G.SKILL FALCON 128GB SSD/2030
+    "OCZ[ -](AGILITY|ONYX|VERTEX( 1199|-TURBO| v1\\.10)?)|" // tested with
+      // OCZ-ONYX/1.6, OCZ-VERTEX 1199/00.P97, OCZ-VERTEX/1.30, OCZ VERTEX-TURBO/1.5, OCZ-VERTEX v1.10/1370
+    "Patriot[ -]Torqx.*|"
+    "RENICE Z2|" // tested with RENICE Z2/2030
+    "STT_FT[MD](28|32|56|64)GX25H|" // Super Talent Ultradrive GX, tested with STT_FTM64GX25H/1916
+    "TS(18|25)M(64|128)MLC(16|32|64|128|256|512)GSSD|" // ASAX Leopard Hunt II, tested with TS25M64MLC64GSSD/0.1
+    "FM-25S2I-(64|128)GBFII|" // G.Skill FALCON II, tested with FM-25S2I-64GBFII
+    "TS(60|120)GSSD25D-M", // Transcend Ultra SSD (SATA II), see also Ticket #80
+    "", "",
+    "-v 1,raw64 " // Raw_Read_Error_Rate
+    "-v 9,raw64 " // Power_On_Hours
+    "-v 12,raw64 " // Power_Cycle_Count
+    "-v 184,raw64,Initial_Bad_Block_Count "
+    "-v 195,raw64,Program_Failure_Blk_Ct "
+    "-v 196,raw64,Erase_Failure_Blk_Ct "
+    "-v 197,raw64,Read_Failure_Blk_Ct "
+    "-v 198,raw64,Read_Sectors_Tot_Ct "
+    "-v 199,raw64,Write_Sectors_Tot_Ct "
+    "-v 200,raw64,Read_Commands_Tot_Ct "
+    "-v 201,raw64,Write_Commands_Tot_Ct "
+    "-v 202,raw64,Error_Bits_Flash_Tot_Ct "
+    "-v 203,raw64,Corr_Read_Errors_Tot_Ct "
+    "-v 204,raw64,Bad_Block_Full_Flag "
+    "-v 205,raw64,Max_PE_Count_Spec "
+    "-v 206,raw64,Min_Erase_Count "
+    "-v 207,raw64,Max_Erase_Count "
+    "-v 208,raw64,Average_Erase_Count "
+    "-v 209,raw64,Remaining_Lifetime_Perc "
+    "-v 210,raw64,Indilinx_Internal "
+    "-v 211,raw64,SATA_Error_Ct_CRC "
+    "-v 212,raw64,SATA_Error_Ct_Handshake "
+    "-v 213,raw64,Indilinx_Internal"
+  },
+  { "Indilinx Barefoot_2/Everest/Martini based SSDs",
+    "OCZ VERTEX[ -]PLUS|" // tested with OCZ VERTEX-PLUS/3.55, OCZ VERTEX PLUS/3.55
+    "OCZ-VERTEX PLUS R2|" // Barefoot 2, tested with OCZ-VERTEX PLUS R2/1.2
+    "OCZ-OCTANE|" // Everest 1, tested with OCZ-OCTANE/1.13
+    "OCZ-PETROL|" // Everest 1, tested with OCZ-PETROL/3.12
+    "OCZ-AGILITY4|" // Everest 2, tested with OCZ-AGILITY4/1.5.2
+    "OCZ-VERTEX4", // Everest 2, tested with OCZ-VERTEX4/1.5
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 3,raw16(avg16),Spin_Up_Time "
+  //"-v 4,raw48,Start_Stop_Count "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 232,raw48,Lifetime_Writes " // LBA?
+  //"-v 233,raw48,Media_Wearout_Indicator"
+  },
+  { "Indilinx Barefoot 3 based SSDs",
+    "OCZ-VECTOR(1[58]0)?|" // tested with OCZ-VECTOR/1.03, OCZ-VECTOR150/1.2, OCZ-VECTOR180
+    "OCZ-VERTEX4[56]0A?|" // Barefoot 3 M10, tested with OCZ-VERTEX450/1.0, OCZ-VERTEX460/1.0, VERTEX460A
+    "OCZ-SABER1000|"
+    "OCZ-ARC100|"
+    "Radeon R7", // Barefoot 3 M00, tested with Radeon R7/1.00
+    "", "",
+    "-v 5,raw48,Runtime_Bad_Block "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 171,raw48,Avail_OP_Block_Count "
+    "-v 174,raw48,Pwr_Cycle_Ct_Unplanned "
+    "-v 187,raw48,Total_Unc_NAND_Reads "
+    "-v 195,raw48,Total_Prog_Failures "
+    "-v 196,raw48,Total_Erase_Failures "
+    "-v 197,raw48,Total_Unc_Read_Failures "
+    "-v 198,raw48,Host_Reads_GiB "
+    "-v 199,raw48,Host_Writes_GiB "
+    "-v 205,raw48,Max_Rated_PE_Count "
+    "-v 206,raw48,Min_Erase_Count "
+    "-v 207,raw48,Max_Erase_Count "
+    "-v 208,raw48,Average_Erase_Count "
+    "-v 210,raw48,SATA_CRC_Error_Count "
+    "-v 212,raw48,Pages_Requiring_Rd_Rtry "
+    "-v 213,raw48,Snmple_Retry_Attempts "
+    "-v 214,raw48,Adaptive_Retry_Attempts "
+    "-v 222,raw48,RAID_Recovery_Count "
+    "-v 224,raw48,In_Warranty "
+    "-v 225,raw48,DAS_Polarity "
+    "-v 226,raw48,Partial_Pfail "
+    "-v 230,raw48,Write_Throttling "
+    "-v 233,raw48,Remaining_Lifetime_Perc "
+    "-v 241,raw48,Host_Writes_GiB " // M00/M10
+    "-v 242,raw48,Host_Reads_GiB "  // M00/M10
+    "-v 249,raw48,Total_NAND_Prog_Ct_GiB "
+    "-v 251,raw48,Total_NAND_Read_Ct_GiB"
+  },
+  { "OCZ Intrepid 3000 SSDs", // tested with OCZ INTREPID 3600/1.4.3.6, 3800/1.4.3.0, 3700/1.5.0.4
+    "OCZ INTREPID 3[678]00",
+    "", "",
+    "-v 5,raw48,Runtime_Bad_Block "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 100,raw48,Total_Blocks_Erased "
+    "-v 171,raw48,Avail_OP_Block_Count "
+    "-v 174,raw48,Pwr_Cycle_Ct_Unplanned "
+    "-v 184,raw48,Factory_Bad_Block_Count "
+    "-v 187,raw48,Total_Unc_NAND_Reads "
+    "-v 190,tempminmax,Temperature_Celsius "
+    "-v 195,raw48,Total_Prog_Failures "
+    "-v 196,raw48,Total_Erase_Failures "
+    "-v 197,raw48,Total_Unc_Read_Failures "
+    "-v 198,raw48,Host_Reads_GiB "
+    "-v 199,raw48,Host_Writes_GiB "
+    "-v 202,raw48,Total_Read_Bits_Corr_Ct "
+    "-v 205,raw48,Max_Rated_PE_Count "
+    "-v 206,raw48,Min_Erase_Count "
+    "-v 207,raw48,Max_Erase_Count "
+    "-v 208,raw48,Average_Erase_Count "
+    "-v 210,raw48,SATA_CRC_Error_Count "
+    "-v 211,raw48,SATA_UNC_Count "
+    "-v 212,raw48,NAND_Reads_with_Retry "
+    "-v 213,raw48,Simple_Rd_Rtry_Attempts "
+    "-v 214,raw48,Adaptv_Rd_Rtry_Attempts "
+    "-v 221,raw48,Int_Data_Path_Prot_Unc "
+    "-v 222,raw48,RAID_Recovery_Count "
+    "-v 230,raw48,SuperCap_Charge_Status " // 0=not charged, 1=fully charged, 2=unknown
+    "-v 233,raw48,Remaining_Lifetime_Perc "
+    "-v 249,raw48,Total_NAND_Prog_Ct_GiB "
+    "-v 251,raw48,Total_NAND_Read_Ct_GiB"
+  },
+  { "OCZ/Toshiba Trion SSDs",
+    "OCZ-TRION1[05]0|" // tested with OCZ-TRION100/SAFM11.2A, TRION150/SAFZ72.2
+    "TOSHIBA-TR150|" // tested with TOSHIBA-TR150/SAFZ12.3
+    "TOSHIBA Q300( Pro\\.)?", // tested with TOSHIBA Q300 Pro./JYRA0101
+    "", "",
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 167,raw48,SSD_Protect_Mode "
+    "-v 168,raw48,SATA_PHY_Error_Count "
+    "-v 169,raw48,Bad_Block_Count "
+    "-v 173,raw48,Erase_Count "
+    "-v 192,raw48,Unexpect_Power_Loss_Ct "
+  //"-v 194,tempminmax,Temperature_Celsius "
+    "-v 241,raw48,Host_Writes"
+  },
+  { "InnoDisk InnoLite SATADOM D150QV SSDs", // tested with InnoLite SATADOM D150QV-L/120319
+                                             // InnoLite SATADOM D150QV/120319
+    "InnoLite SATADOM D150QV.*",
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 2,raw48,Throughput_Performance "
+  //"-v 3,raw16(avg16),Spin_Up_Time "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 7,raw48,Seek_Error_Rate " // from InnoDisk iSMART Linux tool, useless for SSD
+  //"-v 8,raw48,Seek_Time_Performance "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 10,raw48,Spin_Retry_Count "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 168,raw48,SATA_PHY_Error_Count "
+    "-v 170,raw16,Bad_Block_Count_New/Tot "
+    "-v 173,raw16,Erase_Count_Max/Avg "
+    "-v 175,raw48,Bad_Cluster_Table_Count "
+    "-v 192,raw48,Unexpect_Power_Loss_Ct "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 197,raw48,Current_Pending_Sector "
+    "-v 229,hex48,Flash_ID "
+    "-v 235,raw16,Lat_Bad_Blk_Era/Wri/Rea "
+    "-v 236,raw48,Unstable_Power_Count "
+    "-v 240,raw48,Write_Head"
+  },
+  { "Innodisk 1ME3/3ME/3SE SSDs", // tested with 2.5" SATA SSD 3ME/S140714,
+      // Mini PCIeDOM 1ME3/S15604, InnoDisk Corp. - mSATA 3SE/S130710
+    "((1\\.8|2\\.5)\"? SATA SSD|InnoDisk Corp\\. - mSATA|Mini PCIeDOM|SATA Slim) (1ME3|3[MS]E)",
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 2,raw48,Throughput_Performance "
+  //"-v 3,raw16(avg16),Spin_Up_Time "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+    "-v 7,raw48,Seek_Error_Rate "       // ?
+    "-v 8,raw48,Seek_Time_Performance " // ?
+  //"-v 9,raw24(raw8),Power_On_Hours "
+    "-v 10,raw48,Spin_Retry_Count "     // ?
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 168,raw48,SATA_PHY_Error_Count "
+    "-v 169,hex48,Unknown_Innodisk_Attr "
+    "-v 170,raw16,Bad_Block_Count "
+    "-v 173,raw16,Erase_Count "
+    "-v 175,raw48,Bad_Cluster_Table_Count "
+    "-v 176,raw48,Uncorr_RECORD_Count "
+  //"-v 192,raw48,Power-Off_Retract_Count "
+  //"-v 194,tempminmax,Temperature_Celsius " // ] only in spec
+  //"-v 197,raw48,Current_Pending_Sector "
+    "-v 225,raw48,Unknown_Innodisk_Attr "
+    "-v 229,hex48,Flash_ID "
+    "-v 235,raw48,Later_Bad_Block "
+    "-v 236,raw48,Unstable_Power_Count "
+    "-v 240,raw48,Write_Head"
+  },
+  { "Innodisk 3IE2/3ME2/3MG2/3SE2/3TG6 SSDs", // tested with 2.5" SATA SSD 3MG2-P/M140402,
+      // 1.8 SATA SSD 3IE2-P/M150821, 2.5" SATA SSD 3IE2-P/M150821,
+      // SATA Slim 3MG2-P/M141114, M.2 (S80) 3MG2-P/M141114, M.2 (S42) 3SE2-P/M150821,
+      // M.2 (S42) 3ME2/M151013, SATA Slim 3TG6-P/A19926J
+    "((1\\.8|2\\.5)\"? SATA SSD|SATA Slim|M\\.2 \\(S(42|80)\\)) 3(IE2|ME2|MG2|SE2|TG6)(-P)?",
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 2,raw48,Throughput_Performance "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 160,raw48,Uncorrectable_Error_Cnt "
+    "-v 161,raw48,Number_of_Pure_Spare "
+    "-v 163,raw48,Total_Bad_Block_Count "
+    "-v 164,raw48,Total_Erase_Count "
+    "-v 165,raw48,Max_Erase_Count "
+    "-v 166,raw48,Min_Erase_Count "
+    "-v 167,raw48,Average_Erase_Count "
+    "-v 168,raw48,Max_Erase_Count_of_Spec "
+    "-v 169,raw48,Remaining_Lifetime_Perc "
+    "-v 170,raw48,Spare_Block_Count "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+  //"-v 175,raw48,Program_Fail_Count_Chip "
+  //"-v 176,raw48,Erase_Fail_Count_Chip "
+  //"-v 177,raw48,Wear_Leveling_Count "
+    "-v 178,raw48,Runtime_Invalid_Blk_Cnt "
+  //"-v 181,raw48,Program_Fail_Cnt_Total "
+  //"-v 182,raw48,Erase_Fail_Count_Total "
+  //"-v 187,raw48,Reported_Uncorrect " // ] only in spec
+  //"-v 192,raw48,Power-Off_Retract_Count "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 195,raw48,Hardware_ECC_Recovered "
+  //"-v 196,raw16(raw16),Reallocated_Event_Count "
+  //"-v 197,raw48,Current_Pending_Sector "
+  //"-v 198,raw48,Offline_Uncorrectable "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 225,raw48,Host_Writes_32MiB "  // ]
+    "-v 229,raw48,Flash_ID "  // ]
+  //"-v 232,raw48,Available_Reservd_Space "
+    "-v 233,raw48,Flash_Writes_32MiB " // ]
+    "-v 234,raw48,Flash_Reads_32MiB "  // ]
+    "-v 235,raw48,Later_Bad_Block_Info "  // ]
+    "-v 241,raw48,Host_Writes_32MiB "
+    "-v 242,raw48,Host_Reads_32MiB "
+    "-v 245,raw48,Flash_Writes_32MiB "
+    "-v 248,raw48,Remaining_Life "
+    "-v 249,raw48,Spare_Blocks_Remaining"
+  },
+  { "Innodisk 1IE3/3IE3/3ME3/3IE4/3ME4 SSDs", // tested with 2.5" SATA SSD 3ME3/S15A19,
+      // InnoDisk Corp. - mSATA 3ME3/S15A19, mSATA mini 3ME3/S15A19, M.2 (S42) 3ME3,
+      // SATA Slim 3ME3/S15A19, SATADOM-MH 3ME3/S15A19, SATADOM-ML 3ME3/S15A19,
+      // SATADOM-MV 3ME3/S15A19, SATADOM-SL 3ME3/S15A19, SATADOM-SV 3ME3/S15A19,
+      // SATADOM-SL 3IE3/S151019N, 2.5" SATA SSD 3IE3/S15C14i, CFast 3IE3/S15C14i,
+      // InnoDisk Corp. - mSATA 3IE3/S15C14i, Mini PCIeDOM 1IE3/S15C14i, CFast 3ME3/S15A19
+      // mSATA mini 3IE3/S15C14i, M.2 (S42) 3IE3/S15C14i, SATA Slim 3IE3/S15C14i,
+      // SATADOM-SH 3IE3 V2/S15C14i, SATADOM-SL 3IE3 V2/S15A19i, SATADOM-SV 3IE3 V2/S15C14i
+      // mSATA 3ME4/L16711, M.2 (S42) 3ME4/L16711, SATADOM-MH 3ME4/L16B01,
+      // SATADOM-SH 3ME4/L16B01, SATADOM-SH Type C 3ME4/L16B01, SATADOM-SH Type D 3ME4/L16B01,
+      // mSATA 3IE4/L16B01Hi
+    "(2.5\" SATA SSD|CFast|Mini PCIeDOM|(InnoDisk Corp\\. - )?mSATA( mini)?) (1IE3|3[IM]E[34])( V2)?|"
+    "(M\\.2 \\(S42\\)|SATA Slim|SATADOM-[MS][HLV]( Type [CD])?) (1IE3|3[IM]E[34])( V2)?",
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 2,raw48,Throughput_Performance "
+  //"-v 3,raw16(avg16),Spin_Up_Time "
+    "-v 5,raw48,Later_Bad_Block "
+    "-v 7,raw48,Seek_Error_Rate "       // ?
+    "-v 8,raw48,Seek_Time_Performance " // ?
+  //"-v 9,raw24(raw8),Power_On_Hours "
+    "-v 10,raw48,Spin_Retry_Count "     // ?
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 163,raw48,Total_Bad_Block_Count "
+    "-v 165,raw48,Max_Erase_Count "
+    "-v 167,raw48,Average_Erase_Count "
+    "-v 168,raw48,SATA_PHY_Error_Count "
+    "-v 169,raw48,Remaining_Lifetime_Perc "
+    "-v 170,raw48,Spare_Block_Count "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 175,raw48,Bad_Cluster_Table_Count "
+    "-v 176,raw48,RANGE_RECORD_Count "
+  //"-v 187,raw48,Reported_Uncorrect "
+  //"-v 192,raw48,Power-Off_Retract_Count "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 197,raw48,Current_Pending_Sector "
+    "-v 225,raw48,Data_Log_Write_Count "
+    "-v 229,hex48,Flash_ID "
+    "-v 232,raw48,Spares_Remaining_Perc "
+    "-v 235,raw16,Later_Bad_Blk_Inf_R/W/E " // Read/Write/Erase
+    "-v 240,raw48,Write_Head "
+    "-v 241,raw48,Host_Writes_32MiB "
+    "-v 242,raw48,Host_Reads_32MiB"
+  },
+  { "InnoDisk iCF 9000 / 1SE2 Cards", // tested with InnoDisk Corp. - iCF9000 1GB/140808,
+      // InnoDisk Corp. - iCF9000 64GB/140808, InnoDisk Corp. - EDC 1SE2 H 64GB/131216
+    "InnoDisk Corp\\. - (iCF9000|EDC 1SE2 H) (1|2|4|8|16|32|64)GB",
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 160,raw48,Uncorrectable_Error_Cnt "
+    "-v 161,raw48,Valid_Spare_Block_Cnt "
+    "-v 162,raw48,Child_Pair_Count "
+    "-v 163,raw48,Initial_Bad_Block_Count "
+    "-v 164,raw48,Total_Erase_Count "
+    "-v 165,raw48,Max_Erase_Count "
+    "-v 166,raw48,Min_Erase_Count "
+    "-v 167,raw48,Average_Erase_Count "
+  //"-v 192,raw48,Power-Off_Retract_Count "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 195,raw48,Hardware_ECC_Recovered "
+  //"-v 196,raw16(raw16),Reallocated_Event_Count "
+  //"-v 198,raw48,Offline_Uncorrectable "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+  //"-v 229,raw48,Flash_ID " // only in spec
+    "-v 241,raw48,Host_Writes_32MiB "
+    "-v 242,raw48,Host_Reads_32MiB"
+  },
+  { "Intel X25-E SSDs", // tested with
+      // INTELSSDSA2SH064G1IB 43W7659 44E9163IBM/447C8860
+    "(INTEL)?SSDSA2SH(032|064)G1.* (.*IBM|INTEL)", // G1 = first generation
+    "", "",
+  //"-v 3,raw16(avg16),Spin_Up_Time "
+  //"-v 4,raw48,Start_Stop_Count "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 192,raw48,Unsafe_Shutdown_Count "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Intel_Internal "
+    "-v 227,raw48,Intel_Internal "
+    "-v 228,raw48,Intel_Internal "
+  //"-v 232,raw48,Available_Reservd_Space "
+  //"-v 233,raw48,Media_Wearout_Indicator"
+  },
+  { "Intel X18-M/X25-M G1 SSDs",
+    "INTEL SSDSA[12]MH(080|160)G1.*",  // G1 = first generation, 50nm
+    "", "",
+  //"-v 3,raw16(avg16),Spin_Up_Time "
+  //"-v 4,raw48,Start_Stop_Count "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 192,raw48,Unsafe_Shutdown_Count "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Intel_Internal "
+    "-v 227,raw48,Intel_Internal "
+    "-v 228,raw48,Intel_Internal "
+  //"-v 232,raw48,Available_Reservd_Space "
+  //"-v 233,raw48,Media_Wearout_Indicator"
+  },
+  { "Intel X18-M/X25-M/X25-V G2 SSDs", // fixed firmware
+      // tested with INTEL SSDSA2M(080|160)G2GC/2CV102J8 (X25-M)
+    "INTEL SSDSA[12]M(040|080|120|160)G2.*",  // G2 = second generation, 34nm
+    "2CV102(J[89A-Z]|[K-Z].)", // >= "2CV102J8"
+    "",
+  //"-v 3,raw16(avg16),Spin_Up_Time "
+  //"-v 4,raw48,Start_Stop_Count "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+  //"-v 184,raw48,End-to-End_Error " // G2 only
+    "-v 192,raw48,Unsafe_Shutdown_Count "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Workld_Media_Wear_Indic " // Timed Workload Media Wear Indicator (percent*1024)
+    "-v 227,raw48,Workld_Host_Reads_Perc "  // Timed Workload Host Reads Percentage
+    "-v 228,raw48,Workload_Minutes " // 226,227,228 can be reset by 'smartctl -t vendor,0x40'
+  //"-v 232,raw48,Available_Reservd_Space "
+  //"-v 233,raw48,Media_Wearout_Indicator"
+  },
+  { "Intel X18-M/X25-M/X25-V G2 SSDs", // buggy or unknown firmware
+      // tested with INTEL SSDSA2M040G2GC/2CV102HD (X25-V)
+    "INTEL SSDSA[12]M(040|080|120|160)G2.*",
+    "",
+    "This drive may require a firmware update to\n"
+    "fix possible drive hangs when reading SMART self-test log:\n"
+    "https://downloadcenter.intel.com/download/26491",
+    "-v 192,raw48,Unsafe_Shutdown_Count "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Workld_Media_Wear_Indic "
+    "-v 227,raw48,Workld_Host_Reads_Perc "
+    "-v 228,raw48,Workload_Minutes"
+  },
+  { "Intel 311/313 Series SSDs", // tested with INTEL SSDSA2VP020G2/2CV102M5,
+      // INTEL SSDSA2VP020G3/9CV10379, INTEL SSDMAEXC024G3H/9CV10379
+    "INTEL SSD(SA2VP|MAEXC)(020|024)G[23]H?",
+      // SA2VP = 2.5", MAEXC = mSATA, G2 = 311, G3 = 313
+    "", "",
+  //"-v 3,raw16(avg16),Spin_Up_Time "
+  //"-v 4,raw48,Start_Stop_Count "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 170,raw48,Reserve_Block_Count "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 183,raw48,SATA_Downshift_Count "
+  //"-v 184,raw48,End-to-End_Error "
+  //"-v 187,raw48,Reported_Uncorrect "
+    "-v 192,raw48,Unsafe_Shutdown_Count "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Workld_Media_Wear_Indic " // Timed Workload Media Wear Indicator (percent*1024)
+    "-v 227,raw48,Workld_Host_Reads_Perc "  // Timed Workload Host Reads Percentage
+    "-v 228,raw48,Workload_Minutes " // 226,227,228 can be reset by 'smartctl -t vendor,0x40'
+  //"-v 232,raw48,Available_Reservd_Space "
+  //"-v 233,raw48,Media_Wearout_Indicator "
+    "-v 241,raw48,Host_Writes_32MiB "
+    "-v 242,raw48,Host_Reads_32MiB"
+  },
+  { "Intel 320 Series SSDs", // tested with INTEL SSDSA2CT040G3/4PC10362,
+      // INTEL SSDSA2CW160G3/4PC10362, SSDSA2BT040G3/4PC10362, SSDSA2BW120G3A/4PC10362,
+      // INTEL SSDSA2BW300G3D/4PC10362, SSDSA2BW160G3L/4PC1LE04, SSDSA1NW160G3/4PC10362,
+      // INTEL SSDSA2BW160G3H/4PC10365
+    "INTEL SSDSA[12][BCN][WT](040|080|120|160|300|600)G3[ADHL]?",
+      // 2B = 2.5" 7mm, 2C = 2.5" 9.5mm, 1N = 1.8" microSATA, *H = HP OEM
+    "", "",
+    "-F nologdir "
+  //"-v 3,raw16(avg16),Spin_Up_Time "
+  //"-v 4,raw48,Start_Stop_Count "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 170,raw48,Reserve_Block_Count "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 183,raw48,SATA_Downshift_Count " // FW >= 4Px10362
+  //"-v 184,raw48,End-to-End_Error "
+  //"-v 187,raw48,Reported_Uncorrect "
+    "-v 199,raw48,CRC_Error_Count "      // FW >= 4Px10362
+    "-v 192,raw48,Unsafe_Shutdown_Count "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Workld_Media_Wear_Indic " // Timed Workload Media Wear Indicator (percent*1024)
+    "-v 227,raw48,Workld_Host_Reads_Perc "  // Timed Workload Host Reads Percentage
+    "-v 228,raw48,Workload_Minutes " // 226,227,228 can be reset by 'smartctl -t vendor,0x40'
+  //"-v 232,raw48,Available_Reservd_Space "
+  //"-v 233,raw48,Media_Wearout_Indicator "
+    "-v 241,raw48,Host_Writes_32MiB "
+    "-v 242,raw48,Host_Reads_32MiB"
+  },
+  { "Intel 710 Series SSDs", // tested with INTEL SSDSA2BZ[12]00G3/6PB10362
+    "INTEL SSDSA2BZ(100|200|300)G3",
+    "", "",
+    "-F nologdir "
+  //"-v 3,raw16(avg16),Spin_Up_Time "
+  //"-v 4,raw48,Start_Stop_Count "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 170,raw48,Reserve_Block_Count "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct " // Missing in 710 specification from September 2011
+    "-v 183,raw48,SATA_Downshift_Count "
+  //"-v 184,raw48,End-to-End_Error "
+  //"-v 187,raw48,Reported_Uncorrect "
+  //"-v 190,tempminmax,Airflow_Temperature_Cel "
+    "-v 192,raw48,Unsafe_Shutdown_Count "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Workld_Media_Wear_Indic " // Timed Workload Media Wear Indicator (percent*1024)
+    "-v 227,raw48,Workld_Host_Reads_Perc "  // Timed Workload Host Reads Percentage
+    "-v 228,raw48,Workload_Minutes " // 226,227,228 can be reset by 'smartctl -t vendor,0x40'
+  //"-v 232,raw48,Available_Reservd_Space "
+  //"-v 233,raw48,Media_Wearout_Indicator "
+    "-v 241,raw48,Host_Writes_32MiB "
+    "-v 242,raw48,Host_Reads_32MiB"
+  },
+  { "Intel 510 Series SSDs",
+    "INTEL SSDSC2MH(120|250)A2",
+    "", "",
+  //"-v 3,raw16(avg16),Spin_Up_Time "
+  //"-v 4,raw48,Start_Stop_Count "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 192,raw48,Unsafe_Shutdown_Count "
+    "-v 225,raw48,Host_Writes_32MiB "
+  //"-v 232,raw48,Available_Reservd_Space "
+  //"-v 233,raw48,Media_Wearout_Indicator"
+  },
+  { "Intel 520 Series SSDs", // tested with INTEL SSDSC2CW120A3/400i, SSDSC2BW480A3F/400i,
+      // INTEL SSDSC2BW180A3L/LB3i
+    "INTEL SSDSC2[BC]W(060|120|180|240|480)A3[FL]?",
+    "", "",
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+    "-v 9,msec24hour32,Power_On_Hours_and_Msec "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 170,raw48,Available_Reservd_Space "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+  //"-v 184,raw48,End-to-End_Error "
+    "-v 187,raw48,Uncorrectable_Error_Cnt "
+  //"-v 192,raw48,Power-Off_Retract_Count "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Workld_Media_Wear_Indic "
+    "-v 227,raw48,Workld_Host_Reads_Perc "
+    "-v 228,raw48,Workload_Minutes "
+  //"-v 232,raw48,Available_Reservd_Space "
+  //"-v 233,raw48,Media_Wearout_Indicator "
+    "-v 241,raw48,Host_Writes_32MiB "
+    "-v 242,raw48,Host_Reads_32MiB "
+    "-v 249,raw48,NAND_Writes_1GiB"
+  },
+  { "Intel 525 Series SSDs", // mSATA, tested with SSDMCEAC120B3/LLLi
+    "INTEL SSDMCEAC(030|060|090|120|180|240)B3",
+    "", "",
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+    "-v 9,msec24hour32,Power_On_Hours_and_Msec "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 170,raw48,Available_Reservd_Space "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+    "-v 183,raw48,SATA_Downshift_Count "
+  //"-v 184,raw48,End-to-End_Error "
+    "-v 187,raw48,Uncorrectable_Error_Cnt "
+  //"-v 190,tempminmax,Airflow_Temperature_Cel "
+  //"-v 192,raw48,Power-Off_Retract_Count "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Workld_Media_Wear_Indic "
+    "-v 227,raw48,Workld_Host_Reads_Perc "
+    "-v 228,raw48,Workload_Minutes "
+  //"-v 232,raw48,Available_Reservd_Space "
+  //"-v 233,raw48,Media_Wearout_Indicator "
+    "-v 241,raw48,Host_Writes_32MiB "
+    "-v 242,raw48,Host_Reads_32MiB "
+    "-v 249,raw48,NAND_Writes_1GiB"
+  },
+  { "Intel 53x and Pro 1500/2500 Series SSDs", // SandForce SF-2281, tested with
+      // INTEL SSDSC2BW180A4/DC12, INTEL SSDSC2BW240A4/DC12, INTEL SSDMCEAW120A4/DC33,
+      // INTEL SSDMCEAW240A4/DC33, INTEL SSDSC2BF180A4H/LH6i, INTEL SSDSC2BF480A5/TG26,
+      // INTEL SSDSC2BF240A5L/LT2i, INTEL SSDSC2BW240H6/RG21
+    "INTEL SSD(MCEA|SC2B|SCKJ)[WF](056|080|120|180|240|360|480)(A4H?|A5L?|H6)",
+      // SC2B = 2.5", MCEA = mSATA, SCKJ = M.2; A4 = 530/Pro 1500, A5 = Pro 2500, H6 = 535
+    "", "",
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+    "-v 9,msec24hour32,Power_On_Hours_and_Msec "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 170,raw48,Available_Reservd_Space "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+    "-v 183,raw48,SATA_Downshift_Count "
+  //"-v 184,raw48,End-to-End_Error "
+    "-v 187,raw48,Uncorrectable_Error_Cnt "
+  //"-v 190,tempminmax,Airflow_Temperature_Cel "
+  //"-v 192,raw48,Power-Off_Retract_Count "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Workld_Media_Wear_Indic "
+    "-v 227,raw48,Workld_Host_Reads_Perc "
+    "-v 228,raw48,Workload_Minutes "
+  //"-v 232,raw48,Available_Reservd_Space "
+  //"-v 233,raw48,Media_Wearout_Indicator "
+    "-v 241,raw48,Host_Writes_32MiB "
+    "-v 242,raw48,Host_Reads_32MiB "
+    "-v 249,raw48,NAND_Writes_1GiB"
+  },
+  { "Intel 330/335 Series SSDs", // tested with INTEL SSDSC2CT180A3/300i, SSDSC2CT240A3/300i,
+      // INTEL SSDSC2CT240A4/335t
+    "INTEL SSDSC2CT(060|120|180|240)A[34]", // A4 = 335 Series
+    "", "",
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+    "-v 9,msec24hour32,Power_On_Hours_and_Msec "
+  //"-v 12,raw48,Power_Cycle_Count "
+  //"-v 181,raw48,Program_Fail_Cnt_Total " // ] Missing in 330 specification from April 2012
+  //"-v 182,raw48,Erase_Fail_Count_Total " // ]
+  //"-v 192,raw48,Power-Off_Retract_Count "
+    "-v 225,raw48,Host_Writes_32MiB "
+  //"-v 232,raw48,Available_Reservd_Space "
+  //"-v 233,raw48,Media_Wearout_Indicator "
+    "-v 241,raw48,Host_Writes_32MiB "
+    "-v 242,raw48,Host_Reads_32MiB "
+    "-v 249,raw48,NAND_Writes_1GiB"
+  },
+  // https://www.intel.com/content/www/us/en/solid-state-drives/ssd-540s-series-spec.html
+  // https://www.intel.com/content/www/us/en/solid-state-drives/ssd-540s-series-m2-spec.html
+  { "Intel 540 Series SSDs", // INTEL SSDSC2KW120H6/LSF036C, INTEL SSDSC2KW480H6/LSF036C
+    "INTEL SSDSC[K2]KW(120H|180H|240H|360H|480H|010X)6",
+    "", "",
+    "-v 9,msec24hour32,Power_On_Hours_and_Msec "
+    "-v 170,raw48,Available_Reservd_Space "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+    "-v 183,raw48,SATA_Downshift_Count "
+    "-v 187,raw48,Uncorrectable_Error_Cnt "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Workld_Media_Wear_Indic "
+    "-v 227,raw48,Workld_Host_Reads_Perc "
+    "-v 228,raw48,Workload_Minutes "
+    "-v 249,raw48,NAND_Writes_1GiB"
+  },
+  { "Intel 545s Series SSDs", // tested with INTEL SSDSCKKW512G8, INTEL SSDSC2KW512G8/LHF002C
+      // SSDSCKKW128G8X1, SSDSCKKW256G8X1, SSDSCKKW512G8X1, SSDSCKKW010T8X1
+      // INTEL SSDSCKKF512G8 SATA 512GB/LHFD05N
+    "INTEL SSDSC[2K]K[WF](128G|256G|512G|010T)8.*",
+    "", "",
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+  //"-v 170,raw48,Available_Reservd_Space "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+  //"-v 173 is missing in official Intel doc"
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+    "-v 183,raw48,SATA_Downshift_Count "
+  //"-v 184,raw48,End-to-End_Error "
+  //"-v 187,raw48,Reported_Uncorrect "
+    "-v 190,tempminmax,Temperature_Case "
+    "-v 192,raw48,Unsafe_Shutdown_Count "
+    "-v 199,raw48,CRC_Error_Count "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Workld_Media_Wear_Indic " // Timed Workload Media Wear Indicator (percent*1024)
+    "-v 227,raw48,Workld_Host_Reads_Perc "  // Timed Workload Host Reads Percentage
+    "-v 228,raw48,Workload_Minutes " // 226,227,228 can be reset by 'smartctl -t vendor,0x40'
+  //"-v 232,raw48,Available_Reservd_Space "
+  //"-v 233,raw48,Media_Wearout_Indicator "
+  //"-v 236 is missing in official Intel doc"
+    "-v 241,raw48,Host_Writes_32MiB "
+    "-v 242,raw48,Host_Reads_32MiB "
+    "-v 249,raw48,NAND_Writes_1GiB "
+  //"-v 252 is missing in official intel doc"
+  },
+  { "Intel 730 and DC S35x0/3610/3700 Series SSDs", // tested with INTEL SSDSC2BP480G4, SSDSC2BB120G4/D2010355,
+      // INTEL SSDSC2BB800G4T, SSDSC2BA200G3/5DV10250, SSDSC2BB080G6/G2010130,  SSDSC2BX200G4/G2010110,
+      // INTEL SSDSC2BB016T6/G2010140, SSDSC2BX016T4/G2010140, SSDSC2BB150G7/N2010101,
+      // INTEL SSDSC2BB480H4/D2010380, INTEL SSDSC2BB240G4C/D201FJ14, INTEL SSDSC2BA800G3E/5DV10250
+    "INTEL SSDSC(1N|2B)[ABPX]((080|100|120|150|160|200|240|300|400|480|600|800)[GH][3467][CERT]?|(012|016)T[46])|"
+      // A = S3700, B*4 = S3500, B*6 = S3510, P = 730, X = S3610
+      // Dell ships drives with model of the form SSDSC2BB120G4R
+    "VK000(120|240|480)GWSXF", // tested with VK000480GWSXF/HPG2 (HPE INTEL SSDSC2BB480G4)
+    "", "",
+  //"-v 3,raw16(avg16),Spin_Up_Time "
+  //"-v 4,raw48,Start_Stop_Count "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+    "-v 11,raw48,Unknown_Intel_Attribute " // VK000480GWSXF
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 170,raw48,Available_Reservd_Space "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 173,raw48,Unknown_Intel_Attribute " // VK000480GWSXF
+    "-v 174,raw48,Unsafe_Shutdown_Count "
+    "-v 175,raw16(raw16),Power_Loss_Cap_Test "
+    "-v 183,raw48,SATA_Downshift_Count "
+  //"-v 184,raw48,End-to-End_Error "
+  //"-v 187,raw48,Reported_Uncorrect "
+    "-v 190,tempminmax,Temperature_Case "
+    "-v 192,raw48,Unsafe_Shutdown_Count "
+    "-v 194,tempminmax,Temperature_Internal "
+  //"-v 197,raw48,Current_Pending_Sector "
+    "-v 199,raw48,CRC_Error_Count "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Workld_Media_Wear_Indic " // Timed Workload Media Wear Indicator (percent*1024)
+    "-v 227,raw48,Workld_Host_Reads_Perc "  // Timed Workload Host Reads Percentage
+    "-v 228,raw48,Workload_Minutes " // 226,227,228 can be reset by 'smartctl -t vendor,0x40'
+  //"-v 232,raw48,Available_Reservd_Space "
+  //"-v 233,raw48,Media_Wearout_Indicator "
+    "-v 234,raw24/raw32:04321,Thermal_Throttle "
+    "-v 241,raw48,Host_Writes_32MiB "
+    "-v 242,raw48,Host_Reads_32MiB "
+    "-v 243,raw48,NAND_Writes_32MiB " // S3510/3610
+    "-F xerrorlba" // tested with SSDSC2BB600G4/D2010355
+  },
+  // https://www.intel.com/content/www/us/en/solid-state-drives/ssd-pro-5400s-series-spec.html
+  // https://www.intel.com/content/www/us/en/solid-state-drives/ssd-pro-5400s-series-m2-spec.html
+  { "Intel SSD Pro 5400s Series", // Tested with SSDSC2KF480H6/LSF036P
+    "INTEL SSDSC[2K]KF(120H|180H|240H|360H|480H|010X)6",
+    "", "",
+    "-v 170,raw48,Available_Reservd_Space "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+    "-v 183,raw48,SATA_Downshift_Count "
+    "-v 187,raw48,Uncorrectable_Error_Cnt "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Workld_Media_Wear_Indic "
+    "-v 227,raw48,Workld_Host_Reads_Perc "
+    "-v 228,raw48,Workload_Minutes "
+    "-v 249,raw48,NAND_Writes_1GiB "
+  },
+  { "Intel DC S3110 Series SSDs", // Tested with INTEL SSDSCKKI256G8
+    "INTEL SSDSCKKI(128|256|512)G8",
+    "", "",
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 170,raw48,Available_Reservd_Space "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+  //"-v 173 is missing in official Intel doc"
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+    "-v 183,raw48,SATA_Downshift_Count "
+  //"-v 184,raw48,End-to-End_Error "
+    "-v 187,raw48,Uncorrectable_Error_Cnt "
+  //"-v 190,tempminmax,Airflow_Temperature_Cel "
+  //"-v 192,raw48,Power-Off_Retract_Count "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Workld_Media_Wear_Indic "
+    "-v 227,raw48,Workld_Host_Reads_Perc "
+    "-v 228,raw48,Workload_Minutes "
+  //"-v 232,raw48,Available_Reservd_Space "
+  //"-v 233,raw48,Media_Wearout_Indicator "
+  //"-v 236 is missing in official Intel doc"
+    "-v 241,raw48,Host_Writes_32MiB "
+    "-v 242,raw48,Host_Reads_32MiB "
+    "-v 249,raw48,NAND_Writes_1GiB "
+  //"-v 252 is missing in official Intel doc"
+  },
+  { "Intel 3710 Series SSDs", // INTEL SSDSC2BA200G4R/G201DL2B (dell)
+    "INTEL SSDSC2BA(200G|400G|800G|012T)4.?",
+    "", "",
+    "-v 9,msec24hour32,Power_On_Hours_and_Msec "
+    "-v 170,raw48,Available_Reservd_Space "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+    "-v 183,raw48,SATA_Downshift_Count "
+    "-v 187,raw48,Uncorrectable_Error_Cnt "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Workld_Media_Wear_Indic "
+    "-v 227,raw48,Workld_Host_Reads_Perc "
+    "-v 228,raw48,Workload_Minutes "
+    "-v 234,raw24/raw32:04321,Thermal_Throttle "
+    "-v 243,raw48,NAND_Writes_32MiB "
+  },
+  { "Intel S3520 Series SSDs", // INTEL SSDSC2BB960G7/N2010112, INTEL SSDSC2BB016T7/N2010112
+    "INTEL SSDSC(2|K)(J|B)B(240G|480G|960G|150G|760G|800G|012T|016T)7.?",
+    "", "",
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 170,raw48,Available_Reservd_Space "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 174,raw48,Unsafe_Shutdown_Count "
+    "-v 175,raw16(raw16),Power_Loss_Cap_Test "
+    "-v 183,raw48,SATA_Downshift_Count "
+    "-v 184,raw48,End-to-End_Error_Count "
+    "-v 187,raw48,Uncorrectable_Error_Cnt "
+    "-v 190,tempminmax,Case_Temperature "
+    "-v 192,raw48,Unsafe_Shutdown_Count "
+    "-v 194,tempminmax,Drive_Temperature "
+    "-v 197,raw48,Pending_Sector_Count "
+    "-v 199,raw48,CRC_Error_Count "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Workld_Media_Wear_Indic " // Timed Workload Media Wear Indicator (percent*1024)
+    "-v 227,raw48,Workld_Host_Reads_Perc "  // Timed Workload Host Reads Percentage
+    "-v 228,raw48,Workload_Minutes " // 226,227,228 can be reset by 'smartctl -t vendor,0x40'
+  //"-v 232,raw48,Available_Reservd_Space "
+  //"-v 233,raw48,Media_Wearout_Indicator "
+    "-v 234,raw24/raw32:04321,Thermal_Throttle_Status "
+    "-v 241,raw48,Host_Writes_32MiB "
+    "-v 242,raw48,Host_Reads_32MiB "
+    "-v 243,raw48,NAND_Writes_32MiB"
+  },
+  { "Dell Certified Intel S3520 Series SSDs",
+    "SSDSC(2|K)(J|B)B(240G|480G|960G|120G|760G|800G|012T|016T)7R.?",
+    "", "",
+    "-v 170,raw48,Available_Reservd_Space "
+    "-v 174,raw48,Unsafe_Shutdown_Count "
+    "-v 195,raw48,Uncorrectable_Error_Cnt "
+    "-v 199,raw48,CRC_Error_Count "
+    "-v 201,raw16(raw16),Power_Loss_Cap_Test "
+    "-v 202,raw48,End_of_Life "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Workld_Media_Wear_Indic " // Timed Workload Media Wear Indicator (percent*1024)
+    "-v 227,raw48,Workld_Host_Reads_Perc "  // Timed Workload Host Reads Percentage
+    "-v 228,raw48,Workload_Minutes " // 226,227,228 can be reset by 'smartctl -t vendor,0x40'
+    "-v 233,raw48,Total_LBAs_Written "
+    "-v 234,raw24/raw32:04321,Thermal_Throttle_Status "
+    "-v 245,raw48,Percent_Life_Remaining"
+  },
+  { "Intel/Solidigm S46x0/S45x0 Series SSDs", // INTEL SSDSC2KB480G7/SCV10100,
+      // INTEL SSDSC2KB960G7/SCV10100, INTEL SSDSC2KB038T7/SCV10100,
+      // INTEL SSDSC2KB038T7/SCV10121, INTEL SSDSC2KG240G7/SCV10100,
+      // INTEL SSDSC2KB480GZ/7CV10100, INTEL SSDSC2KB076T8/XCV10132,
+      // SOLIDIGM SSDSC2KB960GZ/7CV10130
+    "(INTEL|SOLIDIGM) SSDSC(2K|KK)(B|G)(240G|480G|960G|019T|038T|076T)[78Z].?",
+    "", "",
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 170,raw48,Available_Reservd_Space "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 174,raw48,Unsafe_Shutdown_Count "
+    "-v 175,raw16(raw16),Power_Loss_Cap_Test "
+    "-v 183,raw48,SATA_Downshift_Count "
+    "-v 184,raw48,End-to-End_Error_Count "
+    "-v 187,raw48,Uncorrectable_Error_Cnt "
+    "-v 190,tempminmax,Drive_Temperature "
+    "-v 192,raw48,Unsafe_Shutdown_Count "
+    "-v 197,raw48,Pending_Sector_Count "
+    "-v 199,raw48,CRC_Error_Count "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Workld_Media_Wear_Indic " // Timed Workload Media Wear Indicator (percent*1024)
+    "-v 227,raw48,Workld_Host_Reads_Perc "  // Timed Workload Host Reads Percentage
+    "-v 228,raw48,Workload_Minutes " // 226,227,228 can be reset by 'smartctl -t vendor,0x40'
+  //"-v 232,raw48,Available_Reservd_Space "
+  //"-v 233,raw48,Media_Wearout_Indicator "
+    "-v 234,raw24/raw32:04321,Thermal_Throttle_Status "
+    "-v 235,raw16(raw16),Power_Loss_Cap_Test "
+    "-v 241,raw48,Host_Writes_32MiB "
+    "-v 242,raw48,Host_Reads_32MiB "
+    "-v 243,raw48,NAND_Writes_32MiB"
+  },
+  { "Dell Certified Intel S4x00/D3-S4x10 Series SSDs", // INTEL SSDSC2KB480G7R/SCV1DL58,
+      // INTEL SSDSC2KB960G7R/SCV1DL58, INTEL SSDSC2KB038T7R/SCV1DL58,
+      // INTEL SSDSC2KB038T7R/SCV1DL58, INTEL SSDSC2KG240G7R/SCV1DL58
+    "SSDSC(2K|KK)(B|G)(240G|480G|960G|019T|038T)(7R|8R).?",
+    "", "",
+    "-v 170,raw48,Available_Reservd_Space "
+    "-v 174,raw48,Unsafe_Shutdown_Count "
+    "-v 195,raw48,Uncorrectable_Error_Cnt "
+    "-v 199,raw48,CRC_Error_Count "
+    "-v 201,raw16(raw16),Power_Loss_Cap_Test "
+    "-v 202,raw48,End_of_Life "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Workld_Media_Wear_Indic " // Timed Workload Media Wear Indicator (percent*1024)
+    "-v 227,raw48,Workld_Host_Reads_Perc "  // Timed Workload Host Reads Percentage
+    "-v 228,raw48,Workload_Minutes " // 226,227,228 can be reset by 'smartctl -t vendor,0x40'
+    "-v 233,raw48,Total_LBAs_Written "
+    "-v 234,raw24/raw32:04321,Thermal_Throttle_Status "
+    "-v 245,raw48,Percent_Life_Remaining"
+  },
+  { "Kingston branded X25-V SSDs", // fixed firmware
+    "KINGSTON SSDNow 40GB",
+    "2CV102(J[89A-Z]|[K-Z].)", // >= "2CV102J8"
+    "",
+    "-v 192,raw48,Unsafe_Shutdown_Count "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Workld_Media_Wear_Indic "
+    "-v 227,raw48,Workld_Host_Reads_Perc "
+    "-v 228,raw48,Workload_Minutes"
+  },
+  { "Kingston branded X25-V SSDs", // buggy or unknown firmware
+    "KINGSTON SSDNow 40GB",
+    "",
+    "This drive may require a firmware update to\n"
+    "fix possible drive hangs when reading SMART self-test log.\n"
+    "To update Kingston branded drives, a modified Intel update\n"
+    "tool must be used. Search for \"kingston 40gb firmware\".",
+    "-v 192,raw48,Unsafe_Shutdown_Count "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 226,raw48,Workld_Media_Wear_Indic "
+    "-v 227,raw48,Workld_Host_Reads_Perc "
+    "-v 228,raw48,Workload_Minutes"
+  },
+  { "Kingston SSDNow UV400/500",
+    "KINGSTON SUV400S37A?(120|240|480|960)G|" // tested with KINGSTON SUV400S37120G/0C3J96R9,
+      // KINGSTON SUV400S37240G/0C3J96R9, KINGSTON SUV400S37240G/0C3K87RA,
+      // KINGSTON SUV400S37120G/0C3K87RA
+    "KINGSTON SUV500(M[8S])?(120|240|480|960)G", // tested with KINGSTON SUV500120G/003056R6,
+      // KINGSTON SUV500240G/003056R6, KINGSTON SUV500480G/003056RI,
+      // KINGSTON SUV500MS120G/003056RA, KINGSTON SUV500MS120G/003056RI,
+      // KINGSTON SUV500M8120G/003056RI
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 100,raw48,Unknown_Kingston_Attr "
+    "-v 101,raw48,Unknown_Kingston_Attr "
+    "-v 170,raw48,Reserved_Block_Count "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+  //"-v 175,raw48,Program_Fail_Count_Chip "
+  //"-v 176,raw48,Erase_Fail_Count_Chip "
+  //"-v 177,raw48,Wear_Leveling_Count "
+  //"-v 178,raw48,Used_Rsvd_Blk_Cnt_Chip "
+  //"-v 180,raw48,Unused_Rsvd_Blk_Cnt_Tot "
+  //"-v 183,raw48,Runtime_Bad_Block "
+  //"-v 187,raw48,Reported_Uncorrect "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 195,raw48,Hardware_ECC_Recovered "
+  //"-v 196,raw16(raw16),Reallocated_Event_Count "
+  //"-v 197,raw48,Current_Pending_Sector "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 201,raw48,Unc_Read_Error_Rate "
+  //"-v 204,raw48,Soft_ECC_Correction "
+    "-v 231,raw48,SSD_Life_Left "
+    "-v 241,raw48,Host_Writes_GiB "
+    "-v 242,raw48,Host_Reads_GiB "
+    "-v 250,raw48,Read_Retry_Count"
+  },
+  { "JMicron based SSDs", // JMicron JMF60x
+    "Kingston SSDNow V Series [0-9]*GB|" // tested with Kingston SSDNow V Series 64GB/B090522a
+    "TS(2|4|8|16|32|64|128|192)GSSD(18|25)[MS]?-[MS]", // Transcend IDE and SATA, tested with
+      // TS32GSSD25-M/V090331, TS32GSSD18M-M/v090331
+    "[BVv].*", // other Transcend SSD versions will be caught by subsequent entry
+    "",
+  //"-v 9,raw24(raw8),Power_On_Hours " // raw value always 0?
+  //"-v 12,raw48,Power_Cycle_Count "
+  //"-v 194,tempminmax,Temperature_Celsius " // raw value always 0?
+    "-v 229,hex64:w012345r,Halt_System/Flash_ID " // Halt, Flash[7]
+    "-v 232,hex64:w012345r,Firmware_Version_Info " // "YYMMDD", #Channels, #Banks
+    "-v 233,hex48:w01234,ECC_Fail_Record " // Fail number, Row[3], Channel, Bank
+    "-v 234,raw24/raw24:w01234,Avg/Max_Erase_Count "
+    "-v 235,raw24/raw24:w01z23,Good/Sys_Block_Count"
+  },
+  { "JMicron/Maxiotek based SSDs", // JMicron JMF61x, JMF66x, JMF670
+    "ADATA S596 Turbo|"  // tested with ADATA S596 Turbo 256GB SATA SSD (JMicron JMF616)
+    "ADATA SP310|"  // Premier Pro SP310 mSATA, JMF667, tested with ADATA SP310/3.04
+    "ADATA SP600(NS34)?|" // tested with ADATA SP600/2.4 (JMicron JMF661)
+    "ADATA SX930|"  // tested with ADATA SX930/6.8SE
+    "APPLE SSD TS(064|128|256|512)C|"  // Toshiba?, tested with APPLE SSD TS064C/CJAA0201
+    "IM2S3138E-(128|256)GM-B|" // ADATA OEM, tested with IM2S3138E-128GM-B/DA002
+    "KingSpec KDM-SA\\.51-008GMJ|" // tested with KingSpec KDM-SA.51-008GMJ/1.092.37 (JMF605?)
+    "KINGSTON SNV425S2(64|128)GB|"  // SSDNow V Series (2. Generation, JMF618),
+                                    // tested with KINGSTON SNV425S264GB/C091126a
+    "KINGSTON SSDNOW 30GB|" // tested with KINGSTON SSDNOW 30GB/AJXA0202
+    "KINGSTON SS100S2(8|16)G|"  // SSDNow S100 Series, tested with KINGSTON SS100S28G/D100309a
+    "KINGSTON SNVP325S2(64|128|256|512)GB|" // SSDNow V+ Series, tested with KINGSTON SNVP325S2128GB/AGYA0201
+    "KINGSTON SVP?100S2B?(64|96|128|256|512)G|"  // SSDNow V100/V+100 Series,
+      // tested with KINGSTON SVP100S296G/CJR10202, KINGSTON SV100S2256G/D110225a
+    "KINGSTON SV200S3(64|128|256)G|" // SSDNow V200 Series, tested with KINGSTON SV200S3128G/E120506a
+    "NT-(64|128|256|512|[12]T)|" // KingSpec NT, MAS0902A-B2C or CS1802A-B2C, tested with NT-512/T191212
+    "TOSHIBA THNS128GG4BBAA|"  // Toshiba / Super Talent UltraDrive DX,
+                               // tested with Toshiba 128GB 2.5" SSD (built in MacBooks)
+    "TOSHIBA THNSNC128GMLJ|" // tested with THNSNC128GMLJ/CJTA0202 (built in Toshiba Protege/Dynabook)
+    "TS(8|16|32|64|128|192|256|512)GSSD25S?-(MD?|S)|" // Transcend IDE and SATA, JMF612, tested with
+      // TS256GSSD25S-M/101028, TS32GSSD25-M/20101227
+    "TS(32|64|128|256)G(SSD|MSA)[37]40K?", // Transcend SSD340/340K/740 SATA/mSATA, JMF667/670, tested with
+      // TS256GSSD340/SVN263, TS256GSSD340/SVN423b, TS256GMSA340/SVN263,
+      // TS128GSSD340K/SVN216,TS64GSSD740/SVN167d
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 2,raw48,Throughput_Performance "
+    "-v 3,raw48,Unknown_JMF_Attribute "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+    "-v 7,raw48,Unknown_JMF_Attribute "
+    "-v 8,raw48,Unknown_JMF_Attribute "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+    "-v 10,raw48,Unknown_JMF_Attribute "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 167,raw48,Unknown_JMF_Attribute "
+    "-v 168,raw48,SATA_Phy_Error_Count "
+    "-v 169,raw48,Unknown_JMF_Attribute "
+    "-v 170,raw16,Bad_Block_Count "
+    "-v 173,raw16,Erase_Count " // JMF661: different?
+    "-v 175,raw48,Bad_Cluster_Table_Count "
+    "-v 180,raw48,Unknown_JMF_Attribute "
+    "-v 187,raw48,Unknown_JMF_Attribute "
+    "-v 192,raw48,Unexpect_Power_Loss_Ct "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 197,raw48,Current_Pending_Sector "
+    "-v 231,raw48,Unknown_JMF_Attribute "
+    "-v 233,raw48,Unknown_JMF_Attribute " // FW SVN423b
+    "-v 234,raw48,Unknown_JMF_Attribute " // FW SVN423b
+    "-v 240,raw48,Unknown_JMF_Attribute "
+  //"-v 241,raw48,Total_LBAs_Written "    // FW SVN423b
+  //"-v 242,raw48,Total_LBAs_Read "       // FW SVN423b
+  },
+  { "Plextor M3/M5/M6/M7 Series SSDs", // Marvell 88SS9174 (M3, M5S), 88SS9187 (M5P, M5Pro), 88SS9188 (M6M/S),
+      // tested with PLEXTOR PX-128M3/1.01, PX-128M3P/1.04, PX-256M3/1.05, PX-128M5S/1.02, PX-256M5S/1.03,
+      // PX-128M5M/1.05, PX-128M5S/1.05, PX-128M5Pro/1.05, PX-512M5Pro/1.06, PX-256M5P/1.01, PX-128M6S/1.03
+      // (1.04/5 Firmware self-test log lifetime unit is bogus, possibly 1/256 hours)
+      // PLEXTOR PX-256M6S+/1.00, PLEXTOR  PX-128M3/1.00, PLEXTOR PX-128M3/1.07, PLEXTOR PX-128M6V/1.04,
+      // PLEXTOR PX-128M6G-2242/1.01, PLEXTOR PX-512M7VC/1.05, PLEXTOR PX-512M8VC +/1.00
+    "PLEXTOR  ?PX-(64|128|256|512|768)M(3P?|5[MPS]|5Pro|6[GMSV]|[78]VC)(\\+|-.*| )?",
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 170,raw48,Unknown_Plextor_Attrib "  // M6S/1.03
+    "-v 171,raw48,Unknown_Plextor_Attrib "  // M6S/1.03
+    "-v 172,raw48,Unknown_Plextor_Attrib "  // M6S/1.03
+    "-v 173,raw48,Unknown_Plextor_Attrib "  // M6S/1.03
+    "-v 174,raw48,Unknown_Plextor_Attrib "  // M6S/1.03
+  //"-v 175,raw48,Program_Fail_Count_Chip " // M6S/1.03
+  //"-v 176,raw48,Erase_Fail_Count_Chip "   // M6S/1.03
+  //"-v 177,raw48,Wear_Leveling_Count "
+  //"-v 178,raw48,Used_Rsvd_Blk_Cnt_Chip "
+  //"-v 179,raw48,Used_Rsvd_Blk_Cnt_Tot "   // M6S/1.03
+  //"-v 180,raw48,Unused_Rsvd_Blk_Cnt_Tot " // M6S/1.03
+  //"-v 181,raw48,Program_Fail_Cnt_Total "
+  //"-v 182,raw48,Erase_Fail_Count_Total "
+  //"-v 183,raw48,Runtime_Bad_Block "       // M6S/1.03
+  //"-v 184,raw48,End-to-End_Error "        // M6S/1.03
+  //"-v 187,raw48,Reported_Uncorrect "
+  //"-v 188,raw48,Command_Timeout "         // M6S/1.03
+  //"-v 192,raw48,Power-Off_Retract_Count "
+  //"-v 195,raw48,Hardware_ECC_Recovered "  // MS6/1.03
+  //"-v 196,raw16(raw16),Reallocated_Event_Count "
+  //"-v 198,raw48,Offline_Uncorrectable "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+  //"-v 232,raw48,Available_Reservd_Space "
+  //"-v 233,raw48,Media_Wearout_Indicator " // MS6/1.03
+    "-v 241,raw48,Host_Writes_32MiB "
+    "-v 242,raw48,Host_Reads_32MiB"
+  },
+  { "Samsung based SSDs",
+    "SAMSUNG SSD PM800 .*GB|"  // SAMSUNG PM800 SSDs, tested with SAMSUNG SSD PM800 TH 64GB/VBM25D1Q
+    "SAMSUNG SSD PM810 .*GB|"  // SAMSUNG PM810 (470 series) SSDs, tested with
+      // SAMSUNG SSD PM810 2.5" 128GB/AXM06D1Q
+    "SAMSUNG SSD SM841N? (2\\.5\"? 7mm |mSATA )?(128|256|512)GB( SED)?|" // tested with
+      // SAMSUNG SSD SM841 2.5" 7mm 256GB/DXM02D0Q, SAMSUNG SSD SM841 mSATA 512GB/DXM44D0Q,
+      // SAMSUNG SSD SM841N 2.5 7mm 128GB/DXM03D0Q, SAMSUNG SSD SM841N mSATA 256GB SED/DXM45D6Q
+    "SAMSUNG SSD PM851 (mSATA |M\\.2 )?(2280 )?(128|256|512)GB|" // tested with SAMSUNG SSD PM851 mSATA 128GB,
+      // SAMSUNG SSD PM851 M.2 2280 256GB/EXT25D0Q
+    "SAMSUNG 470 Series SSD|"  // tested with SAMSUNG 470 Series SSD 64GB/AXM09B1Q
+    "Samsung SSD 750 EVO (120|250|500)GB|" // tested with Samsung SSD 750 EVO 250GB/MAT01B6Q
+    "SAMSUNG SSD 830 Series|"  // tested with SAMSUNG SSD 830 Series 64GB/CXM03B1Q
+    "SAMSUNG SSD PM830 .*|" // SAMSUNG SSD PM830 2.5" 7mm 128GB/CXM03D1Q
+    "MZ7PC(512|256|128|064)HA(GH|FU|DR)-000.*|" // probably PM830, tested with SAMSUNG MZ7PC128HAFU-000L1/CXM04L1Q
+    "Samsung SSD 840 (PRO )?Series|" // tested with Samsung SSD 840 PRO Series 128GB/DXM04B0Q,
+      // Samsung SSD 840 Series/DXT06B0Q
+    "Samsung SSD 8[4-7]0 EVO (mSATA |M\\.2 )?((120|250|500|750)G|[124]T)B|" // tested with
+      // Samsung SSD 840 EVO (120|250|500|750)GB/EXT0AB0Q,
+      // Samsung SSD 840 EVO (120|250)GB/EXT0BB6Q, 1TB/EXT0BB0Q, 120GB mSATA/EXT41B6Q,
+      // Samsung SSD 850 EVO 250GB/EMT01B6Q, Samsung SSD 850 EVO M.2 250GB/EMT21B6Q,
+      // Samsung SSD 850 EVO mSATA 120GB/EMT41B6Q, Samsung SSD 850 EVO 2TB/EMT02B6Q,
+      // Samsung SSD 860 EVO 250GB/RVT01B6Q, Samsung SSD 860 EVO mSATA 250GB/RVT41B6Q,
+      // Samsung SSD 860 EVO 500GB/RVT01B6Q, Samsung SSD 860 EVO mSATA 500GB/RVT41B6Q,
+      // Samsung SSD 860 EVO mSATA 1TB/RVT41B6Q, Samsung SSD 860 EVO 2TB/RVT01B6Q,
+      // Samsung SSD 860 EVO 4TB/RVT04B6Q, Samsung SSD 870 EVO 1TB/SVT01B6Q,
+      // Samsung SSD 870 EVO 4TB/SVT02B6Q
+    "Samsung SSD 8[56]0 PRO ((128|256|512)G|[124]T)B|" // tested with Samsung SSD 850 PRO 128GB/EXM01B6Q,
+      // Samsung SSD 850 PRO 1TB/EXM01B6Q, Samsung SSD 850 PRO 2TB/EXM02B6Q,
+      // Samsung SSD 860 PRO 256GB/RVM01B6Q, Samsung SSD 860 PRO 512GB/RVM01B6Q,
+      // Samsung SSD 860 PRO 1TB/RVM01B6Q
+    "Samsung SSD 8[67]0 QVO [1248]TB|" // tested with Samsung SSD 860 QVO 1TB/RVQ02B6Q,
+      // Samsung SSD 860 QVO 2TB/RVQ01B6Q, Samsung SSD 870 QVO 4TB/SVQ01B6Q
+    "Samsung SSD 883 DCT ((240|480|960)G|(1\\.92|3\\.84)T)B|" // tested with
+      // Samsung SSD 883 DCT 480GB/HXT7404Q, Samsung SSD 883 DCT 3.84TB/HXT7404Q
+    "Samsung SSD 845DC EVO .*|" // Samsung SSD 845DC EVO 960GB/EXT03X3Q
+    "SAMSUNG MZ7PA256HMDR-.*|" // PM810 (470 Series), tested with SAMSUNG MZ7PA256HMDR-010H1/AXM07H1Q
+    "SAMSUNG MZ[7M]PC(032|064|128|256|512)HBCD-.*|" // PM830, tested with SAMSUNG MZMPC032HBCD-000L1/CXM12L1Q
+    "SAMSUNG MZ7TD(128|256)HAFV-.*|" // 840 Series, tested with SAMSUNG MZ7TD256HAFV-000L7/DXT06L6Q
+    "SAMSUNG MZ[7M]TD(128|256|512)HA[GF][LMV]-.*|" // PM841, tested with SAMSUNG MZMTD512HAGL-00000/DXT4200Q,
+      // SAMSUNG MZ7TD512HAGM-000L1/DXT06L0Q, SAMSUNG MZMTD128HAFV-000L1/DXT43L0Q
+    "SAMSUNG MZ7WD((120|240)H[AC]FV|480H[AC]GM|960H[AC]GP)-.*|" // SM843T(N?) Series, tested with
+      // SAMSUNG MZ7WD120HAFV-00003/DXM85W3Q, SAMSUNG MZ7WD120HCFV-00003/DXM9203Q,
+      // SAMSUNG MZ7WD960HCGP-000PU/DXM9BW4Q (SM843TN?)
+    "SAMSUNG MZ[7N]TE(128|256|512)HM(HP|JH)-.*|" // PM851, tested with SAMSUNG MZ7TE256HMHP-000L7/EXT09L6Q,
+      // SAMSUNG MZNTE256HMHP-000H1/EXT22H0Q, SAMSUNG MZNTE512HMJH-000L2/EXT26L0Q
+    "SAMSUNG MZMPF(032|064)HCFV-.*|" // CM851 mSATA, tested with SAMSUNG MZMPF032HCFV-000H1/FXM42H2Q
+    "SAMSUNG MZ7GE(240HMGR|(480|960)HMHP)-00003|" // SM853T Series, tested with
+      // SAMSUNG MZ7GE240HMGR-00003/EXT0303Q
+    "SAMSUNG MZ7LM(120|240|480|960|1T9|3T8)HC(JM|HP|GR|FD)-.*|" // PM863 Series, tested with
+      // SAMSUNG MZ7LM960HCHP-0E003/GXT3003Q
+    "(SAMSUNG )?MZ7LM(240|480|960|1T9|3T8)HM(JP|HQ|LP)(-.*|0D3)|" // PM863a Series, tested with
+      // SAMSUNG MZ7LM3T8HMLP-00005/GXT5104Q, MZ7LM240HMHQ0D3/GC5B (Dell)
+    "(SAMSUNG )?MZ7KM(120|240|480|960|1T9)H[AM](FD|GR|H[PQ]|J[MP])(-.*|0D3)|" // SM863(a), tested with
+      // SAMSUNG MZ7KM480HAHP-0E005/GXM1003Q, SAMSUNG MZ7KM480HMHQ-00005/GXM5104Q,
+      // SAMSUNG MZ7KM960HMJP-00005/GXM5304Q, MZ7KM960HMJP0D3/GD53 (Dell)
+    "SAMSUNG MZ[7N]LH(128|256|512|1T0)H[AB](JD|HQ|L[BU])-.*|" // PM881, tested with
+      // SAMSUNG MZ7LH512HALU-00000/RVT0200Q
+    "SAMSUNG MZ7LH(240|480|960|1T9|3T8|7T6)H[AM](HQ|JR|LT|LA)-.*|" //PM883, tested with SAMSUNG MZ7LH960HAJR-00005
+    "SAMSUNG MZ7L3(240|480|960|1T9|3T8|7T6)H(B[LN][AT]|CHQ|CJR)-.*|" // PM893/897, tested with
+      // SAMSUNG MZ7L3240HCHQ-00A07/JXTC104Q, SAMSUNG MZ7L3480HCHQ-00A07/JXTC104Q,
+      // SAMSUNG MZ7L3480HBLT-00A07/JXTE004Q, SAMSUNG MZ7L33T8HBLT-00A07/JXTC104Q
+    "MK000(240|480|960)GZXR[AB]|" // MK000960GZXRB/HPG0 (HPE MZ7L3960HBLT-00AH3)
+      // MK000480GZXRA/HPG0 (HPE P18432-B21)
+    "SAMSUNG MZ7KH(240|480|960|1T9|3T8)HA(HQ|JR|LS)-.*|" //SM883
+    "SAMSUNG MZ[7N](LF|TY)(128|192|256)H[CD](GS|HP)-.*|" // CM871/871a, tested with SAMSUNG MZNLF128HCHP-000H1/FXT21H1Q,
+      // SAMSUNG MZNTY256HDHP-000/MAT21K0Q, SAMSUNG MZ7LF192HCGS-000L1/FXT03L1Q
+    "SAMSUNG MZ[7NY]LN(128|256|512|1T0)H[ACM](GR|HP|HQ|J[HPQ]|LR)-.*|" // PM871/871a/b, tested with
+      // SAMSUNG MZ7LN128HCHP-00000/EMT0100Q, SAMSUNG MZ7LN256HAHQ-000H1/MVT03H6Q,
+      // SAMSUNG MZNLN256HMHQ-000H1/MAV21H3Q, SAMSUNG MZYLN256HCHP-000L2/EMT63L0Q
+    "SAMSUNG SSD PM871 .*|" // SAMSUNG SSD PM871 2.5 7mm 256GB/EMT02D0Q
+      // SAMSUNG MZ7LN256HMJP-00000/MAV0100Q, SAMSUNG MZ7LN512HMJP-00000/MAV0100Q
+    "SAMSUNG MZHPV(128|256|512)HDG(L|M)-.*|" // SM951, tested with SAMSUNG MZHPV512HDGL-00000/BXW2500Q,
+      // SAMSUNG MZHPV128HDGM-00000 (BXW2500Q)
+    "Samsung Portable SSD T5", // tested with Samsung Portable SSD T5 (0x04e8:0x61f5)
+    "", "",
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 170,raw48,Unused_Rsvd_Blk_Ct_Chip " // CM871
+    "-v 171,raw48,Program_Fail_Count_Chip " // CM871
+    "-v 172,raw48,Erase_Fail_Count_Chip " // CM871
+    "-v 173,raw48,Wear_Leveling_Count " // CM871
+    "-v 174,raw48,Unexpect_Power_Loss_Ct " // CM871
+  //"-v 175,raw48,Program_Fail_Count_Chip "
+  //"-v 176,raw48,Erase_Fail_Count_Chip "
+  //"-v 177,raw48,Wear_Leveling_Count "
+  //"-v 178,raw48,Used_Rsvd_Blk_Cnt_Chip "
+  //"-v 179,raw48,Used_Rsvd_Blk_Cnt_Tot "
+  //"-v 180,raw48,Unused_Rsvd_Blk_Cnt_Tot "
+  //"-v 181,raw48,Program_Fail_Cnt_Total "
+  //"-v 182,raw48,Erase_Fail_Count_Total "
+  //"-v 183,raw48,Runtime_Bad_Block "
+  //"-v 184,raw48,End-to-End_Error " // SM843T Series
+    "-v 187,raw48,Uncorrectable_Error_Cnt "
+  //"-v 190,tempminmax,Airflow_Temperature_Cel "  // seems to be some sort of temperature value for 470 Series?
+    "-v 191,raw48,Unknown_Samsung_Attr " // PM810
+  //"-v 194,tempminmax,Temperature_Celsius "
+    "-v 195,raw48,ECC_Error_Rate "
+  //"-v 196,raw16(raw16),Reallocated_Event_Count "
+  //"-v 197,raw48,Current_Pending_Sector " // PM893
+  //"-v 198,raw48,Offline_Uncorrectable "
+    "-v 199,raw48,CRC_Error_Count "
+    "-v 201,raw48,Supercap_Status "
+    "-v 202,raw48,Exception_Mode_Status " // PM893
+  //"-v 233,raw48,Media_Wearout_Indicator " // PM851, 840
+    "-v 234,raw48,Unknown_Samsung_Attr " // PM851, 840
+    "-v 235,raw48,POR_Recovery_Count " // PM851, 830/840/850, PM893
+    "-v 236,raw48,Unknown_Samsung_Attr " // PM851, 840
+    "-v 237,raw48,Unknown_Samsung_Attr " // PM851, 840
+    "-v 238,raw48,Unknown_Samsung_Attr " // PM851, 840
+  //"-v 241,raw48,Total_LBAs_Written "
+  //"-v 242,raw48,Total_LBAs_Read " // PM851, SM841N
+    "-v 243,raw48,SATA_Downshift_Ct " // PM863, PM893
+    "-v 244,raw48,Thermal_Throttle_St " // PM863, PM893
+    "-v 245,raw48,Timed_Workld_Media_Wear " // PM863, PM893
+    "-v 246,raw48,Timed_Workld_RdWr_Ratio " // PM863, PM893
+    "-v 247,raw48,Timed_Workld_Timer " // PM863, PM893
+    "-v 249,raw48,NAND_Writes_1GiB " // CM871a, PM871
+    "-v 250,raw48,SATA_Iface_Downshift " // from the spec
+    "-v 251,raw48,NAND_Writes " // PM863, PM893
+    "-v 252,raw48,Added_Bad_Flash_Blk_Ct" // 870 EVO FW SVT02B6Q
+  },
+  { "Marvell based SanDisk SSDs",
+    "SanDisk SD5SG2[0-9]*G1052E|" // X100 (88SS9174), tested with SanDisk SD5SG2256G1052E/10.04.01
+    "SanDisk SD6S[BFP][12]M[0-9]*G(1022I?|1102)?|" // X110/X210 (88SS9175/187?), tested with SanDisk SD6SB1M064G1022I/X231600,
+      // SanDisk SD6SB1M256G1022I/X231600, SanDisk SD6SF1M128G1022/X231200, SanDisk SD6SB2M512G1022I/X210400
+      // SanDisk SD6SP1M128G1102/X231302
+    "SanDisk SD7S[BN][67]S-?(128|256|512|960)G(1122|-1006)?|" // X300 (88SS9189?), tested with
+      // SanDisk SD7SB6S128G1122/X3310000, SanDisk SD7SN6S-512G-1006/X3511006, SanDisk SD7SB7S960G/X36310DC
+    "SanDisk SD8[ST][BN]8U-?((128|256|512)G|1T00)(1122|-10[01]6)|" // X400 (88SS1074), tested with SanDisk SD8SB8U128G1122/X4120000
+      // SanDisk SD8TB8U-512G-1016/X4163116
+    "SanDisk SD9S[BN]8W-?((128|256|512)G|[12]T00)(1122|-1006|1020)|" // X600, tested with SanDisk SD9SB8W128G1122/X6107000, SD9SB8W-512G-1006/X6103006
+      // SanDisk SD9SB8W1T001122/X6107000, SD9SB8W256G1122/X6107000, SanDisk SD9SN8W128G1020/X6101020
+    "SanDisk SDSSDA-((120|240|480)G|[12]T00)|" // Plus, tested with SanDisk SDSSDA-2T00/411040RL
+    "SanDisk SDSSDHP[0-9]*G|" // Ultra Plus (88SS9175), tested with SanDisk SDSSDHP128G/X23[01]6RL
+    "SanDisk (SDSSDHII|Ultra II )[0-9]*GB?|" // Ultra II (88SS9190/88SS9189), tested with
+      // SanDisk SDSSDHII120G/X31200RL, SanDisk Ultra II 960GB/X41100RL
+    "SanDisk SDSSDH2(128|256)G|" // SanDisk SDSSDH2128G/X211200
+    "SanDisk SDSSDH3 ?((250|500|512|1000|1024|2000)G|[124]T00)|" // Ultra 3D, tested with SanDisk SDSSDH3250G/X61170RL,
+      // SanDisk SDSSDH3 250G/401120RL, SanDisk SDSSDH3500G/X61110RL, SanDisk SDSSDH3 512G/40101000,
+      // SanDisk SDSSDH31024G/X6107000, SanDisk SDSSDH3 1T00/415020RL, SanDisk SDSSDH3 2T00/411040RL,
+      // SanDisk SDSSDH3 4T00/411040RL
+    "SanDisk SDSSDXPS?[0-9]*G|" // Extreme II/Pro (88SS9187), tested with SanDisk SDSSDXP480G/R1311,
+      // SanDisk SDSSDXPS480G/X21200RL
+    "SanDisk SSD G5 BICS4|" // WD Blue SSD WDS100T2B0A (#1378), tested with SanDisk SSD G5 BICS4/415000WD
+    "SanDisk SSD PLUS (120|240|480|[12]000) ?GB|" // Plus (88SS1074), tested with SanDisk SSD PLUS 120 GB/UE3000RL,
+      // SanDisk SSD PLUS 120 GB/UE4500RL, SanDisk SSD PLUS 1000GB/UH4400RL
+      // SanDisk SSD PLUS 2000GB/UP4504RL
+    "SSD SATAIII 16GB", // SSD SATAIII 16GB/i221100 (see #923)
+    "", "",
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 165,raw48,Total_Write/Erase_Count "
+    "-v 166,raw48,Min_W/E_Cycle "
+    "-v 167,raw48,Min_Bad_Block/Die "
+    "-v 168,raw48,Maximum_Erase_Cycle "
+    "-v 169,raw48,Total_Bad_Block "
+    "-v 170,raw48,Unknown_Marvell_Attr " // SDSSDH3 4T00
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 173,raw48,Avg_Write/Erase_Count "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+  //"-v 184,raw48,End-to-End_Error "
+  //"-v 187,raw48,Reported_Uncorrect "
+  //"-v 188,raw48,Command_Timeout "
+  //"-v 194,tempminmax,Temperature_Celsius "
+    "-v 199,raw48,SATA_CRC_Error "
+    "-v 201,raw48,Lifetime_Remaining% "
+    "-v 212,raw48,SATA_PHY_Error "
+    "-v 230,raw16,Perc_Write/Erase_Count "
+    "-v 232,raw48,Perc_Avail_Resrvd_Space "
+    "-v 233,raw48,Total_NAND_Writes_GiB "
+    "-v 234,raw48,Perc_Write/Erase_Ct_BC "
+    "-v 241,raw48,Total_Writes_GiB "
+    "-v 242,raw48,Total_Reads_GiB "
+    "-v 243,raw48,Unknown_Marvell_Attr "
+    "-v 244,raw48,Thermal_Throttle "
+    "-v 249,raw48,TLC_NAND_GB_Writes"
+  },
+  { "SanDisk based SSDs", // see also #463 for the vendor attribute description
+    "SanDisk iSSD P4 [0-9]*GB|" // tested with SanDisk iSSD P4 16GB/SSD 9.14
+    "SanDisk pSSD|" // tested with SandDisk pSSD/3 (62.7 GB, SanDisk Extreme USB3.0 SDCZ80-064G-J57, 0x0781:0x5580)
+    "SanDisk SDSSDP[0-9]*G|" // tested with SanDisk SDSSDP064G/1.0.0, SDSSDP128G/2.0.0
+    "SanDisk SDSSDRC032G|" // tested with SanDisk SanDisk SDSSDRC032G/3.1.0
+    "SanDisk SSD i100 [0-9]*GB|" // tested with SanDisk SSD i100 8GB/11.56.04, 24GB/11.56.04
+    "SanDisk SSD U100 ([0-9]*GB|SMG2)|" // tested with SanDisk SSD U100 8GB/10.56.00, 256GB/10.01.02, SMG2/10.56.04
+    "SanDisk SSD U110 (8|16|24|32|64|128)GB|" // tested with SanDisk SSD U110 32GB/U221000
+    "SanDisk SDSA6[DGM]M-[0-9]*G-.*|" // tested with SanDisk SDSA6GM-016G-1006/U221006, SanDisk SDSA6MM-016G-1006/U221006,
+      // SanDisk SDSA6GM-016G-1006/U221006
+    "SanDisk SD7[SU]B[23]Q(064|128|256|512)G.*", // tested with SD7SB3Q064G1122/SD7UB3Q256G1122/SD7SB3Q128G/SD7UB2Q512G1122
+    "", "",
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 165,raw48,Total_Write/Erase_Count "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 173,raw48,Avg_Write/Erase_Count "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+  //"-v 187,raw48,Reported_Uncorrect "
+    "-v 212,raw48,SATA_PHY_Error "
+    "-v 230,raw48,Perc_Write/Erase_Count "
+    "-v 232,raw48,Perc_Avail_Resrvd_Space "
+    "-v 234,raw48,Perc_Write/Erase_Ct_BC "
+  //"-v 241,raw48,Total_LBAs_Written "
+  //"-v 242,raw48,Total_LBAs_Read "
+    "-v 244,raw48,Thermal_Throttle "
+  },
+  // SDLF1DAR-480G-1HAW/ZR07RE41
+  // SDLF1DAR-480G-1JA1/RP41ZH06
+  { "Sandisk SATA Cloudspeed Max and GEN2 ESS SSDs",
+    "SD[A-Z0-9]{2}[1-3][A-Z]{3}-?[0-9]{3}[GT]-?1[A-Z0-9]{3}",
+    "","",
+    "-v 13,raw48,Lifetime_UECC_Ct "
+    "-v 32,raw48,Lifetime_Write_AmpFctr "
+    "-v 33,raw48,Write_AmpFctr "
+    "-v 170,raw48,Reserve_Erase_BlkCt "
+    "-v 171,raw48,Program_Fail_Ct "
+    "-v 172,raw48,Erase_Fail_Ct "
+    "-v 173,raw48,Percent_Life_Used "
+    "-v 174,raw48,Unexpect_Power_Loss "
+    "-v 175,raw48,Lifetime_Die_Failure_Ct "
+    "-v 177,raw48,Lifetime_Remaining% "
+    "-v 178,raw48,SSD_LifeLeft(0.01%) "
+    "-v 180,raw48,Undetected_Data_Err_Ct "
+    "-v 183,raw48,LT_Link_Rate_DwnGrd_Ct "
+    "-v 191,raw48,Clean_Shutdown_Ct "
+    "-v 192,raw48,Unclean_Shutdown_Ct "
+    "-v 196,raw48,Lifetime_Retried_Blk_Ct "
+    "-v 204,raw48,Average_Block-Erase_Ct "
+    "-v 205,raw48,Read_Retry_Enable_Ct "
+    "-v 206,raw48,Successful_RaidRecov_Ct "
+    "-v 207,raw48,Trimmed_Sector_Ct "
+    "-v 211,raw48,Read_Disturb_ReallocEvt "
+    "-v 233,raw48,Lifetime_Nand_Writes "
+    "-v 235,raw48,Capacitor_Health "
+    "-v 244,raw48,Therm_Throt_Activation "
+    "-v 245,raw48,Drive_Life_Remaining% "
+    "-v 253,raw48,SPI_Test_Remaining "
+  },
+  { "Sandisk SATA CS1K GEN1 ESS SSDs",
+    "SD[A-Z0-9]{2}[NO][A-Z0-9]{3}-?[0-9]{3}[GT]-?1[A-Z0-9]{3}",
+    "","",
+    "-v 1,raw48,UECC_Ct "
+    "-v 2,raw48,Internal_File_Check "
+    "-v 5,raw16(raw16),Retried_Blk_Ct "
+    "-v 32,raw48,Write_Ampflication "
+    "-v 170,raw48,Reserve_Blk_Remaining "
+    "-v 171,raw48,Program_Fail_Ct "
+    "-v 172,raw48,Erase_Fail_Ct "
+    "-v 173,raw48,Drive_Life_Used% "
+    "-v 174,raw48,Unexpect_PwrLoss_Ct "
+    "-v 175,raw48,PwrLoss_ProtectionFail "
+    "-v 177,raw48,DriveLife_Remaining% "
+    "-v 178,raw48,SSD_Life_Left "
+    "-v 180,raw48,End_to_End_Err_Detect "
+    "-v 190,raw48,Drive_Temp_Warning "
+    "-v 195,raw48,Uncorrectable_Err_Ct "
+    "-v 202,raw48,Exception_Mode_Status "
+    "-v 233,raw48,Number_Of_Write_Ct "
+    "-v 245,raw48,DriveLife_Used% "
+  },
+  { "Silicon Motion based SSDs",
+    "ADATA_IMSS332-((008|016|032|064|128|256|512)G|001T)[AEMT]P?|" // tested with ADATA_IMSS332-128GTP/Q0810B
+    "ADATA (SP550|SU(630|650(NS38)?|655|[89]00))|" // tested with ADATA SP550/O0803B5a, ADATA SU630/S1127B0,
+      // ADATA SU650/S0212B0, ADATA SU650/V8X01c45, ADATA SU650/V8X21c64, ADATA SU650NS38/P191202a,
+      // ADATA SU655/V8X01c55, ADATA SU800/Q0913A, ADATA SU800/R0427A, ADATA SU800/R0918B, ADATA SU900/Q0125A,
+      // ADATA SU900/Q0710B
+    "AMD R5SL512G|"// tested with AMD R5SL512G/V0929A0
+    "CORSAIR FORCE LX SSD|" // tested with CORSAIR FORCE LX SSD/N0307A
+    "CHN mSATAM3 (128|256|512)|" // Zheino M3, tested with CHN mSATAM3 128/Q1124A0
+    "CIS 2S M305 (16|32|64|128|256)GB|" // Ceroz M305, tested with CIS 2S M305 64GB/P0316B
+    "CT(120|250|500|1000)BX100SSD1|" // Crucial BX100, tested with CT250BX100SSD1/MU02,
+      // CT500BX100SSD1/MU02, CT1000BX100SSD1/MU02
+    "CT(240|480|960)BX200SSD1|" // Crucial BX200 Solid State Drive, tested with CT480BX200SSD1/MU02.6
+    "DREVO X1 SSD|" // tested with DREVO X1 SSD/Q0111A
+    "Drevo X1 pro (64|128|256)G|" // tested with Drevo X1 pro 64G/Q0303B
+    "DEXP SSD C100 (128|256|512)Gb|" // tested with DEXP SSD C100 256Gb/V0218A0
+    "JAJS[56]00M((12[08]|240|256|480|512|960)C|1TB)(-1)?|" // J&A LEVEN JS500/600 (Intenso TOP), tested with
+      // JAJS500M120C-1/P0614D, JAJS600M1TB/T0529A0, JAJS600M256C/U0803A0
+    "KingDian S100 (32|64)GB|" // SM2244LT, tested with KingDian S100 32GB/0311A
+    "KingDian S(200|280|400) ((60|120|240|480)GB|1TB)|" // SM2256EN, tested with KingDian S200 60GB/R0724A0
+      // KingDian S280 120GB/Q0526A, KingDian S280 1TB/S0509A0, KingDian S400 120GB/Q0607A
+    "KingSpec KSD-[PS]A25\\.[1-9]-(016|032|064|128)(MS|SJ)|" // tested with KingSpec KSD-PA25.6-064MS/20140803
+    "KINGSTON SKC600(MS)?(256|512|1024|2048)G|" // KC600 MS=mSATA, tested with KINGSTON SKC600256G/S4500105,
+      // KINGSTON SKC600MS256G/S4500107
+    "LITEON L[CM]H-(128|256|512)V2[MS](-.*)?|" // tested with LITEON LCH-256V2S-HP/2C02,
+      // LITEON LCH-256V2S/3C87901, LITEON LMH-256V2M-11 MSATA 256GB/FM8110C
+    "MKNSSDRE((25[06]|500|512)G|[12]T)B(-LT)?|" // Mushkin, tested with MKNSSDRE256GB/N1007C,
+      // MKNSSDRE250GB-LT/O1026A
+    "MKNSSD(S2|TR)(12[08]|2[45]0|480|500)GB(-(3DL|LT))?|" // Mushkin, tested with MKNSSDS2500GB/T0818A0,
+      // MKNSSDTR500GB/O1126A, MKNSSDTR128GB-3DL/Q0616B0
+    "NFN025SA31T-.*|" // Neo Forza (?), from HP Laptop, tested with NFN025SA31T-6000000/S0628A0
+    "NFORCE (256|512)25 - SSZS13|" // Nextron NForce, tested with NFORCE 25625 - SSZS13/V0915A0
+    "ONDA S-12 64GB|" // tested with ONDA S-12 64GB/U0401A0
+    "OWC Envoy Pro|" // tested with OWC Envoy Pro/R0522A0 (0x1e91:0xa2a5)
+    "Patriot P2[01]0 ((128|256|512)GB|[12]TB)|" // tested with Patriot P200 256GB/S1022A0,
+      // Patriot P210 256GB/HPS2227P
+    "R3SL(120|240|480|960)G|" // AMD Radeon SSDs, tested with R3SL240G/P0422C
+    "Ramsta SSD S800 (120|240|480)GB|" // SM2258G, tested with Ramsta SSD S800 480GB/RS81V0
+    "SED2QII-LP SATA SSD ((64|128|256|512)GB|[12]TB)|" // ACPI SED2QII-LP, tested with
+      // SED2QII-LP SATA SSD 64GB/S0410A
+    "T60|" // KingSpec T60, tested with T60/20151120
+    "TCSUNBOW [MX]3 (60|120|240|480)GB|" // TC-Sunbow M3/X3, tested with TCSUNBOW M3 240GB/R0327B0,
+      // TCSUNBOW X3 120GB/R1211A0, TCSUNBOW X3 480GB/S0509A0
+    "TEAM( T253(TD|X6)|L5Lite3D)((120|240|256|480|512)G|[12]T)|" // TEAMGROUP, tested with
+      // TEAML5Lite3D240G/R0302A0 (L5Lite 3D), TEAM T253TD480G/Q0410A, TEAM T253X6256G/U1014A0 (CX2)
+    "TS((16|32|64|128|256|512)G|1T)(SSD|MS[AM])(230S?|3[67]0[SI]?|420[IK]?)|" // Transcend SSD230/360/370/420
+      // SATA/mSATA, TS6500, tested with TS128GMSA230S/02J0S86A, TS32GMSA370/20140402,
+      // mSATA MSM360 mini SSD, tested with TS32GMSM360/Q0407A
+      // TS128GMSA370I/P1225CH1
+      // TS16GMSA370/20140516, TS64GSSD370/20140516, TS256GSSD370/N0815B, TS256GSSD370S/N1114H,
+      // TS512GSSD370S/N1114H, TS32GSSD420I/N1114H, TS32GSSD420K/P1225CE
+    "TS(16|32|64|128|512|256)GMTS4[03]0S?|" // TS256GMTS400, TS256GMTS430S/S0423A
+    "TS(120|240)GMTS420S?|" // Transcend MTS420, tested with TS120GMTS420S/R0510A0
+    "TS(128G|256G|512G|1T|2T|4T)SSD230S|" // TS128GSSD230S/P1025F8, TS2TSSD230S/22Z4W14J
+    "TS(120|240|480|960)GSSD220S|" // TS480GSSD220S/P0520AA
+    "TS((64|128|256|512)G|[12]T)SSD452K|"// Transcend 452K, tested with TS128GSSD452K/02J0S86A
+    "TS(16G|32G|64G|128G|256G|512G|1T)MTS800S?|" // MTS800, tested with TS1TMTS800/O1225H1
+    "TS(16|32|64)GMSA630|" // MSA630 mSATA SSD, tested with TS32GMSA630/N0113E1
+    "TS(32|64|128)GPSD330|" // Transcend PSD SSD, tested with TS64GPSD330/20140121
+    "TS(16|32|64|96|128|256)GSSD(630|360S)|" // Transcend 630/360S, tested with TS16GSSD630/N0113E1,
+      // TS256GSSD360S/R0123A0
+    "TS(128G|256G|512G|1T)ESD400K|" // Transcend ESD400 Portable, tested with
+      // TS256GESD400K/R0605AS (0x2174:0x2000)
+    "TS(128G|256G|512G|1T)MTS830S|" // Transcend 830S, tested with TS256GMTS830S/02J0T3HB
+    "TSG(16|32|64|128|256|512)MTS400ISI|" // Transcend MTS400I, tested with TSG64MTS400ISI/S0903D
+    "UMAX 2242 (128|256|512)GB", // tested with UMAX 2242 256GB/U0330A0
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 2,raw48,Throughput_Performance "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 148,raw48,Total_SLC_Erase_Ct "
+    "-v 149,raw48,Max_SLC_Erase_Ct "
+    "-v 150,raw48,Min_SLC_Erase_Ct "
+    "-v 151,raw48,Average_SLC_Erase_Ct "
+    "-v 159,raw48,DRAM_1_Bit_Error_Count " // KINGSTON SKC600256G/S4500105
+    "-v 160,raw48,Uncorrectable_Error_Cnt "
+    "-v 161,raw48,Valid_Spare_Block_Cnt "
+    "-v 162,raw48,Cache_Block_Count " // Transcend MSM360 
+    "-v 163,raw48,Initial_Bad_Block_Count "
+    "-v 164,raw48,Total_Erase_Count "
+    "-v 165,raw48,Max_Erase_Count "
+    "-v 166,raw48,Min_Erase_Count "
+    "-v 167,raw48,Average_Erase_Count "
+    "-v 168,raw48,Max_Erase_Count_of_Spec "
+    "-v 169,raw48,Remaining_Lifetime_Perc "
+  //"-v 175,raw48,Program_Fail_Count_Chip "
+  //"-v 176,raw48,Erase_Fail_Count_Chip "
+  //"-v 177,raw48,Wear_Leveling_Count "
+    "-v 178,raw48,Runtime_Invalid_Blk_Cnt "
+  //"-v 181,raw48,Program_Fail_Cnt_Total "
+  //"-v 182,raw48,Erase_Fail_Count_Total "
+  //"-v 187,raw48,Reported_Uncorrect "
+  //"-v 192,raw48,Power-Off_Retract_Count "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 195,raw48,Hardware_ECC_Recovered "
+  //"-v 196,raw16(raw16),Reallocated_Event_Count "
+  //"-v 197,raw48,Current_Pending_Sector "
+  //"-v 198,raw48,Offline_Uncorrectable "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 225,raw48,Host_Writes_32MiB " // FW 20140402
+    "-v 231,raw48,SSD_Life_Left " // KINGSTON SKC600256G/S4500105
+  //"-v 232,raw48,Available_Reservd_Space "
+    "-v 241,raw48,Host_Writes_32MiB "
+    "-v 242,raw48,Host_Reads_32MiB "
+    "-v 245,raw48,TLC_Writes_32MiB " // FW N0815B, N1114H // TS128GMSA370I: Flash Write Sector Count
+    "-v 246,raw48,SLC_Writes_32MiB "
+    "-v 247,raw48,Raid_Recoverty_Ct "
+    "-v 248,raw48,Unkn_SiliconMotion_Attr " // ADATA SU900/Q0125A
+    "-v 249,raw48,Unkn_SiliconMotion_Attr " // ADATA SU650/V8X01c45
+  //"-v 250,raw48,Read_Error_Retry_Rate " // ADATA SU800/Q0913A
+    "-v 251,raw48,Unkn_SiliconMotion_Attr" // ADATA SU800/Q0913A
+  },
+  // Supermicro SSD-DM032-SMCMVN1, tested with SuperMicro SSD/SOB20R, see (#1380)
+  { "Supermicro SATA DOM (SuperDOM)",
+    "SuperMicro SSD",
+    "", "",
+    "-v 1,raw48,Raw_Read_Error_Rate "
+    "-v 15,raw48,User_Cpcty_Sector_Cnt "
+    "-v 160,raw48,Not_In_Use "
+    "-v 161,raw48,Not_In_Use "
+    "-v 163,raw48,Not_In_Use "
+    "-v 164,raw48,Not_In_Use "
+    "-v 165,raw48,Not_In_Use "
+    "-v 166,raw48,Minimum_PE_Cycles_TLC "
+    "-v 167,raw48,Not_In_Use "
+    "-v 168,raw48,Maximum_PE_Cycles_TLC "
+    "-v 231,raw48,SSD_Life_Left "
+    "-v 233,raw48,NAND_Writes_1GiB "
+    "-v 241,raw48,Lifetime_Writes_GiB "
+    "-v 242,raw48,Lifetime_Reads_GiB "
+  },
+  { "Silicon Motion based OEM SSDs", // Like 'Silicon Motion based SSDs' but with FW detection
+    "240GB|" // from Lenovo T430 Thinkpad, tested with 240GB/P0510E
+    "Dogfish SSD (128|256|512)GB|" // tested with Dogfish SSD 128GB/S1211A0
+    "GIM(16|32|64|128|256|512)|"// GUDGA GIM, tested with GIM128/U0401A0
+    "INTENSO( SSD)?|" // tested with INTENSO/S1211A0 (Portable SSD 256GB premium edition),
+      // INTENSO/V0609A0, INTENSO SSD/V0823A0, INTENSO/V0718B0, INTENSO SSD/W0413A0, INTENSO SSD/W0714A0,
+    "Intenso  ?SSD( S(ata|ATA) ?III)?|" // tested with Intenso SSD/Q1107A0, Intenso  SSD Sata III/P0510E,
+      // Intenso SSD Sata III/R0817B0, Intenso SSD Sata III/S0222A0, Intenso SSD Sata III/V0303B0,
+      // Intenso SSD SATAIII/W0825A0,
+    "KingFast|" // tested with KingFast/P0725A (F6M), KingFast/S0424A0 (120GB), KingFast/S1128B0 (512GB)
+    "KSM512|" // KingSpec, tested with KSM512/S0509A0
+    "LDLC|" // tested with LDLC/KFS03005
+    "Netac MobileDataStar|" // tested with Netac MobileDataStar/HPS2227I (0x0dd8:0x0562)
+    "ORTIAL SSD|" // tested with ORTIAL SSD/U0202A0 (128GB)
+    "RX7 (240|256|512)G|" // tested with RX7 240G/T0910A0
+    "SATA3 ((12[08]|240|256|480)G|[12]T)B SSD|" // TCSUNBOW X3, tested with SATA3 240GB SSD/S0618A0,
+      // SATA3 1TB SSD/S1230A0,
+      // KingDian S370, tested with SATA3 128GB SSD/T0311A0, SATA3 256GB SSD/S1127B0
+      // KingDian S280, tested with SATA3 240GB SSD/T0519A0
+    "SPCC M\\.2 SSD|" // Silicon Power A/M55, tested with SPCC M.2 SSD/Q0627A0, SPCC M.2 SSD/U0506A0,
+      // SPCC M.2 SSD/U1209A0
+    "SSD 120GB|" // Intenso M.2 SSD High, tested with SSD 120GB/R0529A
+    "T-FORCE (128|256|512)GB|" // tested with T-FORCE 512GB/T0910A0
+    "Verbatim Vi550 S3|" // tested with Verbatim Vi550 S3/U1124A0 (128GB),
+       // may also exist with different controllers (tickets #1626, #1629, #1774, #1930, GH issues/185),
+    "Vi550 S3", // another variant (ticket #1899), tested with Vi550 S3/HP3418C5
+    "HP(3418C5|S2227I)|KFS03005|P0510E|P0725A|Q(0627|1107)A0|R(0529A|0817B0)|"
+    "S(0222|0424|0509|0618|1211|1230)A0|S112[78]B0|T0(311|519|910)A0|"
+    "U(0202|0401|0506|1124|1209)A0|V0((609|823)A|(303|718)B)0|V1027A0|"
+    "W(0413|0714|0825)A0",
+    "",
+    "-v 148,raw48,Total_SLC_Erase_Ct "
+    "-v 149,raw48,Max_SLC_Erase_Ct "
+    "-v 150,raw48,Min_SLC_Erase_Ct "
+    "-v 151,raw48,Average_SLC_Erase_Ct "
+    "-v 159,raw48,Unkn_SiliconMotion_Attr "
+    "-v 160,raw48,Uncorrectable_Error_Cnt "
+    "-v 161,raw48,Valid_Spare_Block_Cnt "
+    "-v 163,raw48,Initial_Bad_Block_Count "
+    "-v 164,raw48,Total_Erase_Count "
+    "-v 165,raw48,Max_Erase_Count "
+    "-v 166,raw48,Min_Erase_Count "
+    "-v 167,raw48,Average_Erase_Count "
+    "-v 168,raw48,Max_Erase_Count_of_Spec "
+    "-v 169,raw48,Remaining_Lifetime_Perc "
+    "-v 178,raw48,Runtime_Invalid_Blk_Cnt "
+    "-v 225,raw48,Host_Writes_32MiB "
+    "-v 241,raw48,Host_Writes_32MiB "
+    "-v 242,raw48,Host_Reads_32MiB "
+    "-v 245,raw48,TLC_Writes_32MiB "
+    "-v 246,raw48,SLC_Writes_32MiB "
+    "-v 247,raw48,Raid_Recoverty_Ct "
+    "-v 248,raw48,Unkn_SiliconMotion_Attr "
+    "-v 251,raw48,Unkn_SiliconMotion_Attr"
+  },
+  { "SMART Modular Technologies mSATA XL+ SLC SSDs", // tested with SH9MST6D16GJSI01
+    "SH9MST6D[0-9]*GJSI?[0-9]*", // based on http://www.smartm.com/salesLiterature/embedded/mSATA_overview.pdf
+    "", "", // attributes info from http://www.mouser.com/ds/2/723/smartmodular_09302015_SH9MST6DxxxGJSxxx_rA[1]-770719.pdf
+    "-v 1,raw48,Uncorrectable_ECC_Cnt "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+    "-v 9,raw48,Power_On_Hours " // override default raw24(raw8) format
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 14,raw48,Device_Capacity_LBAs "
+    "-v 15,raw48,User_Capacity_LBAs " // spec DecID is wrong, HexID is right
+    "-v 16,raw48,Init_Spare_Blocks_Avail " // spec DecID is wrong, HexID is right
+    "-v 17,raw48,Spare_Blocks_Remaining " // spec DecID is wrong, HexID is right
+    "-v 100,raw48,Total_Erase_Count "
+    "-v 168,raw48,SATA_PHY_Err_Ct "
+    "-v 170,raw48,Initial_Bad_Block_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 173,raw48,Max_Erase_Count "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+    "-v 175,raw48,Average_Erase_Count "
+  //"-v 181,raw48,Program_Fail_Cnt_Total "
+  //"-v 187,raw48,Reported_Uncorrect "
+  //"-v 194,tempminmax,Temperature_Celsius "
+    "-v 197,raw48,Not_In_Use "
+    "-v 198,raw48,Not_In_Use "
+    "-v 199,raw48,SATA_CRC_Error_Count "
+    "-v 202,raw48,Perc_Rated_Life_Used "
+    "-v 231,raw48,Perc_Rated_Life_Remain "
+    "-v 232,raw48,Read_Fail_Count "
+    "-v 234,raw48,Flash_Reads_LBAs "
+    "-v 235,raw48,Flash_Writes_LBAs "
+  //"-v 241,raw48,Total_LBAs_Written "
+  //"-v 242,raw48,Total_LBAs_Read "
+    //  247-248 Missing in specification from April 2015
+  },
+  { "Smart Storage Systems Xcel-10 SSDs",  // based on http://www.smartm.com/files/salesLiterature/storage/xcel10.pdf
+    "SMART A25FD-(32|64|128)GI32N", // tested with SMART A25FD-128GI32N/B9F23D4K
+    "",
+    "", // attributes info from http://www.adtron.com/pdf/SMART_Attributes_Xcel-10_810800014_RevB.pdf
+    "-v 1,raw48,Not_Supported "
+    "-v 2,raw48,Not_Supported "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 191,raw48,Not_Supported "
+  //"-v 192,raw48,Power-Off_Retract_Count "
+    "-v 197,raw48,ECC_Error_Count "
+  //"-v 198,raw48,Offline_Uncorrectable "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 251,raw48,Min_Spares_Remain_Perc " // percentage of the total number of spare blocks available
+    "-v 252,raw48,Added_Bad_Flash_Blk_Ct " // number of bad flash blocks
+    "-v 254,raw48,Total_Erase_Blocks_Ct" // number of times the drive has erased any erase block
+  },
+  { "Smart Storage Systems XceedSecure2 SSDs",
+    "(SMART|Adtron) ([AIS]25FBS|S35FCS).*",
+    "", "",
+    "-v 9,sec2hour,Power_On_Hours "
+    "-v 194,hex64,Proprietary_194"
+  },
+  { "Smart Storage Systems XceedUltraX/Adtron A25FBX SSDs",
+    "(SMART|Adtron) (A|I)25FBX.*",
+    "", "",
+    "-v 9,hex64,Proprietary_9 "
+    "-v 194,hex48,Proprietary_194"
+  },
+  { "Smart Storage Systems Adtron A25FB 2xN SSDs",
+    "(SMART|Adtron) A25FB.*2.N",
+    "", "",
+    "-v 110,hex64,Proprietary_HWC "
+    "-v 111,hex64,Proprietary_MP "
+    "-v 112,hex64,Proprietary_RtR "
+    "-v 113,hex64,Proprietary_RR "
+    "-v 120,hex64,Proprietary_HFAll "
+    "-v 121,hex64,Proprietary_HF1st "
+    "-v 122,hex64,Proprietary_HF2nd "
+    "-v 123,hex64,Proprietary_HF3rd "
+    "-v 125,hex64,Proprietary_SFAll "
+    "-v 126,hex64,Proprietary_SF1st "
+    "-v 127,hex64,Proprietary_SF2nd "
+    "-v 128,hex64,Proprietary_SF3rd "
+    "-v 194,raw24/raw32:zvzzzw,Fractional_Temperature"
+  },
+  { "Smart Storage Systems Adtron A25FB 3xN SSDs",
+    "(SMART|Adtron) A25FB-.*3.N",
+    "", "",
+    "-v 9,sec2hour,Power_On_Hours "
+    "-v 113,hex48,Proprietary_RR "
+    "-v 130,raw48:54321,Minimum_Spares_All_Zs"
+  //"-v 194,tempminmax,Temperature_Celsius"
+  },
+  { "SSSTC ERX GD/CD Series SSDs", // Marvel DEAN 2.1
+    "(SSSTC|SATA) ER[2-9]-[CG]D(240|480|960|1920|3840|7680|15360)A?|" // tested with
+      // SSSTC ER3-GD240/F2MRD0F, SSSTC ER2-GD480/E4N23021, SSSTC ER3-CD960A/F3MRD0Y,
+      // SSSTC ER2-CD1920A/E5MN401, SSSTC ER4-CD7680A/G62RD14
+    "AF[2-9]MA31DT[ED]LT(240|480|960|1920|3840|7680|15360)A?", // tested with
+      // AF2MA31DTDLT240A/F2M96T0, AF3MA31DTELT240A/F2M9601
+    "","",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 100,raw48,Max_Min_EC_Count "
+    "-v 170,raw48,Available_Reservd_Space "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 173,raw48,Average_PE_Count "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+    "-v 175,raw48,PLP_Failure "
+  //"-v 176,raw48,Erase_Fail_Count_Chip "
+  //"-v 177,raw48,Wear_Leveling_Count "
+  //"-v 178,raw48,Used_Rsvd_Blk_Cnt_Chip "
+  //"-v 179,raw48,Used_Rsvd_Blk_Cnt_Tot "
+    "-v 180,raw48,Over-Provisioning_Rate "
+    "-v 181,raw48,Sys_Percent_Life_Remain "
+    "-v 182,raw48,Heavy_GC_Log "
+    "-v 183,raw48,SATA_Iface_Downshift "
+  //"-v 184,raw48,End-to-End_Error "
+  //"-v 187,raw48,Reported_Uncorrect "
+  //"-v 188,raw48,Command_Timeout "
+    "-v 189,raw48,Maximum_Erase_Count "
+  //"-v 190,tempminmax,Airflow_Temperature_Cel "
+    "-v 191,raw48,Mininum_Erase_Count "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 195,raw48,Hardware_ECC_Recovered "
+  //"-v 198,raw48,Offline_Uncorrectable "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 202,raw48,Percent_Lifetime_Remain "
+    "-v 210,raw48,Raid_Success_Recover_Ct "
+    "-v 229,raw48,PLP_Failure "
+    "-v 231,raw48,Percent_Lifetime_Remain "
+  //"-v 232,raw48,Available_Reservd_Space "
+    "-v 233,raw48,Percent_Lifetime_Remain "
+    "-v 234,raw48,Thermal_Throttle_Status "
+  //"-v 241,raw48,Total_LBAs_Written "
+  //"-v 242,raw48,Total_LBAs_Read "
+    "-v 243,raw48,Total_NAND_Written " // GiB?
+    "-v 244,raw48,SoC_Data_Path_Prot_Det "
+    "-v 245,raw48,Thermal_Sensor_Health "
+    "-v 246,raw48,Heavy_Read_Retry_count "
+    "-v 247,raw48,NOR_Health "
+    "-v 248,raw48,Cross_Temp_Duration "
+    "-v 249,raw48,SSD_Health"
+  },
+  { "STEC Mach2 CompactFlash Cards", // tested with STEC M2P CF 1.0.0/K1385MS
+    "STEC M2P CF 1.0.0",
+    "", "",
+    "-v 100,raw48,Erase_Program_Cycles "
+    "-v 103,raw48,Remaining_Energy_Storg "
+    "-v 170,raw48,Reserved_Block_Count "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 173,raw48,Wear_Leveling_Count "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+    "-v 211,raw48,Unknown_Attribute " // ] Missing in specification
+    "-v 212,raw48,Unknown_Attribute"  // ] from September 2012
+  },
+  { "Transcend CompactFlash Cards", // tested with TRANSCEND/20080820,
+      // TS4GCF133/20100709, TS16GCF133/20100709, TS16GCF150/20110407
+    "TRANSCEND|TS(4|8|16)GCF(133|150)",
+    "", "",
+    "-v 7,raw48,Unknown_Attribute "
+    "-v 8,raw48,Unknown_Attribute"
+  },
+  { "Xmore Industrial SATA SSDs", // tested with M2CA032GXAIMS-003Z/XP01.1GB
+    "(CFAST|M2[AC]A|MSATA|SSD)[0-9]{3}[GT]XA[CEI][MT][MST]-[0-9]{3}[TZ]",
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 168,raw48,SATA_Phy_Error_Count "
+    "-v 169,raw48,Bad_Block_Rate "
+    "-v 170,raw24/raw24:z54z10,Bad_Blk_Ct_Lat/Erl " // Later bad block/Early bad block
+    "-v 173,raw16(avg16),MaxAvgErase_Ct "
+    "-v 192,raw48,Unexpect_Power_Loss_Ct "
+  //"-v 194,tempminmax,Temperature_Celsius " // optional
+    "-v 218,raw48,SATA_CRC_Error_Count "
+    "-v 231,raw48,Percent_Lifetime_Remain "
+    "-v 241,raw48,Host_Writes_GiB"
+  },
+  { "Marvell SSD SD88SA024BA0 (SUN branded)",
+    "MARVELL SD88SA024BA0 SUN24G 0902M0054V",
+    "", "", ""
+  },
+  { "HP 1TB SATA disk GB1000EAFJL",
+    "GB1000EAFJL",
+    "", "", ""
+  },
+  { "HP 500GB SATA disk MM0500EANCR",
+    "MM0500EANCR",
+    "", "", ""
+  },
+  { "HP 250GB SATA disk VB0250EAVER",
+    "VB0250EAVER",
+    "", "", ""
+  },
+  { "IBM Deskstar 60GXP",  // ER60A46A firmware
+    "(IBM-|Hitachi )?IC35L0[12346]0AVER07.*",
+    "ER60A46A",
+    "", ""
+  },
+  { "IBM Deskstar 60GXP",  // All other firmware
+    "(IBM-|Hitachi )?IC35L0[12346]0AVER07.*",
+    "",
+    "IBM Deskstar 60GXP drives may need upgraded SMART firmware.\n"
+    "Please see http://haque.net/dtla_update/",
+    ""
+  },
+  { "IBM Deskstar 40GV & 75GXP (A5AA/A6AA firmware)",
+    "(IBM-)?DTLA-30[57]0[123467][05].*",
+    "T[WX][123468AG][OF]A[56]AA",
+    "", ""
+  },
+  { "IBM Deskstar 40GV & 75GXP (all other firmware)",
+    "(IBM-)?DTLA-30[57]0[123467][05].*",
+    "",
+    "IBM Deskstar 40GV and 75GXP drives may need upgraded SMART firmware.\n"
+    "Please see http://haque.net/dtla_update/",
+    ""
+  },
+  { "", // ExcelStor J240, J340, J360, J680, J880 and J8160
+    "ExcelStor Technology J(24|34|36|68|88|816)0",
+    "", "", ""
+  },
+  { "", // Fujitsu M1623TAU
+    "FUJITSU M1623TAU",
+    "",
+    "",
+    "-v 9,seconds"
+  },
+  { "Fujitsu MHG",
+    "FUJITSU MHG2...ATU?.*",
+    "",
+    "",
+    "-v 9,seconds"
+  },
+  { "Fujitsu MHH",
+    "FUJITSU MHH2...ATU?.*",
+    "",
+    "",
+    "-v 9,seconds"
+  },
+  { "Fujitsu MHJ",
+    "FUJITSU MHJ2...ATU?.*",
+    "",
+    "",
+    "-v 9,seconds"
+  },
+  { "Fujitsu MHK",
+    "FUJITSU MHK2...ATU?.*",
+    "",
+    "",
+    "-v 9,seconds"
+  },
+  { "",  // Fujitsu MHL2300AT
+    "FUJITSU MHL2300AT",
+    "",
+    "This drive's firmware has a harmless Drive Identity Structure\n"
+    "checksum error bug.",
+    "-v 9,seconds"
+  },
+  { "",  // MHM2200AT, MHM2150AT, MHM2100AT, MHM2060AT
+    "FUJITSU MHM2(20|15|10|06)0AT",
+    "",
+    "This drive's firmware has a harmless Drive Identity Structure\n"
+    "checksum error bug.",
+    "-v 9,seconds"
+  },
+  { "Fujitsu MHN",
+    "FUJITSU MHN2...AT",
+    "",
+    "",
+    "-v 9,seconds"
+  },
+  { "", // Fujitsu MHR2020AT
+    "FUJITSU MHR2020AT",
+    "",
+    "",
+    "-v 9,seconds"
+  },
+  { "", // Fujitsu MHR2040AT
+    "FUJITSU MHR2040AT",
+    "",    // Tested on 40BA
+    "",
+    "-v 9,seconds -v 192,emergencyretractcyclect "
+    "-v 198,offlinescanuncsectorct -v 200,writeerrorcount"
+  },
+  { "Fujitsu MHS AT",
+    "FUJITSU MHS20[6432]0AT(  .)?",
+    "",
+    "",
+    "-v 9,seconds -v 192,emergencyretractcyclect "
+    "-v 198,offlinescanuncsectorct -v 200,writeerrorcount "
+    "-v 201,detectedtacount"
+  },
+  { "Fujitsu MHT", // tested with FUJITSU MHT2030AC/909B
+    "FUJITSU MHT2...(AC|AH|AS|AT|BH)U?.*",
+    "",
+    "",
+    "-v 9,seconds"
+  },
+  { "Fujitsu MHU",
+    "FUJITSU MHU2...ATU?.*",
+    "",
+    "",
+    "-v 9,seconds"
+  },
+  { "Fujitsu MHV",
+    "FUJITSU MHV2...(AH|AS|AT|BH|BS|BT).*",
+    "",
+    "",
+    "-v 9,seconds"
+  },
+  { "Fujitsu MPA..MPG",
+    "FUJITSU MP[A-G]3...A[HTEV]U?.*",
+    "",
+    "",
+    "-v 9,seconds"
+  },
+  { "Fujitsu MHY BH",
+    "FUJITSU MHY2(04|06|08|10|12|16|20|25)0BH.*",
+    "", "",
+    "-v 240,raw48,Transfer_Error_Rate"
+  },
+  { "Fujitsu MHW AC", // tested with FUJITSU MHW2060AC/00900004
+    "FUJITSU MHW20(40|60)AC",
+    "", "", ""
+  },
+  { "Fujitsu MHW BH",
+    "FUJITSU MHW2(04|06|08|10|12|16)0BH.*",
+    "", "", ""
+  },
+  { "Fujitsu MHW BJ",
+    "FUJITSU MHW2(08|12|16)0BJ.*",
+    "", "", ""
+  },
+  { "Fujitsu MHZ BH",
+    "FUJITSU MHZ2(04|08|12|16|20|25|32)0BH.*",
+    "", "", ""
+  },
+  { "Fujitsu MHZ BJ",
+    "FUJITSU MHZ2(08|12|16|20|25|32)0BJ.*",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Fujitsu MHZ BS",
+    "FUJITSU MHZ2(12|25)0BS.*",
+    "", "", ""
+  },
+  { "Fujitsu MHZ BK",
+    "FUJITSU MHZ2(08|12|16|25)0BK.*",
+    "", "", ""
+  },
+  { "Fujitsu MJA BH",
+    "FUJITSU MJA2(08|12|16|25|32|40|50)0BH.*",
+    "", "", ""
+  },
+  { "", // Samsung SV4012H (known firmware)
+    "SAMSUNG SV4012H",
+    "RM100-08",
+    "",
+    "-v 9,halfminutes -F samsung"
+  },
+  { "", // Samsung SV4012H (all other firmware)
+    "SAMSUNG SV4012H",
+    "",
+    "May need -F samsung disabled; see manual for details.",
+    "-v 9,halfminutes -F samsung"
+  },
+  { "", // Samsung SV0412H (known firmware)
+    "SAMSUNG SV0412H",
+    "SK100-01",
+    "",
+    "-v 9,halfminutes -v 194,10xCelsius -F samsung"
+  },
+  { "", // Samsung SV0412H (all other firmware)
+    "SAMSUNG SV0412H",
+    "",
+    "May need -F samsung disabled; see manual for details.",
+    "-v 9,halfminutes -v 194,10xCelsius -F samsung"
+  },
+  { "", // Samsung SV1204H (known firmware)
+    "SAMSUNG SV1204H",
+    "RK100-1[3-5]",
+    "",
+    "-v 9,halfminutes -v 194,10xCelsius -F samsung"
+  },
+  { "", // Samsung SV1204H (all other firmware)
+    "SAMSUNG SV1204H",
+    "",
+    "May need -F samsung disabled; see manual for details.",
+    "-v 9,halfminutes -v 194,10xCelsius -F samsung"
+  },
+  { "", // SAMSUNG SV0322A tested with FW JK200-35
+    "SAMSUNG SV0322A",
+    "", "", ""
+  },
+  { "SAMSUNG SpinPoint V80", // tested with SV1604N/TR100-23
+    "SAMSUNG SV(0211|0401|0612|0802|1203|1604)N",
+    "",
+    "",
+    "-v 9,halfminutes -F samsung2"
+  },
+  { "", // SAMSUNG SP40A2H with RR100-07 firmware
+    "SAMSUNG SP40A2H",
+    "RR100-07",
+    "",
+    "-v 9,halfminutes -F samsung"
+  },
+  { "", // SAMSUNG SP80A4H with RT100-06 firmware
+    "SAMSUNG SP80A4H",
+    "RT100-06",
+    "",
+    "-v 9,halfminutes -F samsung"
+  },
+  { "", // SAMSUNG SP8004H with QW100-61 firmware
+    "SAMSUNG SP8004H",
+    "QW100-61",
+    "",
+    "-v 9,halfminutes -F samsung"
+  },
+  { "SAMSUNG SpinPoint F1 DT", // tested with HD103UJ/1AA01113
+    "SAMSUNG HD(083G|16[12]G|25[12]H|32[12]H|50[12]I|642J|75[23]L|10[23]U)J",
+    "", "", ""
+  },
+  { "SAMSUNG SpinPoint F1 EG", // tested with HD103UI/1AA01113
+    "SAMSUNG HD(252H|322H|502I|642J|753L|103U)I",
+    "", "", ""
+  },
+  { "SAMSUNG SpinPoint F1 RE", // tested with HE103UJ/1AA01113
+    "SAMSUNG HE(252H|322H|502I|642J|753L|103U)J",
+    "", "", ""
+  },
+  { "SAMSUNG SpinPoint F2 EG", // tested with HD154UI/1AG01118
+    "SAMSUNG HD(502H|10[23]S|15[34]U)I",
+    "", "", ""
+  },
+  { "SAMSUNG SpinPoint F3", // tested with HD502HJ/1AJ100E4
+    "SAMSUNG HD(502H|754J|103S)J",
+    "", "", ""
+  },
+  { "Seagate Barracuda SpinPoint F3", // tested with ST1000DM005 HD103SJ/1AJ100E5
+    "ST[0-9DM]* HD(502H|754J|103S)J",
+    "", "", ""
+  },
+  { "SAMSUNG SpinPoint F3 EG", // tested with HD503HI/1AJ100E4, HD153WI/1AN10002
+    "SAMSUNG HD(253G|(324|503)H|754J|105S|(153|203)W)I",
+    "", "", ""
+  },
+  { "SAMSUNG SpinPoint F3 RE", // tested with HE103SJ/1AJ30001
+    "SAMSUNG HE(502H|754J|103S)J",
+    "", "", ""
+  },
+  { "Seagate Samsung Spinpoint F4", // tested with ST250DM001 HD256GJ/1AR10001
+    "ST(250|320)DM001 HD(256G|322G|323H)J",
+    "", "", ""
+  },
+  { "SAMSUNG SpinPoint F4 EG (AF)",// tested with HD204UI/1AQ10001(buggy|fixed)
+    "SAMSUNG HD(155|204)UI",
+    "", // 1AQ10001
+    "Using smartmontools or hdparm with this\n"
+    "drive may result in data loss due to a firmware bug.\n"
+    "****** THIS DRIVE MAY OR MAY NOT BE AFFECTED! ******\n"
+    "Buggy and fixed firmware report same version number!\n"
+    "See the following web pages for details:\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/223571en\n"
+    "https://www.smartmontools.org/wiki/SamsungF4EGBadBlocks",
+    ""
+  },
+  { "Seagate Samsung SpinPoint F4 EG (AF)", // later sold as Barracuda Green,
+      // tested with ST2000DL004 HD204UI/1AQ10001
+    "ST2000DL004 HD204UI",
+    "", "", ""
+  },
+  { "SAMSUNG SpinPoint S250", // tested with HD200HJ/KF100-06
+    "SAMSUNG HD(162|200|250)HJ",
+    "", "", ""
+  },
+  { "SAMSUNG SpinPoint T133", // tested with HD300LJ/ZT100-12, HD400LJ/ZZ100-14, HD401LJ/ZZ100-15
+    "SAMSUNG HD(250KD|(30[01]|320|40[01])L[DJ])",
+    "", "", ""
+  },
+  { "SAMSUNG SpinPoint T166", // tested with HD252KJ/CM100-11, HD501LJ/CR100-1[01]
+    "SAMSUNG HD(080G|160H|252K|32[01]K|403L|50[01]L)J",
+    "", "",
+    "-v 197,increasing" // at least HD501LJ/CR100-11
+  },
+  { "SAMSUNG SpinPoint P120", // VF100-37 firmware, tested with SP2514N/VF100-37
+    "SAMSUNG SP(16[01]3|2[05][01]4)[CN]",
+    "VF100-37",
+    "",
+    "-F samsung3"
+  },
+  { "SAMSUNG SpinPoint P120", // other firmware, tested with SP2504C/VT100-33
+    "SAMSUNG SP(16[01]3|2[05][01]4)[CN]",
+    "",
+    "May need -F samsung3 enabled; see manual for details.",
+    ""
+  },
+  { "SAMSUNG SpinPoint P80 SD", // tested with HD160JJ/ZM100-33, SAMSUNG HD080HJ/P/ZH100-34
+    "SAMSUNG HD(080H|120I|160J)J(/P)?",
+    "", "", ""
+  },
+  { "SAMSUNG SpinPoint P80", // BH100-35 firmware, tested with SP0842N/BH100-35
+    "SAMSUNG SP(0451|08[0124]2|12[0145]3|16[0145]4)[CN]",
+    "BH100-35",
+    "",
+    "-F samsung3"
+  },
+  { "SAMSUNG SpinPoint P80", // firmware *-35 or later
+    "SAMSUNG SP(0451|08[0124]2|12[0145]3|16[0145]4)[CN]",
+    ".*-3[5-9]",
+    "May need -F samsung3 enabled; see manual for details.",
+    ""
+  },
+  { "SAMSUNG SpinPoint P80", // firmware *-25...34, tested with
+      // SP0401N/TJ100-30, SP1614C/SW100-25 and -34
+    "SAMSUNG SP(04[05]1|08[0124]2|12[0145]3|16[0145]4)[CN]",
+    ".*-(2[5-9]|3[0-4])",
+    "",
+    "-v 9,halfminutes -v 198,increasing"
+  },
+  { "SAMSUNG SpinPoint P80", // firmware *-23...24, tested with
+    // SP0802N/TK100-23,
+    // SP1213N/TL100-23,
+    // SP1604N/TM100-23 and -24
+    "SAMSUNG SP(0451|08[0124]2|12[0145]3|16[0145]4)[CN]",
+    ".*-2[34]",
+    "",
+    "-v 9,halfminutes -F samsung2"
+  },
+  { "SAMSUNG SpinPoint P80", // unknown firmware
+    "SAMSUNG SP(0451|08[0124]2|12[0145]3|16[0145]4)[CN]",
+    "",
+    "May need -F samsung2 or -F samsung3 enabled; see manual for details.",
+    ""
+  },
+  { "SAMSUNG SpinPoint M40/60/80", // tested with HM120IC/AN100-16, HM160JI/AD100-16
+    "SAMSUNG HM(0[468]0H|120I|1[026]0J)[CI]",
+    "",
+    "",
+    "-v 9,halfminutes"
+  },
+  { "SAMSUNG SpinPoint M5", // tested with HM160HI/HH100-12
+    "SAMSUNG HM(((061|080)G|(121|160)H|250J)I|160HC)",
+    "", "", ""
+  },
+  { "SAMSUNG SpinPoint M6", // tested with HM320JI/2SS00_01 M6
+    "SAMSUNG HM(251J|320[HJ]|[45]00L)I",
+    "", "", ""
+  },
+  { "SAMSUNG SpinPoint M7", // tested with HM500JI/2AC101C4
+    "SAMSUNG HM(250H|320I|[45]00J)I",
+    "", "", ""
+  },
+  { "SAMSUNG SpinPoint M7E (AF)", // tested with HM321HI/2AJ10001, HM641JI/2AJ10001
+    "SAMSUNG HM(161G|(251|321)H|501I|641J)I",
+    "", "", ""
+  },
+  { "Seagate Samsung SpinPoint M7E", // tested with ST640LM000 HM641JI/2AJ10001
+    "ST(160|250|320|500|640)LM00[01] HM[0-9]*[GHIJ]I",
+    "", "", ""
+  },
+  { "SAMSUNG SpinPoint M7U (USB)", // tested with HM252HX/2AC101C4
+    "SAMSUNG HM(162H|252H|322I|502J)X",
+    "", "", ""
+  },
+  { "SAMSUNG SpinPoint M8 (AF)", // tested with HN-M101MBB/2AR10001
+    "SAMSUNG HN-M(250|320|500|640|750|101)MBB",
+    "", "", ""
+  },
+  { "Seagate Samsung SpinPoint M8 (AF)", // tested with
+      // ST750LM022 HN-M750MBB/2AR10001, ST320LM001 HN-M320MBB/2AR10002,
+      // APPLE HDD ST500LM012/2BA30003
+    "ST(250|320|500|640|750|1000)LM0[012][124] HN-M[0-9]*MBB|"
+    "APPLE HDD ST500LM012",
+    "", "", ""
+  },
+  { "SAMSUNG SpinPoint M8U (USB)", // tested with HN-M500XBB/2AR10001
+    "SAMSUNG HN-M(320|500|750|101)XBB",
+    "", "", ""
+  },
+  { "Seagate Samsung SpinPoint M8U (USB)", // tested with ST1000LM025 HN-M101ABB/2AR10001,
+      // ST1000LM025 HN-M101ABB/2BA30003 (0x04e8:0x61b6)
+    "ST(250|320|500|640|750|1000)LM0[012][3459] HN-M[0-9]*ABB",
+    "", "", ""
+  },
+  { "Seagate Barracuda Pro Compute", // tested with ST1000LM049-2GH172/SDM1
+    "ST(1000LM049|500LM034)-.*",
+    "", "", ""
+  },
+  { "Seagate Samsung SpinPoint M9T", // tested with ST2000LM003 HN-M201RAD/2BC10003
+      // (Seagate Expansion Portable)
+    "ST(1500|2000)LM0(03|04|06|07|10) HN-M[0-9]*RAD",
+    "", "", ""
+  },
+  { "Seagate Mobile HDD", // tested with ST1000LM035-1RK172/ACM1,
+     // ST1000LM035-1RK172/ACM2, ST1000LM035-1RK172/EB01 (0x1005:0xc004),
+     // ST2000LM007-1R8174/SBK2
+    "ST(2000LM0(07|09|10)|1000LM03[578])-.*",
+    "", "", ""
+  },
+  // Flash accelerated, no SMART info in the specs
+  // ST1000LX015-1U7172/SDM1
+  { "Seagate FireCuda 2.5",
+    "ST(500|1000|2000)LX0(01|15|25)-.*",
+    "", "", "-v 240,msec24hour32 "
+  },
+  { "Seagate FireCuda 3.5", // ST2000DX002-2DV164/CC41
+    "ST[12]000DX002-.*",
+    "", "", "-v 240,msec24hour32 "
+  },
+  { "Seagate Samsung SpinPoint M9TU (USB)", // tested with ST1500LM008 HN-M151AAD/2BC10001
+      // (0x04e8:0x61b5), ST2000LM005 HN-M201AAD2BC10001 (0x04e8:0x61b4)
+    "ST(1500|2000)LM00[58] HN-M[0-9]*AAD",
+    "", "", ""
+  },
+  { "Seagate FreePlay", // tested with ST1500LM003-9YH148/CC94
+    // from FreeAgent GoFlex Enclosure.
+    "ST(1500LM003|1000LM010|1000LM002)-.*",
+    "", "", ""
+  },
+  { "SAMSUNG SpinPoint MP5", // tested with HM250HJ/2AK10001
+    "SAMSUNG HM(250H|320H|500J|640J)J",
+    "", "", ""
+  },
+  { "SAMSUNG SpinPoint MT2", // tested with HM100UI/2AM10001
+    "SAMSUNG HM100UI",
+    "", "", ""
+  },
+  { "SAMSUNG HM100UX (S2 Portable)", // tested with HM100UX/2AM10001
+    "SAMSUNG HM100UX",
+    "", "", ""
+  },
+  { "SAMSUNG SpinPoint M", // tested with MP0402H/UC100-11
+    "SAMSUNG MP0(302|402|603|804)H",
+    "",
+    "",
+    "-v 9,halfminutes"
+  },
+  { "SAMSUNG SpinPoint N3U-3 (USB)", // tested with
+      // SAMSUNG HS25YJZ/3AU10-01 (0x18a5:0x0227, reports 4KiB LPS/LLS. ticket #159),
+      // SAMSUNG HS20YJZ/3AU10-01 (0x04e8:0x2f06, reports 512B sectors, Debian Bug 964032)
+    "SAMSUNG HS(122H|2[05]YJ)Z",
+    "", "", ""
+  },
+  { "SK hynix SATA SSDs",
+    "SK ?hynix (SC(210|300|308|311|313|401)|SH920) .*|" // tested with
+      // SK hynix SC210 mSATA 256GB/20002L00,
+      // SKhynix SC300 HFS256G32MND-3210A/20131P00,
+      // SK hynix SC308 SATA 256GB/30000P10,
+      // SK hynix SC308 SATA 128GB/30001P10,
+      // SK hynix SC311 SATA 512GB/70000P10,
+      // SK hynix SC313 HFS256G32TNF-N3A0A/70000P10,
+      // SK hynix SC401 SATA 512GB/90000121,
+      // SK hynix SH920 mSATA 256GB/1010BL00
+    "HFS(128|256|512)G3[29A]MN[BD]-(2200|3[23]10)A|" // SC210, tested with
+      // HFS128G32MND-2200A/20200L00, HFS512G32MND-3210A/20100P00,
+      // HFS512G39MND-3310A/20002P00, HFS256G3AMNB-2200A/1010BL00
+    "HFS(128|256|512)G3[29]MND-3(312|510)A|" // SC300, tested with HFS256G32MND-3312A/20001P00,
+      // HFS512G39MND-3510A/20400P00
+    "HFS(128|256|512)G39TND-N210A|" // SC308, tested with HFS128G39TND-N210A/30001P10
+    "HFS(120|250|500)G32TND-N1A2A|" // SL308, tested with HFS500G32TND-N1A2A/30000P10
+    "HFS(128|256|512)G32TNF-N3A0A|" // SC313, tested with HFS256G32TNF-N3A0A/70000P10
+    // HFS480G32FEH-BA10A/DD02 (Dell)
+    "SHGS31-(250|500|1000)GS-2", // S31, tested with SHGS31-1000GS-2/90000Q00
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+    "-v 5,raw48,Retired_Block_Count "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 100,raw48,Total_Erase_Count "
+    "-v 168,raw48,Min_Erase_Count "
+    "-v 169,raw48,Max_Erase_Count "
+    "-v 170,raw48,Unknown_SK_hynix_Attrib "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 173,raw48,Wear_Leveling_Count "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+  //"-v 175,raw48,Program_Fail_Count_Chip "
+    "-v 176,raw48,Unused_Rsvd_Blk_Cnt_Tot "
+  //"-v 177,raw48,Wear_Leveling_Count "
+  //"-v 178,raw48,Used_Rsvd_Blk_Cnt_Chip "
+  //"-v 179,raw48,Used_Rsvd_Blk_Cnt_Tot "
+    "-v 180,raw48,Erase_Fail_Count "
+    "-v 181,raw48,Non4k_Aligned_Access "
+    "-v 183,raw48,SATA_Downshift_Count "
+  //"-v 184,raw48,End-to-End_Error "
+  //"-v 187,raw48,Reported_Uncorrect "
+  //"-v 188,raw48,Command_Timeout "
+    "-v 191,raw48,Unknown_SK_hynix_Attrib " // SC210
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 195,raw48,Hardware_ECC_Recovered "
+  //"-v 196,raw16(raw16),Reallocated_Event_Count "
+  //"-v 198,raw48,Offline_Uncorrectable "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 201,raw48,Percent_Lifetime_Remain "
+  //"-v 204,raw48,Soft_ECC_Correction "
+    "-v 212,raw48,Phy_Error_Count "
+    "-v 231,raw48,SSD_Life_Left "
+    "-v 234,raw48,Unknown_SK_hynix_Attrib "
+    "-v 236,raw48,Unknown_SK_hynix_Attrib " // SC311, SC313
+    "-v 238,raw48,Unknown_SK_hynix_Attrib " // SC401
+    "-v 241,raw48,Total_Writes_GB " // SC31: ~GB, not GiB (#1517)
+    "-v 242,raw48,Total_Reads_GB "
+    "-v 243,raw48,Total_Media_Writes "
+    "-v 249,raw48,NAND_Writes_GiB " // SC311, SC313
+    "-v 250,raw48,Read_Retry_Count "
+  },
+  { "SK hynix SATA SSDs",
+    "HFS(480|960|1T9|3T8)G3[2E]FEH-[7B][4A]10A|" // tested with HFS480G32FEH-7410A/90037Q00,
+      // HFS480G32FEH-BA10A/DD02 (Dell), HFS1T9G32FEH-BA10A/DD02 (Dell)
+    "HFS(480|960|1T9|3T8)G3H2X069N|" // tested with HFS480G3H2X069N/DZ00 (Dell)
+    "SK HYNIX SE5110 (480|960|1920|3840)GB ZIRCON LITE 3DTLC", // tested with
+      // SK HYNIX SE5110 480GB ZIRCON LITE 3DTLC/410A5Z00
+      // SK HYNIX SE5110 960GB ZIRCON LITE 3DTLC/410A5Z00
+      // SK HYNIX SE5110 1920GB ZIRCON LITE 3DTLC/410A5Z00
+      // SK HYNIX SE5110 3840GB ZIRCON LITE 3DTLC/410A5Z00
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+    "-v 5,raw48,Retired_Block_Count "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+  //"-v 13,raw48,Read_Soft_Error_Rate "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 173,raw48,Max_Erase_Count "
+    "-v 174,raw48,Unexpected_Pwr_Loss_Cnt "
+    "-v 175,raw48,Program_Fail_Count "
+    "-v 176,raw48,Erase_Fail_Count "
+    "-v 177,raw48,Endurance_Limit_Met "
+    "-v 178,raw48,Used_Rsrvd_Blk_Cnt_Wrst "
+    "-v 179,raw48,Used_Rsrvd_Blk_Cnt_Tot "
+    "-v 180,raw48,E2E_Error_Det_Corr_Rate "
+    "-v 181,raw48,Program_Fail_Count "
+    "-v 182,raw48,Erase_Fail_Count "
+    "-v 183,raw48,SATA_Downshift_Count "
+  //"-v 184,raw48,End-to-End_Error "
+  //"-v 187,raw48,Reported_Uncorrect "
+  //"-v 188,raw48,Command_Timeout "
+  //"-v 194,tempminmax,Temperature_Celsius "
+    "-v 195,raw48,ECC_on_the_Fly_Rate "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 201,raw48,Uncorr_Soft_Read_Err_Rt "
+    "-v 202,raw48,Exception_Mode_Status "
+    "-v 204,raw48,Soft_ECC_Correction_Rt "
+    "-v 231,raw48,SSD_Life_Left "
+    "-v 234,raw48,Lifetime_NAND_Prg_GiB " // ?
+    "-v 235,raw48,Lifetime_Writes_GiB "
+    "-v 241,raw48,Lifetime_NAND_Prg_GiB "
+    "-v 242,raw48,Lifetime_Reads_GiB "
+    "-v 245,raw48,SSD_Life_Left "
+    "-v 250,raw48,Read_Retry_Count "
+  },
+  { "Maxtor Fireball 541DX",
+    "Maxtor 2B0(0[468]|1[05]|20)H1",
+    "",
+    "",
+    "-v 9,minutes -v 194,unknown"
+  },
+  { "Maxtor Fireball 3",
+    "Maxtor 2F0[234]0[JL]0",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax 1280 ATA",  // no self-test log, ATA2-Fast
+    "Maxtor 8(1280A2|2160A4|2560A4|3840A6|4000A6|5120A8)",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax 2160 Ultra ATA",
+    "Maxtor 8(2160D2|3228D3|3240D3|4320D4|6480D6|8400D8|8455D8)",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax 2880 Ultra ATA",
+    "Maxtor 9(0510D4|0576D4|0648D5|0720D5|0840D6|0845D6|0864D6|1008D7|1080D8|1152D8)",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax 3400 Ultra ATA",
+    "Maxtor 9(1(360|350|202)D8|1190D7|10[12]0D6|0840D5|06[48]0D4|0510D3|1(350|202)E8|1010E6|0840E5|0640E4)",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax D540X-4G",
+    "Maxtor 4G(120J6|160J[68])",
+    "",
+    "",
+    "-v 9,minutes -v 194,unknown"
+  },
+  { "Maxtor DiamondMax D540X-4K",
+    "MAXTOR 4K(020H1|040H2|060H3|080H4)",
+    "", "", ""
+  },
+  { "Maxtor DiamondMax Plus D740X",
+    "MAXTOR 6L0(20[JL]1|40[JL]2|60[JL]3|80[JL]4)",
+    "", "", ""
+  },
+  { "Maxtor DiamondMax Plus 5120 Ultra ATA 33",
+    "Maxtor 9(0512D2|0680D3|0750D3|0913D4|1024D4|1360D6|1536D6|1792D7|2048D8)",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax Plus 6800 Ultra ATA 66",
+    "Maxtor 9(2732U8|2390U7|204[09]U6|1707U5|1366U4|1024U3|0845U3|0683U2)",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax D540X-4D",
+    "Maxtor 4D0(20H1|40H2|60H3|80H4)",
+    "",
+    "",
+    "-v 9,minutes -v 194,unknown"
+  },
+  { "Maxtor DiamondMax 16",
+    "Maxtor 4(R0[68]0[JL]0|R1[26]0L0|A160J0|R120L4)",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax 4320 Ultra ATA",
+    "Maxtor (91728D8|91512D7|91303D6|91080D5|90845D4|90645D3|90648D[34]|90432D2)",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax 17 VL",
+    "Maxtor 9(0431U1|0641U2|0871U2|1301U3|1741U4)",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax 20 VL",
+    "Maxtor (94091U8|93071U6|92561U5|92041U4|91731U4|91531U3|91361U3|91021U2|90841U2|90651U2)",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax VL 30",  // U: ATA66, H: ATA100
+    "Maxtor (33073U4|32049U3|31536U2|30768U1|33073H4|32305H3|31536H2|30768H1)",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax 36",
+    "Maxtor (93652U8|92739U6|91826U4|91369U3|90913U2|90845U2|90435U1)",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax 40 ATA 66",
+    "Maxtor 9(0684U2|1024U2|1362U3|1536U3|2049U4|2562U5|3073U6|4098U8)",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax Plus 40 (Ultra ATA 66 and Ultra ATA 100)",
+    "Maxtor (54098[UH]8|53073[UH]6|52732[UH]6|52049[UH]4|51536[UH]3|51369[UH]3|51024[UH]2)",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax 40 VL Ultra ATA 100",
+    "Maxtor 3(1024H1|1535H2|2049H2|3073H3|4098H4)( B)?",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax Plus 45 Ulta ATA 100",
+    "Maxtor 5(4610H6|4098H6|3073H4|2049H3|1536H2|1369H2|1023H2)",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax 60 ATA 66",
+    "Maxtor 9(1023U2|1536U2|2049U3|2305U3|3073U4|4610U6|6147U8)",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax 60 ATA 100",
+    "Maxtor 9(1023H2|1536H2|2049H3|2305H3|3073H4|4098H6|4610H6|6147H8)",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax Plus 60",
+    "Maxtor 5T0(60H6|40H4|30H3|20H2|10H1)",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax 80",
+    "Maxtor (98196H8|96147H6)",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax 536DX",
+    "Maxtor 4W(100H6|080H6|060H4|040H3|030H2)",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax Plus 8",
+    "Maxtor 6(E0[234]|K04)0L0",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax 10 (ATA/133 and SATA/150)",
+    "Maxtor 6(B(30|25|20|16|12|10|08)0[MPRS]|L(080[MLP]|(100|120)[MP]|160[MP]|200[MPRS]|250[RS]|300[RS]))0",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax 10 (SATA/300)",
+    "Maxtor 6V(080E|160E|200E|250F|300F|320F)0",
+    "", "", ""
+  },
+  { "Maxtor DiamondMax Plus 9",
+    "Maxtor 6Y((060|080|120|160)L0|(060|080|120|160|200|250)P0|(060|080|120|160|200|250)M0)",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor DiamondMax 11",
+    "Maxtor 6H[45]00[FR]0",
+    "", "", ""
+  },
+  { "Maxtor DiamondMax 17",
+    "Maxtor 6G(080L|160[PE])0",
+    "", "", ""
+  },
+  { "Seagate Maxtor DiamondMax 20",
+    "MAXTOR STM3(40|80|160)[28]1[12]0?AS?",
+    "", "", ""
+  },
+  { "Seagate Maxtor DiamondMax 21", // tested with MAXTOR STM3250310AS/3.AAF
+    "MAXTOR STM3(80[28]15|160215|250310|(250|320)820|320620|500630)AS?",
+    "", "", ""
+  },
+  { "Seagate Maxtor DiamondMax 22", // fixed firmware
+    "(MAXTOR )?STM3(500320|750330|1000340)AS?",
+    "MX1A", // http://knowledge.seagate.com/articles/en_US/FAQ/207969en
+    "", ""
+  },
+  { "Seagate Maxtor DiamondMax 22", // fixed firmware
+    "(MAXTOR )?STM3(160813|320614|640323|1000334)AS?",
+    "MX1B", // http://knowledge.seagate.com/articles/en_US/FAQ/207975en
+    "", ""
+  },
+  { "Seagate Maxtor DiamondMax 22", // buggy firmware
+    "(MAXTOR )?STM3(500320|750330|1000340)AS?",
+    "MX15",
+    "There are known problems with these drives,\n"
+    "AND THIS FIRMWARE VERSION IS AFFECTED,\n"
+    "see the following Seagate web pages:\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/207931en\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/207969en",
+    ""
+  },
+  { "Seagate Maxtor DiamondMax 22", // unknown firmware
+    "(MAXTOR )?STM3(160813|32061[34]|500320|640323|750330|10003(34|40))AS?",
+    "",
+    "There are known problems with these drives,\n"
+    "see the following Seagate web pages:\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/207931en\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/207969en\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/207975en",
+    ""
+  },
+  { "Seagate Maxtor DiamondMax 23", // new firmware
+    "STM3((160|250)31|(320|500)41|(750|1000)52)8AS?",
+    "CC3[D-Z]",
+    "", ""
+  },
+  { "Seagate Maxtor DiamondMax 23", // unknown firmware
+    "STM3((160|250)31|(320|500)41|(750|1000)52)8AS?",
+    "",
+    "A firmware update for this drive may be available,\n"
+    "see the following Seagate web pages:\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/207931en\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/213911en",
+    ""
+  },
+  { "Maxtor MaXLine Plus II",
+    "Maxtor 7Y250[PM]0",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor MaXLine II",
+    "Maxtor [45]A(25|30|32)0[JN]0",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor MaXLine III (ATA/133 and SATA/150)",
+    "Maxtor 7L(25|30)0[SR]0",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Maxtor MaXLine III (SATA/300)",
+    "Maxtor 7V(25|30)0F0",
+    "", "", ""
+  },
+  { "Maxtor MaXLine Pro 500",  // There is also a 7H500R0 model, but I
+    "Maxtor 7H500F0",               // haven't added it because I suspect
+    "",                               // it might need vendoropts_9_minutes
+    "", ""                            // and nobody has submitted a report yet
+  },
+  { "", // HITACHI_DK14FA-20B
+    "HITACHI_DK14FA-20B",
+    "",
+    "",
+    "-v 9,minutes -v 193,loadunload"
+  },
+  { "HITACHI Travelstar DK23XX/DK23XXB",
+    "HITACHI_DK23..-..B?",
+    "",
+    "",
+    "-v 9,minutes -v 193,loadunload"
+  },
+  { "Hitachi Endurastar J4K20/N4K20 (formerly DK23FA-20J)",
+    "(HITACHI_DK23FA-20J|HTA422020F9AT[JN]0)",
+    "",
+    "",
+    "-v 9,minutes -v 193,loadunload"
+  },
+  { "Hitachi Endurastar J4K30/N4K30",
+    "HE[JN]4230[23]0F9AT00",
+    "",
+    "",
+    "-v 9,minutes -v 193,loadunload"
+  },
+  { "Hitachi Travelstar C4K60",  // 1.8" slim drive
+    "HTC4260[23]0G5CE00|HTC4260[56]0G8CE00",
+    "",
+    "",
+    "-v 9,minutes -v 193,loadunload"
+  },
+  { "IBM Travelstar 4GT",
+    "IBM-DTCA-2(324|409)0",
+    "", "", ""
+  },
+  { "IBM Travelstar 6GN",
+    "IBM-DBCA-20(324|486|648)0",
+    "", "", ""
+  },
+  { "IBM Travelstar 25GS, 18GT, and 12GN",
+    "IBM-DARA-2(25|18|15|12|09|06)000",
+    "", "", ""
+  },
+  { "IBM Travelstar 14GS",
+    "IBM-DCYA-214000",
+    "", "", ""
+  },
+  { "IBM Travelstar 4LP",
+    "IBM-DTNA-2(180|216)0",
+    "", "", ""
+  },
+  { "IBM Travelstar 48GH, 30GN, and 15GN",
+    "(IBM-|Hitachi )?IC25(T048ATDA05|N0(30|20|15|12|10|07|06|05)ATDA04)-.",
+    "", "", ""
+  },
+  { "IBM Travelstar 32GH, 30GT, and 20GN",
+    "IBM-DJSA-2(32|30|20|10|05)",
+    "", "", ""
+  },
+  { "IBM Travelstar 4GN",
+    "IBM-DKLA-2(216|324|432)0",
+    "", "", ""
+  },
+  { "IBM/Hitachi Travelstar 60GH and 40GN",
+    "(IBM-|Hitachi )?IC25(T060ATC[SX]05|N0[4321]0ATC[SX]04)-.",
+    "", "", ""
+  },
+  { "IBM/Hitachi Travelstar 40GNX",
+    "(IBM-|Hitachi )?IC25N0[42]0ATC[SX]05-.",
+    "", "", ""
+  },
+  { "Hitachi Travelstar 80GN",
+    "(Hitachi )?IC25N0[23468]0ATMR04-.",
+    "", "", ""
+  },
+  { "Hitachi Travelstar 4K40",
+    "(Hitachi )?HTS4240[234]0M9AT00",
+    "", "", ""
+  },
+  { "Hitachi Travelstar 4K120",
+    "(Hitachi )?(HTS4212(60|80|10|12)H9AT00|HTS421260G9AT00)",
+    "", "", ""
+  },
+  { "Hitachi Travelstar 5K80",
+    "(Hitachi )?HTS5480[8642]0M9AT00",
+    "", "", ""
+  },
+  { "Hitachi Travelstar 5K100",
+    "(Hitachi )?HTS5410[1864]0G9(AT|SA)00",
+    "", "", ""
+  },
+  { "Hitachi Travelstar E5K100",
+    "(Hitachi )?HTE541040G9(AT|SA)00",
+    "", "", ""
+  },
+  { "Hitachi Travelstar 5K120",
+    "(Hitachi )?HTS5412(60|80|10|12)H9(AT|SA)00",
+    "", "", ""
+  },
+  { "Hitachi Travelstar 5K160",
+    "(Hitachi |HITACHI )?HTS5416([468]0|1[26])J9(AT|SA)00",
+    "", "", ""
+  },
+  { "Hitachi Travelstar E5K160",
+    "(Hitachi )?HTE5416(12|16|60|80)J9(AT|SA)00",
+    "", "", ""
+  },
+  { "Hitachi Travelstar 5K250",
+    "(Hitachi |HITACHI )?HTS5425(80|12|16|20|25)K9(A3|SA)00",
+    "", "", ""
+  },
+  { "Hitachi Travelstar 5K320", // tested with HITACHI HTS543232L9SA00/FB4ZC4EC,
+    // Hitachi HTS543212L9SA02/FBBAC52F
+    "(Hitachi |HITACHI )?HT(S|E)5432(80|12|16|25|32)L9(A3(00)?|SA0[012])",
+    "", "", ""
+  },
+  { "Hitachi/HGST Travelstar Z5K320", // tested with Hitachi HTS543232A7A384/ES2OA70K
+    "(Hitachi|HGST) HT[ES]5432(16|25|32)A7A38[145]",
+    "", "", ""
+  },
+  { "Hitachi Travelstar 5K500.B", // tested with Hitachi HTS545050B9SA00/PB4OC60X,
+      // Hitachi HTS545025B9SA02/PB2AC60W
+    "(Hitachi )?HT[ES]5450(12|16|25|32|40|50)B9(A30[01]|SA0[02])",
+    "", "", ""
+  },
+  { "Hitachi/HGST Travelstar Z5K500", // tested with HGST HTS545050A7E380/GG2OAC90,
+      // Hitachi HTS545032A7E380/GGBOA7A0, HGST HTS545050A7E680/GR2OA230,
+      // APPLE HDD HTS545050A7E362/GG2AB990
+    "(Hitachi|HGST|APPLE HDD) HT[ES]5450(25|32|50)A7E(362|38[01]|680)",
+    "", "", ""
+  },
+  { "Hitachi/HGST Travelstar 5K750", // tested with Hitachi HTS547575A9E384/JE4OA60A,
+      // APPLE HDD HTS547550A9E384/JE3AD70F
+    "(Hitachi|APPLE HDD) HT[ES]5475(50|64|75)A9E38[14]",
+    "", "", ""
+  },
+  { "HGST Travelstar 5K1000", // tested with HGST HTS541010A9E680/JA0OA560,
+      // HGST HTS541075A9E680/JA2OA560
+    "HGST HT[ES]5410(64|75|10)A9E68[01]",
+    "", "", ""
+  },
+  { "HGST Travelstar Z5K1000", // tested with HGST HTS541010A7E630/SE0OA4A0,
+      // HGST HTS541010B7E610/01.01A01
+    "HGST HTS5410(75|10)[AB]7E6(10|3[015])",
+    "", "", ""
+  },
+  { "HGST Travelstar 5K1500", // tested with HGST HTS541515A9E630/KA0OA500
+    "HGST HT[ES]541515A9E63[015]",
+    "", "", ""
+  },
+  { "Hitachi Travelstar 7K60",
+    "(Hitachi )?HTS726060M9AT00",
+    "", "", ""
+  },
+  { "Hitachi Travelstar E7K60",
+    "(Hitachi )?HTE7260[46]0M9AT00",
+    "", "", ""
+  },
+  { "Hitachi Travelstar 7K100",
+    "(Hitachi )?HTS7210[168]0G9(AT|SA)00",
+    "", "", ""
+  },
+  { "Hitachi Travelstar E7K100",
+    "(Hitachi )?HTE7210[168]0G9(AT|SA)00",
+    "", "", ""
+  },
+  { "Hitachi Travelstar 7K200", // tested with HITACHI HTS722016K9SA00/DCDZC75A
+    "(Hitachi |HITACHI )?HTS7220(80|10|12|16|20)K9(A3|SA)00",
+    "", "", ""
+  },
+  { "Hitachi Travelstar 7K320", // tested with HITACHI HTS723216L9SA60/FC2ZC50B,
+    // HTS723225L9A360/FCDOC30F, HTS723216L9A362/FC2OC39F
+    "(Hitachi |HITACHI )?HT[ES]7232(80|12|16|25|32)L9(A300|A36[02]|SA6[01])",
+    "", "", ""
+  },
+  { "Hitachi Travelstar Z7K320", // tested with HITACHI HTS723232A7A364/EC2ZB70B
+    "(HITACHI )?HT[ES]7232(16|25|32)A7A36[145]",
+    "", "", ""
+  },
+  { "Hitachi Travelstar 7K500", // tested with Hitachi HTS725050A9A360/PC4OC70D,
+    // HITACHI HTS725032A9A364/PC3ZC70F
+    "(Hitachi |HITACHI )?HT[ES]7250(12|16|25|32|50)A9A36[02-5]",
+    "", "", ""
+  },
+  { "Hitachi/HGST Travelstar Z7K500", // tested with HITACHI HTS725050A7E630/GH2ZB390,
+      // HGST HTS725050A7E630/GH2OA420, HGST HTS725050A7E630/GH2OA530
+    "(HITACHI|HGST) HT[ES]7250(25|32|50)A7E63[015]",
+    "", "", ""
+  },
+  { "Hitachi/HGST Travelstar 7K750", // tested with Hitachi HTS727550A9E364/JF3OA0E0,
+      // Hitachi HTS727575A9E364/JF4OA0D0
+    "(Hitachi|HGST) HT[ES]7275(50|64|75)A9E36[14]",
+    "", "", ""
+  },
+  { "HGST Travelstar 7K1000", // tested with HGST HTS721010A9E630/JB0OA3B0
+    // HGST HTS721075A9E630/JB2OA3J0
+    "HGST HT[ES]7210(10|75)A9E63[01]",
+    "", "", ""
+  },
+  { "IBM Deskstar 14GXP and 16GP",
+    "IBM-DTTA-3(7101|7129|7144|5032|5043|5064|5084|5101|5129|5168)0",
+    "", "", ""
+  },
+  { "IBM Deskstar 25GP and 22GXP",
+    "IBM-DJNA-3(5(101|152|203|250)|7(091|135|180|220))0",
+    "", "", ""
+  },
+  { "IBM Deskstar 37GP and 34GXP",
+    "IBM-DPTA-3(5(375|300|225|150)|7(342|273|205|136))0",
+    "", "", ""
+  },
+  { "IBM/Hitachi Deskstar 120GXP",
+    "(IBM-)?IC35L((020|040|060|080|120)AVVA|0[24]0AVVN)07-[01]",
+    "", "", ""
+  },
+  { "IBM/Hitachi Deskstar GXP-180",
+    "(IBM-)?IC35L(030|060|090|120|180)AVV207-[01]",
+    "", "", ""
+  },
+  { "Hitachi CinemaStar 5K320", // tested with Hitachi HCS5C3225SLA380/STBOA37H
+    "Hitachi HCS5C32(25|32)SLA380",
+    "", "", ""
+  },
+  { "Hitachi CinemaStar 5K1000", // Hitachi HCS5C1010CLA382/JC4OA3EA
+    "Hitachi HCS5C10(10|75|50|32|25|16)CLA382",
+    "", "", ""
+  },
+  { "Hitachi Deskstar 5K3000", // tested with HDS5C3030ALA630/MEAOA5C0,
+      // Hitachi HDS5C3020BLE630/MZ4OAAB0 (OEM, Toshiba Canvio Desktop)
+    "(Hitachi )?HDS5C30(15|20|30)(ALA|BLE)63[02].*",
+    "", "", ""
+  },
+  { "Hitachi/HGST Deskstar 5K4000", // tested with HDS5C4040ALE630/MPAOA250
+      // HGST HDS5C4040ALE630/MPAOA580
+    "(Hitachi |HGST )?HDS5C40(30|40)ALE63[01].*",
+    "", "", ""
+  },
+  { "Hitachi Deskstar 7K80",
+    "(Hitachi )?HDS7280([48]0PLAT20|(40)?PLA320|80PLA380).*",
+    "", "", ""
+  },
+  { "Hitachi Deskstar 7K160",
+    "(Hitachi )?HDS7216(80|16)PLA[3T]80.*",
+    "", "", ""
+  },
+  { "Hitachi Deskstar 7K250",
+    "(Hitachi )?HDS7225((40|80|12|16)VLAT20|(12|16|25)VLAT80|(80|12|16|25)VLSA80)",
+    "", "", ""
+  },
+  { "Hitachi Deskstar 7K250 (SUN branded)",
+    "HITACHI HDS7225SBSUN250G.*",
+    "", "", ""
+  },
+  { "Hitachi Deskstar T7K250",
+    "(Hitachi )?HDT7225((25|20|16)DLA(T80|380))",
+    "", "", ""
+  },
+  { "Hitachi Deskstar 7K400",
+    "(Hitachi )?HDS724040KL(AT|SA)80",
+    "", "", ""
+  },
+  { "Hitachi Deskstar 7K500",
+    "(Hitachi )?HDS725050KLA(360|T80)",
+    "", "", ""
+  },
+  { "Hitachi Deskstar P7K500",
+    "(Hitachi )?HDP7250(16|25|32|40|50)GLA(36|38|T8)0",
+    "", "", ""
+  },
+  { "Hitachi Deskstar T7K500",
+    "(Hitachi )?HDT7250(25|32|40|50)VLA(360|380|T80)",
+    "", "", ""
+  },
+  { "Hitachi Deskstar 7K1000",
+    "(Hitachi )?HDS7210(50|75|10)KLA330",
+    "", "", ""
+  },
+  { "Hitachi Deskstar 7K1000.B",
+    "(Hitachi )?HDT7210((16|25)SLA380|(32|50|64|75|10)SLA360)",
+    "", "", ""
+  },
+  { "Hitachi Deskstar 7K1000.C", // tested with Hitachi HDS721010CLA330/JP4OA3MA,
+      // Hitachi HDS721025CLA682/JP1OA41A
+    "(Hitachi )?HDS7210((16|25)CLA[36]82|(32|50)CLA[36]62|(64|75|10)CLA[36]3[02])",
+    "", "", ""
+  },
+  { "Hitachi Deskstar 7K1000.D", // tested with HDS721010DLE630/MS2OA5Q0
+    "Hitachi HDS7210(25|32|50|75|10)DLE630",
+    "", "", ""
+  },
+  { "Hitachi Deskstar E7K1000", // tested with HDE721010SLA330/ST6OA31B
+    "Hitachi HDE7210(50|75|10)SLA330",
+    "", "", ""
+  },
+  { "Hitachi Deskstar 7K2000",
+    "Hitachi HDS722020ALA330",
+    "", "", ""
+  },
+  { "Hitachi Deskstar 7K3000", // tested with Hitachi HDS723030ALA640/MKAOA3B0,
+      // Hitachi HDS723030BLE640/MX6OAAB0
+    "Hitachi HDS7230((15|20)BLA642|30ALA640|30BLE640)",
+    "", "", ""
+  },
+  { "Hitachi/HGST Deskstar 7K4000", // tested with Hitachi HDS724040ALE640/MJAOA250,
+      // HGST HDS724040ALE640/MJAOA580
+    "(Hitachi|HGST) HDS724040ALE640",
+    "", "", ""
+  },
+  { "HGST Deskstar NAS", // tested with HGST HDN724040ALE640/MJAOA5E0,
+      // HGST HDN726050ALE610/APGNT517, HGST HDN726060ALE610/APGNT517
+      // HGST HDN726040ALE614/APGNW7JH, HGST HDN726060ALE614/K1HE594D
+      // HGST HDN728080ALE604/A4GNW91X
+    "HGST HDN72(40[34]|60[456]|808)0ALE6(04|1[04]|40)",
+    "", "", ""
+  //"-v 22,raw48,Helium_Level" // HDN728080ALE604
+  },
+  { "Hitachi/HGST Ultrastar 5K3000", // tested with Hitachi HUA5C3030ALA640/MEAOA800
+    "(Hitachi |HGST )?HUA5C30(20|30)ALA64[01]",
+    "", "", ""
+  },
+  { "Hitachi Ultrastar A7K1000", // tested with
+    // HUA721010KLA330      44X2459 42C0424IBM/GKAOAB4A,,
+    // Hitachi HUA721075KLA330/GK8OA70M,
+    // HITACHI HUA721075KLA330/GK8OA90A
+    "(Hitachi |HITACHI )?HUA7210(50|75|10)KLA330.*",
+    "", "", ""
+  },
+  { "Hitachi Ultrastar A7K2000", // tested with
+    // HUA722010CLA330      43W7629 42C0401IBM
+    "(Hitachi )?HUA7220(50|10|20)[AC]LA33[01].*",
+    "", "", ""
+  },
+  { "Hitachi Ultrastar 7K3000", // tested with Hitachi HUA723030ALA640/MKAOA580,
+      // Hitachi HUA723020ALA641/MK7OA840, HUA723020ALA640/MK7OAAA0
+    "(Hitachi )?HUA7230(20|30)ALA64[01]",
+    "", "", ""
+  },
+  { "Hitachi/HGST Ultrastar 7K4000", // tested with Hitachi HUS724040ALE640/MJAOA3B0,
+      // HGST HUS724040ALE640/MJAOA580, HGST HUS724020ALA640/MF6OAA70,
+      // HUS724030ALA640/MF8OAAZ0, HITACHI HUS724040ALE640/MJAONS04,
+      // HGST HUS724045ALE640/MJBOA5G0
+    "(Hitachi |HITACHI |HGST )?HUS7240([234]0|45)AL[AE]64[01]",
+    "", "", ""
+  },
+  { "Hitachi/HGST Ultrastar 7K2",
+    "(Hitachi|HGST) HUS722T[12]TALA604",
+    "", "",
+    "-v 16,raw48,Gas_Gauge"
+  },
+  { "HGST Ultrastar 7K6000", // tested with HGST HUS726060ALE614/APGNW517
+    "HGST HUS7260[2456]0AL[AEN]61[014]",
+    "", "", ""
+  },
+  { "HGST Ultrastar HC310/320", // tested with HGST HUS726T6TALE6L4/VKGNW40H,
+      // HGST HUS728T8TALE6L4/V8GNW460, HGST HUS726T4TALA6L1/VLGNX41C
+    "HGST HUS72(6T[46]|8T8)TAL[AE]6L[14]",
+    "", "", ""
+  },
+  { "HGST Ultrastar He6", // tested with HGST HUS726060ALA640/AHGNT1E2
+    "HGST HUS726060ALA64[01]",
+    "", "", ""
+  //"-v 22,raw48,Helium_Level"
+  },
+  { "HGST Ultrastar He8", // tested with HGST HUH728060ALE600/GR2OA230
+    "HGST HUH7280(60|80)AL[EN]60[014]",
+    "", "", ""
+  //"-v 22,raw48,Helium_Level"
+  },
+  { "HGST Ultrastar He10", // tested with HGST HUH7210100ALE600/0F27452
+    "HGST HUH7210(08|10)AL[EN]60[014]",
+    "", "", ""
+  //"-v 22,raw48,Helium_Level"
+  },
+  { "Western Digital Ultrastar (He10/12)", // WD white label, tested with
+      // WDC WD80EMAZ-00WJTA0/83.H0A83 (Easystore 0x1058:0x25fb),
+      // WDC WD80EZAZ-11TDBA0/83.H0A83, WDC WD100EMAZ-00WJTA0/83.H0A83,
+      // WDC WD100EZAZ-11TDBA0/83.H0A83, WDC WD120EMAZ-11BLFA0/81.00A81
+      // WDC WD140EDFZ-11A0VA0/81.00A81 (Easystore 0x1058:0x25fb)
+      // WDC WD140EDGZ-11B2DA2/85.00A85, WDC WD140EDGZ-11B1PA0/85.00A85
+      // WDC WD120EDAZ-11F3RA0/81.00A81, WDC WD80EDAZ-11TA3A0/81.00A81
+      // WDC WD40EDAZ-11SLVB0/80.00A80
+    "WDC WD(40EDA|(80|100|120|140)E([MZ]A|DA|DF|DG))Z-.*",
+    "", "", ""
+  //"-v 22,raw48,Helium_Level" // not: WD80EDAZ, WD40EDAZ
+  },
+  { "HGST Ultrastar DC HC520 (He12)", // tested with HGST HUH721212ALE600/LEGNT3D0
+    "HGST HUH721212AL[EN]60[014]",
+    "", "", ""
+  //"-v 22,raw48,Helium_Level"
+  },
+  { "Western Digital Ultrastar DC HC530", // tested with
+      // WDC  WUH721414ALE604/LDAZW110, WDC  WUH721414ALE6L4/LDGNW07G
+    "WDC  ?WUH721414ALE6[0L]4",
+    "", "",
+  //"-v 22,raw48,Helium_Level "
+    "-v 188,raw16 "
+  },
+  { "Western Digital Ultrastar DC HC550", // tested with WDC  WUH721818ALE6L4/PCGNW110,
+      // WUH721818ALE6L4/PCGAW232, WDC  WUH721818ALN6L4/PCGNW088
+    "(WDC  ?)?WUH72181[68]AL[EN]6[0L][0146]",
+    "", "", ""
+  //"-v 22,raw48,Helium_Level"
+  },
+  { "Western Digital Ultrastar DC HC560", // tested with WDC  WUH722020ALN604/PQGNW108
+    // WDC WUH722020BLE6L4
+    "(WDC  ?)?WUH722020[AB]L[EN]6[0L][014]",
+    "", "",
+  //"-v 22,raw48,Helium_Level "
+    "-v 82,raw16,Head_Health_Score "
+    "-v 90,hex48,NAND_Master"
+  },
+  { "Western Digital Ultrastar DC HC570", // tested with WUH722222ALE604
+    "(WDC  ?)?WUH722222[AB]L[EN]6[0L]4",
+    "", "",
+  //"-v 22,raw48,Helium_Level "
+    "-v 71,raw16,Milli_Micro_Actuator "
+    "-v 82,raw16,Head_Health_Score "
+    "-v 90,hex48,NAND_Master"
+  },
+  { "Western Digital Ultrastar DC HC650", // tested with WDC  WSH722020ALE6L0/PCGMT421
+    "(WDC  ?)?WSH7220(20|VC)AL[EN]6[0L][0146]",
+    "", "", ""
+  //"-v 22,raw48,Helium_Level"
+  },
+  { "Western Digital Ultrastar DC HC670", // WSH722626ALE604
+    "(WDC  ?)?WSH722222[AB]L[EN]6[0L]4",
+    "", "",
+  //"-v 22,raw48,Helium_Level "
+    "-v 71,raw16,Milli_Micro_Actuator "
+    "-v 82,raw16,Head_Health_Score "
+    "-v 90,hex48,NAND_Master"
+  },
+  { "HGST MegaScale 4000", // tested with HGST HMS5C4040ALE640/MPAOA580
+    "HGST HMS5C4040[AB]LE64[01]", // B = DC 4000.B
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD (10-20 GB)",
+    "TOSHIBA MK(101[67]GAP|15[67]GAP|20(1[678]GAP|(18|23)GAS))",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD (30-60 GB)",
+    "TOSHIBA MK((6034|4032)GSX|(6034|4032)GAX|(6026|4026|4019|3019)GAXB?|(6025|6021|4025|4021|4018|3025|3021|3018)GAS|(4036|3029)GACE?|(4018|3017)GAP)",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD (80 GB and above)",
+    "TOSHIBA MK(80(25GAS|26GAX|32GAX|32GSX)|10(31GAS|32GAX)|12(33GAS|34G[AS]X)|2035GSS)",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MK..37GSX", // tested with TOSHIBA MK1637GSX/DL032C
+    "TOSHIBA MK(12|16)37GSX",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MK..46GSX", // tested with TOSHIBA MK1246GSX/LB213M
+    "TOSHIBA MK(80|12|16|25)46GSX",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MK..50GACY", // tested with TOSHIBA MK8050GACY/TF105A
+    "TOSHIBA MK8050GACY",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MK..34GSX", // tested with TOSHIBA MK8034GSX/AH301E
+    "TOSHIBA MK(80|12|10)34GSX",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MK..32GSX", // tested with TOSHIBA MK1032GSX/AS021G
+    "TOSHIBA MK(10|80|60|40)32GSX",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MK..51GSY", // tested with TOSHIBA MK1251GSY/LD101D
+    "TOSHIBA MK(80|12|16|25)51GSY",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Toshiba 2.5\" HDD MK..52GSX", // tested with TOSHIBA MK3252GSX/LV010A
+    "TOSHIBA MK(80|12|16|25|32)52GSX",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MK..55GSX", // tested with TOSHIBA MK5055GSX/FG001A, MK3255GSXF/FH115B
+    "TOSHIBA MK(12|16|25|32|40|50)55GSXF?",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MK..56GSY", // tested with TOSHIBA MK2556GSYF/LJ001D
+    "TOSHIBA MK(16|25|32|50)56GSYF?",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Toshiba 2.5\" HDD MK..59GSXP (AF)",
+    "TOSHIBA MK(32|50|64|75)59GSXP?",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MK..59GSM (AF)",
+    "TOSHIBA MK(75|10)59GSM",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MK..61GSY[N]", // tested with TOSHIBA MK5061GSY/MC102E, MK5061GSYN/MH000A,
+      // TOSHIBA MK2561GSYN/MH000D
+    "TOSHIBA MK(16|25|32|50|64)61GSYN?",
+    "",
+    "",
+    "-v 9,minutes" // TOSHIBA MK2561GSYN/MH000D
+  },
+  { "Toshiba 2.5\" HDD MK..61GSYB", // tested with TOSHIBA MK5061GSYB/ME0A
+    "TOSHIBA MK(16|25|32|50|64)61GSYB",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MK..65GSX", // tested with TOSHIBA MK5065GSX/GJ003A, MK3265GSXN/GH012H,
+      // MK5065GSXF/GP006B, MK2565GSX H/GJ003A
+    "TOSHIBA MK(16|25|32|50|64)65GSX[FN]?( H)?", // "... H" = USB ?
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MK..75GSX", // tested with TOSHIBA MK7575GSX/GT001C
+    "TOSHIBA MK(32|50|64|75)75GSX",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MK..76GSX/GS001A", // tested with TOSHIBA MK2576GSX/GS001A
+    "TOSHIBA MK(16|25|32|50|64)76GSX",
+    "GS001A",
+    "", ""
+  },
+  { "Toshiba 2.5\" HDD MK..76GSX", // tested with TOSHIBA MK3276GSX/GS002D
+    "TOSHIBA MK(16|25|32|50|64)76GSX",
+    "",
+    "",
+    "-v 9,minutes"
+  },
+  { "Toshiba 2.5\" HDD MQ01ABB...", // tested with TOSHIBA MQ01ABB200/AY000U
+    "TOSHIBA MQ01ABB(100|150|200)",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MQ01ABC...", // tested with TOSHIBA MQ01ABC150/AQ001U
+    "TOSHIBA MQ01ABC(100|150|200)",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MQ01ABD...", // tested with TOSHIBA MQ01ABD100/AX001U,
+      // TOSHIBA MQ01ABD100/AX1R4C, TOSHIBA MQ01ABD100V/AX001Q
+    "TOSHIBA MQ01ABD(025|032|050|064|075|100)V?",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MQ01ABF...", // tested with TOSHIBA MQ01ABF050/AM001J,
+      // TOSHIBA MQ01ABF032/AM001J 
+    "TOSHIBA MQ01ABF(032|050|075|100)",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MQ01UBB... (USB 3.0)", // tested with TOSHIBA MQ01UBB200/AY000U (0x0480:0xa100),
+      // TOSHIBA MQ01UBB200/34MATMZ5T (0x05ac:0x8406)
+    "TOSHIBA MQ01UBB200",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MQ01UBD... (USB 3.0)", // tested with TOSHIBA MQ01UBD050/AX001U (0x0480:0xa007),
+      // TOSHIBA MQ01UBD100/AX001U (0x0480:0x0201, 0x0480:0xa200),
+      // TOSHIBA MQ01UBD050/AX101U (0x0480:0xa202)
+    "TOSHIBA MQ01UBD(050|075|100)",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MQ04UBF... (USB 3.0)", // tested with TOSHIBA MQ04UBF100/JU000U (0x0480:0xa202)
+    "TOSHIBA MQ04UBF100",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MQ04UBD...", // tested with TOSHIBA MQ04UBD200/68U2T2VWT
+    "TOSHIBA MQ04UBD200",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MQ03ABB...", // tested with TOSHIBA MQ03ABB300
+    "TOSHIBA MQ03ABB[23]00",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MQ03UBB...", // tested with TOSHIBA MQ03UBB200/37I7T0NJT
+    "TOSHIBA MQ03UBB(300|200|250)",
+    "", "", ""
+  },
+  { "Toshiba 2.5\" HDD MQ04UBB... (USB, SMR)", // tested with TOSHIBA MQ04UBB400/JS000U,
+      // TOSHIBA MQ04UBB400/JS0B0U (0x0480:0xa301) ('Device managed zones', no TRIM support)
+    "TOSHIBA MQ04UBB[24]00",
+    "", "", ""
+  },
+  { "Toshiba 3.5\" HDD MK.002TSKB", // tested with TOSHIBA MK1002TSKB/MT1A
+    "TOSHIBA MK(10|20)02TSKB",
+    "", "", ""
+  },
+  { "Toshiba 3.5\" MG03ACAxxx(Y) Enterprise HDD", // tested with TOSHIBA MG03ACA100/FL1A
+    "TOSHIBA MG03ACA[1234]00Y?",
+    "", "", ""
+  },
+  { "Toshiba MD04ACA... Enterprise HDD", // tested with TOSHIBA MD04ACA500/FP1A
+    "TOSHIBA MD04ACA[2-6]00N?",
+    "", "", ""
+  },
+  { "Toshiba MG04ACA... Enterprise HDD", // tested with TOSHIBA MG04ACA600A/FS2B,
+      // TOSHIBA MG04ACA400NY/FK5D (Dell)
+    "TOSHIBA MG04ACA[1-6]00[AEN]Y?",
+    "", "", ""
+  },
+  { "Toshiba MG05ACA... Enterprise Capacity HDD", // tested with TOSHIBA MG05ACA800E/GX2A
+    "TOSHIBA MG05ACA800[AE]",
+    "", "", ""
+  },
+  { "Toshiba MG06ACA... Enterprise Capacity HDD", // tested with TOSHIBA MG06ACA800E/0109,
+      // TOSHIBA MG06ACA800E/4303, TOSHIBA MG06ACA10TE/0103,
+    "TOSHIBA MG06ACA([68]00|10T)[AE]Y?",
+    "", "", ""
+  },
+  { "Toshiba MG07ACA... Enterprise Capacity HDD", // tested with TOSHIBA MG07ACA14TE/0101
+    "TOSHIBA MG07ACA1[24]T[AE]Y?",
+    "", "", ""
+  //"-v 23,raw48,Helium_Condition_Lower "
+  //"-v 24,raw48,Helium_Condition_Upper"
+  },
+  { "Toshiba MG08ACA... Enterprise Capacity HDD", // tested with TOSHIBA MG08ACA14TE/0102,
+      // TOSHIBA MG08ACA16TE/0102
+    "TOSHIBA MG08ACA1[46]T[AE]Y?",
+    "", "", ""
+  //"-v 23,raw48,Helium_Condition_Lower "
+  //"-v 24,raw48,Helium_Condition_Upper"
+  },
+  { "Toshiba MG08ADA... Enterprise Capacity HDD", // tested with TOSHIBA MG08ADA800E/0101,
+      // TOSHIBA MG08ADA800E/4303, TOSHIBA MG08ADA800E/4304
+    "TOSHIBA MG08ADA[468]00[AEN]Y?",
+    "", "", ""
+  },
+  { "Toshiba MG09ACA... Enterprise Capacity HDD", // tested with TOSHIBA MG09ACA18TE/0102,
+      // "MG09ACA12TE          01GV181D7A01906LEN/BB3A"
+    "(TOSHIBA )?MG09ACA1[02468]T[AE]Y?( .*LEN)?",
+    "", "",
+  //"-v 23,raw48,Helium_Condition_Lower "
+  //"-v 24,raw48,Helium_Condition_Upper "
+    "-v 27,raw48,MAMR_Health_Monitor"
+  },
+  { "Toshiba MG10ACA... Enterprise Capacity HDD", // tested with TOSHIBA MG10ACA20TE/0102
+    "TOSHIBA MG10ACA20T[AE]Y?",
+    "", "",
+  //"-v 23,raw48,Helium_Condition_Lower "
+  //"-v 24,raw48,Helium_Condition_Upper "
+    "-v 27,raw48,MAMR_Health_Monitor"
+  },
+  { "Toshiba MG10ADA... Enterprise Capacity HDD", // tested with TOSHIBA MG10ADA10TE/0101
+    "TOSHIBA MG10ADA([12468]00|10T)[EN]",
+    "", "",
+  //"-v 23,raw48,Helium_Condition_Lower "
+  //"-v 24,raw48,Helium_Condition_Upper "
+    "-v 27,raw48,MAMR_Health_Monitor"
+  },
+  { "Toshiba MG10AFA... Enterprise Capacity HDD", // tested with TOSHIBA MG10AFA22TE/0102
+    "TOSHIBA MG10AFA22T[AE]Y?",
+    "", "",
+  //"-v 23,raw48,Helium_Condition_Lower "
+  //"-v 24,raw48,Helium_Condition_Upper "
+    "-v 27,raw48,MAMR_Health_Monitor"
+  },
+  { "Toshiba MG11 Cloud-scale Capacity HDD", // tested with TOSHIBA MG11ACA24TE/0102
+    "TOSHIBA MG11AC[AP](1[468]|2[024])TEY?", // ACP = self-encrypting device (SED)
+    "", "",                                  // TEY = sanitize instant erase (SIE)
+  //"-v 23,raw48,Helium_Condition_Lower "
+  //"-v 24,raw48,Helium_Condition_Upper "
+    "-v 27,raw48,MAMR_Health_Monitor"
+  },
+  { "Toshiba 3.5\" DT01ABA... Desktop HDD", // tested with TOSHIBA DT01ABA300/MZ6OABB0
+    "TOSHIBA DT01ABA(100|150|200|300)",
+    "", "", ""
+  },
+  { "Toshiba 3.5\" DT01ACA... Desktop HDD", // tested with TOSHIBA DT01ACA100/MS2OA750,
+      // TOSHIBA DT01ACA200/MX4OABB0, TOSHIBA DT01ACA300/MX6OABB0
+    "TOSHIBA DT01ACA(025|032|050|075|100|150|200|300)",
+    "", "", ""
+  },
+  { "Toshiba N300/MN NAS HDD", // tested with TOSHIBA HDWQ140/FJ1M, TOSHIBA HDWN160/FS1M,
+      // TOSHIBA HDWN180/GX2M, TOSHIBA HDWG440/0601 (4TB), TOSHIBA HDWG480/0601 (8TB),
+      // TOSHIBA HDWG11A/0603 (10TB), TOSHIBA HDWG21C/0601 (12TB), TOSHIBA HDWG21E/0601 (14TB), 
+      // TOSHIBA MN07ACA12T/0601, TOSHIBA MN08ACA14T/0601, TOSHIBA HDWG51J/0104 (18TB)
+    "TOSHIBA HDW([GNQ]1[468]0|G(440|480|11A|21[CE]|31[EG]|51[EJ]))|" // 31G: 16TB
+    "TOSHIBA MN0(4ACA400|6ACA([68]00|10T)|7ACA1[24]T|8ACA1[46]T)",
+    "", "",
+  //"-v 23,raw48,Helium_Condition_Lower " // ] >= 12TB
+  //"-v 24,raw48,Helium_Condition_Upper " // ]
+    "-v 27,raw48,MAMR_Health_Monitor" // HDWG51J/0104
+  },
+  { "Toshiba P300 (CMR)", // tested with TOSHIBA HDWD120/MX4OACF0
+    "TOSHIBA HDWD1(05|10|20|30)",
+    "", "", ""
+  },
+  { "Toshiba P300 (SMR)", // tested with TOSHIBA HDWD240/KQ000A
+    "TOSHIBA HDWD2[246]0",
+    "", "", ""
+  },
+  { "Toshiba S300 (SMR)", // tested with TOSHIBA HDWT860/KQ0H1L
+    "TOSHIBA HDWT(7[24]|8[46])0",
+    "", "", ""
+  },
+  { "Toshiba X300", // tested with TOSHIBA HDWE160/FS2A, TOSHIBA HDWF180/GX0B
+      // TOSHIBA HDWR480/0601
+    "TOSHIBA HDW(E1[456]0|[FR]180|R(4[468]0|11A|21[CE]|31[EG]|51J))", // 4n0:nTB, 11A:10TB,
+      // 21C:12TB, 21E:14TB, 31E:14TB, 31G:16TB, 51J:18TB
+    "", "", ""
+  //"-v 23,raw48,Helium_Condition_Lower " // ] >= 12TB
+  //"-v 24,raw48,Helium_Condition_Upper"  // ]
+  },
+  { "Toshiba L200 (CMR)",
+    "TOSHIBA HDW[JK]1(05|10)",
+    "", "", ""
+  },
+  { "Toshiba L200 (SMR)", // tested with TOSHIBA HDWL110/JU000A. TOSHIBA HDWL120/JT000A
+    "TOSHIBA HDWL1[12]0",
+    "", "", ""
+  },
+  { "Toshiba 1.8\" HDD",
+    "TOSHIBA MK[23468]00[4-9]GA[HL]",
+    "", "", ""
+  },
+  { "Toshiba 1.8\" HDD MK..29GSG",
+    "TOSHIBA MK(12|16|25)29GSG",
+    "", "", ""
+  },
+  { "", // TOSHIBA MK6022GAX
+    "TOSHIBA MK6022GAX",
+    "", "", ""
+  },
+  { "Toshiba HK4R Series SSD", // TOSHIBA THNSN8960PCSE/8EET6101
+    "TOSHIBA THNSN8(120P|240P|480P|960P|1Q92)CSE",
+    "", "",
+    "-v 167,raw48,SSD_Protect_Mode "
+    "-v 168,raw48,SATA_PHY_Error_Count "
+    "-v 169,raw48,Bad_Block_Count "
+    "-v 173,raw48,Erase_Count "
+  },
+  { "Toshiba HG6 Series SSD", // TOSHIBA THNSNJ512GCST/JTRA0102
+    // http://www.farnell.com/datasheets/1852757.pdf
+    // TOSHIBA THNSFJ256GCSU/JULA1102
+    // TOSHIBA THNSFJ256GDNU A/JYLA1102
+    "TOSHIBA THNS[NF]J(060|128|256|512)G[BCAM8VD][SCN][TU].*",
+    "", "",
+    "-v 167,raw48,SSD_Protect_Mode "
+    "-v 168,raw48,SATA_PHY_Error_Count "
+    "-v 169,raw48,Bad_Block_Count "
+    "-v 173,raw48,Erase_Count "
+  },
+  { "", // TOSHIBA MK6409MAV
+    "TOSHIBA MK6409MAV",
+    "", "", ""
+  },
+  { "Toshiba MKx019GAXB (SUN branded)",
+    "TOS MK[34]019GAXB SUN[34]0G",
+    "", "", ""
+  },
+  { "Seagate Momentus",
+    "ST9(20|28|40|48)11A",
+    "", "", ""
+  },
+  { "Seagate Momentus 42",
+    "ST9(2014|3015|4019)A",
+    "", "", ""
+  },
+  { "Seagate Momentus 4200.2", // tested with ST960812A/3.05
+    "ST9(100822|808210|60812|50212|402113|30219)A",
+    "", "", ""
+  },
+  { "Seagate Momentus 5400.2",
+    "ST9(808211|6082[12]|408114|308110|120821|10082[34]|8823|6812|4813|3811)AS?",
+    "", "", ""
+  },
+  { "Seagate Momentus 5400.3",
+    "ST9(4081[45]|6081[35]|8081[15]|100828|120822|160821)AS?",
+    "", "", ""
+  },
+  { "Seagate Momentus 5400.3 ED",
+    "ST9(4081[45]|6081[35]|8081[15]|100828|120822|160821)AB",
+    "", "", ""
+  },
+  { "Seagate Momentus 5400.4",
+    "ST9(120817|(160|200|250)827)AS",
+    "", "", ""
+  },
+  { "Seagate Momentus 5400.5",
+    "ST9((80|120|160)310|(250|320)320)AS",
+    "", "", ""
+  },
+  { "Seagate Momentus 5400.6",
+    "ST9(80313|160(301|314)|(12|25)0315|250317|(320|500)325|500327|640320)ASG?",
+    "", "",
+    "-F xerrorlba" // ST9500325AS/0002SDM1 (ticket #1094)
+  },
+  { "Seagate Momentus 5400.7",
+    "ST9(160316|(250|320)310|(500|640)320)AS",
+    "", "", ""
+  },
+  { "Seagate Momentus 5400.7 (AF)", // tested with ST9640322AS/0001BSM2
+      // (device reports 4KiB LPS with 1 sector offset)
+    "ST9(320312|400321|640322|750423)AS",
+    "", "", ""
+  },
+  { "Seagate Momentus 5400 PSD", // Hybrid drives
+    "ST9(808212|(120|160)8220)AS",
+    "", "", ""
+  },
+  { "Seagate Momentus 7200.1",
+    "ST9(10021|80825|6023|4015)AS?",
+    "", "", ""
+  },
+  { "Seagate Momentus 7200.2",
+    "ST9(80813|100821|120823|160823|200420)ASG?",
+    "", "", ""
+  },
+  { "Seagate Momentus 7200.3",
+    "ST9((80|120|160)411|(250|320)421)ASG?",
+    "", "", ""
+  },
+  { "Seagate Momentus 7200.4",
+    "ST9(160412|250410|320423|500420)ASG?",
+    "", "", ""
+  },
+  { "Seagate Momentus 7200 FDE.2",
+    "ST9((160413|25041[12]|320426|50042[12])AS|(16041[489]|2504[16]4|32042[67]|500426)ASG)",
+    "", "", ""
+  },
+  { "Seagate Momentus 7200.5", // tested with ST9750420AS/0001SDM5, ST9750420AS/0002SDM1
+    "ST9(50042[34]|64042[012]|75042[02])ASG?",
+    "", "", ""
+  },
+  { "Seagate Momentus XT", // fixed firmware
+    "ST9(2505610|3205620|5005620)AS",
+    "SD2[68]", // http://knowledge.seagate.com/articles/en_US/FAQ/215451en
+    "", ""
+  },
+  { "Seagate Momentus XT", // buggy firmware, tested with ST92505610AS/SD24
+    "ST9(2505610|3205620|5005620)AS",
+    "SD2[45]",
+    "These drives may corrupt large files,\n"
+    "AND THIS FIRMWARE VERSION IS AFFECTED,\n"
+    "see the following web pages for details:\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/215451en\n"
+    "https://superuser.com/questions/313447/seagate-momentus-xt-corrupting-files-linux-and-mac",
+    ""
+  },
+  { "Seagate Momentus XT", // unknown firmware
+    "ST9(2505610|3205620|5005620)AS",
+    "",
+    "These drives may corrupt large files,\n"
+    "see the following web pages for details:\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/215451en\n"
+    "https://superuser.com/questions/313447/seagate-momentus-xt-corrupting-files-linux-and-mac",
+    ""
+  },
+  { "Seagate Momentus XT (AF)", // tested with ST750LX003-1AC154/SM12
+    "ST750LX003-.*",
+    "", "", ""
+  },
+  { "Seagate Momentus Thin", // tested with ST320LT007-9ZV142/0004LVM1
+    "ST(160|250|320)LT0(07|09|11|14)-.*",
+    "", "", ""
+  },
+  { "Seagate Laptop HDD", // tested with ST500LT012-9WS142/0001SDM1,
+      // ST500LM021-1KJ152/0002LIM1, ST4000LM016-1N2170/0003
+    "ST((25|32|50)0LT0(12|15|25)|(32|50)0LM0(10|21)|[34]000LM016)-.*",
+    "", "", ""
+  },
+  { "Seagate Laptop SSHD", // tested with ST500LM000-1EJ162/SM11
+    "ST(500|1000)LM0(00|14)-.*",
+    "", "", ""
+  },
+  { "Seagate Medalist 1010, 1720, 1721, 2120, 3230 and 4340",  // ATA2, with -t permissive
+    "ST3(1010|1720|1721|2120|3230|4340)A",
+    "", "", ""
+  },
+  { "Seagate Medalist 2110, 3221, 4321, 6531, and 8641",
+    "ST3(2110|3221|4321|6531|8641)A",
+    "", "", ""
+  },
+  { "Seagate U4",
+    "ST3(2112|4311|6421|8421)A",
+    "", "", ""
+  },
+  { "Seagate U5",
+    "ST3(40823|30621|20413|15311|10211)A",
+    "", "", ""
+  },
+  { "Seagate U6",
+    "ST3(8002|6002|4081|3061|2041)0A",
+    "", "", ""
+  },
+  { "Seagate U7",
+    "ST3(30012|40012|60012|80022|120020)A",
+    "", "", ""
+  },
+  { "Seagate U8",
+    "ST3(4313|6811|8410|4313|13021|17221)A",
+    "", "", ""
+  },
+  { "Seagate U9", // tested with ST3160022ACE/9.51
+    "ST3(80012|120025|160022)A(CE)?",
+    "", "", ""
+  },
+  { "Seagate U10",
+    "ST3(20423|15323|10212)A",
+    "", "", ""
+  },
+  { "Seagate UX",
+    "ST3(10014A(CE)?|20014A)",
+    "", "", ""
+  },
+  { "Seagate Barracuda ATA",
+    "ST3(2804|2724|2043|1362|1022|681)0A",
+    "", "", ""
+  },
+  { "Seagate Barracuda ATA II",
+    "ST3(3063|2042|1532|1021)0A",
+    "", "", ""
+  },
+  { "Seagate Barracuda ATA III",
+    "ST3(40824|30620|20414|15310|10215)A",
+    "", "", ""
+  },
+  { "Seagate Barracuda ATA IV",
+    "ST3(20011|30011|40016|60021|80021)A",
+    "", "", ""
+  },
+  { "Seagate Barracuda ATA V",
+    "ST3(12002(3A|4A|9A|3AS)|800(23A|15A|23AS)|60(015A|210A)|40017A)",
+    "", "", ""
+  },
+  { "Seagate Barracuda 5400.1",
+    "ST340015A",
+    "", "", ""
+  },
+  { "Seagate Barracuda 7200.7 and 7200.7 Plus", // tested with "ST380819AS          39M3701 39M0171 IBM"/3.03
+    "ST3(200021A|200822AS?|16002[13]AS?|12002[26]AS?|1[26]082[78]AS|8001[13]AS?|8081[79]AS|60014A|40111AS|40014AS?)( .* IBM)?",
+    "", "", ""
+  },
+  { "Seagate Barracuda 7200.8",
+    "ST3(400[68]32|300[68]31|250[68]23|200826)AS?",
+    "", "", ""
+  },
+  { "Seagate Barracuda 7200.9",
+    "ST3(402111?|80[28]110?|120[28]1[0134]|160[28]1[012]|200827|250[68]24|300[68]22|(320|400)[68]33|500[68](32|41))AS?.*",
+    "", "", ""
+  },
+  { "Seagate Barracuda 7200.10", // tested with GB0160EAFJE/HPG0
+    "ST3((80|160)[28]15|200820|250[34]10|(250|300|320|400)[68]20|360320|500[68]30|750[68]40)AS?|"
+    "GB0160EAFJE", // HP OEM
+    "", "", ""
+  },
+  { "Seagate Barracuda 7200.11", // unaffected firmware
+    "ST3(160813|320[68]13|500[368]20|640[36]23|640[35]30|750[36]30|1000(333|[36]40)|1500341)AS?",
+    "CC.?.?", // http://knowledge.seagate.com/articles/en_US/FAQ/207957en
+    "", ""
+  },
+  { "Seagate Barracuda 7200.11", // fixed firmware
+    "ST3(500[368]20|750[36]30|1000340)AS?",
+    "SD1A", // http://knowledge.seagate.com/articles/en_US/FAQ/207951en
+    "", ""
+  },
+  { "Seagate Barracuda 7200.11", // fixed firmware
+    "ST3(160813|320[68]13|640[36]23|1000333|1500341)AS?",
+    "SD[12]B", // http://knowledge.seagate.com/articles/en_US/FAQ/207957en
+    "", ""
+  },
+  { "Seagate Barracuda 7200.11", // buggy or fixed firmware
+    "ST3(500[368]20|640[35]30|750[36]30|1000340)AS?",
+    "(AD14|SD1[5-9]|SD81)",
+    "There are known problems with these drives,\n"
+    "THIS DRIVE MAY OR MAY NOT BE AFFECTED,\n"
+    "see the following web pages for details:\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/207931en\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/207951en\n"
+    "https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=632758",
+    ""
+  },
+  { "Seagate Barracuda 7200.11", // unknown firmware
+    "ST3(160813|320[68]13|500[368]20|640[36]23|640[35]30|750[36]30|1000(333|[36]40)|1500341)AS?",
+    "",
+    "There are known problems with these drives,\n"
+    "see the following Seagate web pages:\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/207931en\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/207951en\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/207957en",
+    ""
+  },
+  { "Seagate Barracuda 7200.12", // new firmware, tested with ST3500418AS/HP34
+    "ST3(160318|250318|320418|50041[08]|750528|1000528)AS",
+    "CC4[9A-Z]|HP34", // HP34: 180 Unknown_HDD_Attribute
+    "", ""
+  },
+  { "Seagate Barracuda 7200.12", // unknown firmware
+    "ST3(160318|250318|320418|50041[08]|750528|1000528)AS",
+    "",
+    "A firmware update for this drive may be available,\n"
+    "see the following Seagate web pages:\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/207931en\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/213891en",
+    ""
+  },
+  { "Seagate Barracuda 7200.12", // tested with ST3160316AS/JC45, ST3250312AS/JC45,
+      // ST3500413AS/JC47, ST3500413AS/JC4B, ST3750525AS/JC4B, ST31000524AS/JC45,
+      // ST31000524AS/JC4B
+    "ST3(160318|25031[128]|320418|50041[038]|750(518|52[358])|100052[348]|320413|160316)AS",
+    "", "", ""
+    "-v 188,raw16 -v 240,msec24hour32"
+  },
+  { "Seagate Barracuda XT", // tested with ST32000641AS/CC13,
+      // ST4000DX000-1C5160/CC42
+    "ST(3(2000641|3000651)AS|4000DX000-.*)",
+    "", "", ""
+  },
+  { "Seagate Barracuda 7200.14 (AF)", // new firmware, tested with
+      // ST3000DM001-9YN166/CC4H, ST3000DM001-9YN166/CC9E
+    "ST(1000|1500|2000|2500|3000)DM00[1-3]-9YN16.",
+    "CC(4[H-Z]|[5-9A-Z]..*)", // >= "CC4H"
+    "",
+    "-v 188,raw16 -v 240,msec24hour32" // tested with ST3000DM001-9YN166/CC4H
+  },
+  { "Seagate Barracuda 7200.14 (AF)", // old firmware, tested with
+      // ST1000DM003-9YN162/CC46
+    "ST(1000|1500|2000|2500|3000)DM00[1-3]-9YN16.",
+    "CC4[679CG]",
+    "A firmware update for this drive is available,\n"
+    "see the following Seagate web pages:\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/207931en\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/223651en",
+    "-v 188,raw16 -v 240,msec24hour32"
+  },
+  { "Seagate Barracuda 7200.14 (AF)", // unknown firmware
+    "ST(1000|1500|2000|2500|3000)DM00[1-3]-9YN16.",
+    "",
+    "A firmware update for this drive may be available,\n"
+    "see the following Seagate web pages:\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/207931en\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/223651en",
+    "-v 188,raw16 -v 240,msec24hour32"
+  },
+  { "Seagate Barracuda 7200.14 (AF)", // different part number, tested with
+      // ST1000DM003-1CH162/CC47, ST1000DM003-1CH162/CC49, ST2000DM001-1CH164/CC24,
+      // ST1000DM000-9TS15E/CC92, APPLE HDD ST3000DM001/AP15 (no attr 240)
+    "ST(1000|1500|2000|2500|3000)DM00[0-3]-.*|"
+    "APPLE HDD ST3000DM001",
+    "", "",
+    "-v 188,raw16 -v 240,msec24hour32"
+  },
+  { "Seagate Barracuda 7200.14 (AF)", // < 1TB, tested with ST250DM000-1BC141
+    "ST(250|320|500|750)DM00[0-3]-.*",
+    "", "",
+    "-v 188,raw16 -v 240,msec24hour32"
+  },
+  { "Seagate BarraCuda 3.5 (CMR)", // tested with ST1000DM010-2EP102/CC43,
+      // ST3000DM008-2DM166/CC26, ST4000DM006-2G5107/DN02, ST10000DM0004-1ZC101/DN01,
+      // ST12000DM0007-2GR116/DN01
+    "ST(500DM009|1000DM010|2000DM00[67]|3000DM00[89]|4000DM006|6000DM004|8000DM005|10000DM0004|12000DM0007)-.*",
+    "", "",
+    "-v 200,raw48,Pressure_Limit "
+    "-v 188,raw16 -v 240,msec24hour32"
+  },
+  { "Seagate BarraCuda 3.5 (SMR)", // tested with ST2000DM008-2FR102/0001,
+      // ST4000DM004-2CV104/0001 (TRIM: no), ST4000DM005-2DP166/0001, ST8000DM004-2CX188/0001
+    "ST(2000DM00[589]|3000DM007|4000DM00[45]|6000DM003|8000DM004)-.*",
+    "", "",
+    "-v 9,msec24hour32 " // ST4000DM004-2CV104/0001
+    "-v 200,raw48,Pressure_Limit "
+    "-v 188,raw16 -v 240,msec24hour32"
+  },
+  { "Seagate Desktop HDD.15", // tested with ST4000DM000-1CD168/CC43, ST5000DM000-1FK178/CC44,
+      // ST6000DM001-1XY17Z/CC48
+    "ST[4568]000DM00[012]-.*",
+    "", "",
+    "-v 188,raw16 -v 240,msec24hour32"
+  },
+  { "Seagate Desktop SSHD", // tested with ST2000DX001-1CM164/CC43
+    "ST[124]000DX001-.*",
+    "", "",
+    "-v 188,raw16 -v 240,msec24hour32"
+  },
+  { "Seagate Barracuda LP", // new firmware
+    "ST3(500412|1000520|1500541|2000542)AS",
+    "CC3[5-9A-Z]",
+    "",
+    "" // -F xerrorlba ?
+  },
+  { "Seagate Barracuda LP", // unknown firmware
+    "ST3(500412|1000520|1500541|2000542)AS",
+    "",
+    "A firmware update for this drive may be available,\n"
+    "see the following Seagate web pages:\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/207931en\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/213915en",
+    "-F xerrorlba" // tested with ST31000520AS/CC32
+  },
+  { "Seagate Barracuda Green (AF)", // new firmware
+    "ST((10|15|20)00DL00[123])-.*",
+    "CC(3[2-9A-Z]|[4-9A-Z]..*)", // >= "CC32"
+    "", ""
+  },
+  { "Seagate Barracuda Green (AF)", // unknown firmware
+    "ST((10|15|20)00DL00[123])-.*",
+    "",
+    "A firmware update for this drive may be available,\n"
+    "see the following Seagate web pages:\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/207931en\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/218171en",
+    ""
+  },
+  { "Seagate Barracuda ES",
+    "ST3(250[68]2|32062|40062|50063|75064)0NS",
+    "", "", ""
+  },
+  // ST5000LM000, ST4000LM024, ST3000LM024, ST2000LM015, ST1000LM048, ST500LM030
+  { "Seagate Barracuda 2.5 5400", // ST2000LM015-2E8174/SDM1, ST4000LM024-2AN17V/0001
+    "ST(5000LM000|[34]000LM024|2000LM015|1000LM048|500LM030)-.*",
+    "",
+    "",
+    "-v 183,raw48,SATA_Downshift_Count "
+  },
+  { "Seagate Barracuda ES.2", // fixed firmware
+    "ST3(25031|50032|75033|100034)0NS",
+    "SN[01]6|"         // http://knowledge.seagate.com/articles/en_US/FAQ/207963en
+    "MA(0[^7]|[^0].)", // http://dellfirmware.seagate.com/dell_firmware/DellFirmwareRequest.jsp
+    "",                //        ^^^^^^^^^^^^ down (no DNS A record)
+    "-F xerrorlba" // tested with ST31000340NS/SN06
+  },
+  { "Seagate Barracuda ES.2", // buggy firmware (Dell)
+    "ST3(25031|50032|75033|100034)0NS",
+    "MA07",
+    "There are known problems with these drives,\n"
+    "AND THIS FIRMWARE VERSION IS AFFECTED,\n"
+    "contact Dell support for a firmware update.",
+    ""
+  },
+  { "Seagate Barracuda ES.2", // unknown firmware
+    "ST3(25031|50032|75033|100034)0NS",
+    "",
+    "There are known problems with these drives,\n"
+    "see the following Seagate web pages:\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/207931en\n"
+    "http://knowledge.seagate.com/articles/en_US/FAQ/207963en",
+    ""
+  },
+  { "Seagate Constellation (SATA)", // tested with ST9500530NS/SN03
+    "ST9(160511|500530)NS",
+    "", "", ""
+  },
+  { "Seagate Constellation ES (SATA)", // tested with ST31000524NS/SN11,
+      // MB0500EAMZD/HPG1
+    "ST3(50051|100052|200064)4NS|"
+    "MB0500EAMZD", // HP OEM
+    "", "", ""
+  },
+  { "Seagate Constellation ES (SATA 6Gb/s)", // tested with ST1000NM0011/SN02,
+      // MB1000GCEEK/HPG1
+    "ST(5|10|20)00NM0011|"
+    "MB1000GCEEK", // HP OEM
+    "", "", ""
+  },
+  { "Seagate Constellation ES.2 (SATA 6Gb/s)", // tested with ST32000645NS/0004, ST33000650NS,
+      // "ST33000650NS         81Y9799 81Y3865IBM/BB3A", MB3000EBKAB/HPG6,
+    "ST3(2000645|300065[012])NS( .*IBM)?|"
+    "MB3000EBKAB", // HP OEM
+    "", "", ""
+  },
+  { "Seagate Constellation ES.3", // tested with ST1000NM0033-9ZM173/0001,
+      // ST4000NM0033-9ZM170/SN03, MB1000GCWCV/HPGC, MB4000GCWDC/HPGE
+    "ST[1234]000NM00[35]3-.*|"
+    "MB[14]000GCW(CV|DC)", // HP OEM
+    "", "", ""
+  },
+  { "Seagate Constellation CS", // tested with ST3000NC000/CE02, ST3000NC002-1DY166/CN02
+    "ST(1000|2000|3000)NC00[0-3](-.*)?",
+    "", "", ""
+  },
+  { "Seagate Constellation.2 (SATA)", // 2.5", tested with ST91000640NS/SN02, MM1000GBKAL/HPGB
+    "ST9(25061|50062|100064)[012]NS|" // *SS = SAS
+    "MM1000GBKAL", // HP OEM
+    "", "", ""
+  },
+  // ST6000NM0004, ST6000NM0024, ST6000NM0044, ST6000NM0084, ST5000NM0024,
+  // ST5000NM0044, ST4000NM0024, ST4000NM0044, ST2000NM0024, ST2000NM0044
+  // ST4000NM0035, ST3000NM0005, ST2000NM0055, ST1000NM0055, ST4000NM0045,
+  // ST3000NM0015, ST2000NM0065, ST1000NM0065, ST4000NM0105, ST3000NM0055
+  { "Seagate Enterprise Capacity 3.5 HDD", // tested with ST6000NM0024-1HT17Z/SN02,
+      // ST10000NM0016-1TT101/SNB0
+      // ST4000NM0085-1YY107/ZC11SXPH
+      // ST8000NM0045-1RL112/NN02
+      // ST6000NM0004-1FT17Z/NN01
+      // ST4000NM0035-1V4107/TNC3
+      // ST1000NM0055-1V410C/TN02
+      // ST8000NM0055-1RM112/SN04
+      // ST10000NM0156-2AA111/SS05, ST4000NM0245-1Z2107/SS05
+    "ST([1234568]|10)000NM0[012][0-68][456]-.*", // *[069]4 = 4Kn
+    "", "",
+    "-v 200,raw48,Pressure_Limit "
+    "-v 188,raw16 -v 240,msec24hour32"
+  },
+  { "Seagate Enterprise Capacity 3.5 HDD", // V5.1, ms in attribute 9
+    "ST[12]000NM0008-.*", // tested with ST1000NM0008-2F2100/SN01
+    "", "",
+    "-v 9,msec24hour32 -v 188,raw16 -v 240,msec24hour32"
+  },
+  { "Seagate Enterprise Capacity 3.5 HDD v7 SED", // tested with ST12000NM0127/G005
+    "ST12000NM01[12]7",
+    "", "",
+    "-v 1,raw24/raw32 -v 7,raw24/raw32 "
+    "-v 195,raw24/raw32,Hardware_ECC_Recovered "
+  },
+  { "Seagate Exos 5E8", // tested with ST8000AS0003-2HH188/0003
+    "ST8000AS0003-.*",
+    "", "",
+    "-v 9,msec24hour32 -v 240,msec24hour32"
+  },
+  // ST1000NM000A, ST1000NM002A, ST2000NM000A, ST2000NM001A, ST2000NM002A,
+  // ST3000NM000A, ST3000NM004A, ST4000NM000A, ST4000NM001A, ST4000NM002A,
+  // ST4000NM006A, ST4000NM010A, ST4000NM012A, ST4000NM013A, ST6000NM002A,
+  // ST6000NM021A, ST6000NM022A, ST6000NM025A, ST6000NM026A, ST8000NM000A,
+  // ST8000NM002A, ST8000NM004A, ST8000NM008A, ST8000NM009A, ST8000NM016A
+  { "Seagate Exos 7E8", // tested with ST4000NM000A-2HZ100/TN03, ST6000NM021A-2R7101/SN02,
+      // ST8000NM000A-2KE101/SN02, OOS6000G/OOS1
+    "ST[123468]000NM0(0[01234689]|1[0236]|2[1256])A-.*|"
+    "OOS6000G", // 6TB refurbished and rebranded
+    "", "",
+    "-v 18,raw48,Head_Health "
+    "-v 188,raw16 "
+    "-v 240,msec24hour32"
+  },
+  { "Seagate Exos X12", // tested with ST12000NM0007-2A1101/SN02
+    "ST12000NM00[01]7-.*", // *17 = SED
+    "", "",
+    "-v 200,raw48,Pressure_Limit "
+    "-v 240,msec24hour32"
+  },
+  { "Seagate Exos X14", // tested with ST12000NM0008-2H3101/SN02,
+      // ST12000NM0538-2K2101/CMA2 (OEM?)
+    "ST(14000NM04[24]8|14000NM0(01|25)8|12000NM0(00|24|53)8|10000NM0(47|56)8)-.*",
+    "", "",
+    "-v 18,raw48,Head_Health "
+    "-v 200,raw48,Pressure_Limit "
+    "-v 240,msec24hour32"
+  },
+  { "Seagate Exos X16", // tested with ST10000NM001G-2MW103/SN02
+      // ST14000NM001G-2KJ103/SN02, ST14000NM001G-2KJ1037/SN04, ST16000NM001G-2KK103/SN02,
+      // ST16000NM001G-2KK103/SN03
+    "ST1[0246]000NM00[13]G-.*",
+    "", "",
+    "-v 1,raw24/raw32 -v 7,raw24/raw32 "
+    "-v 18,raw48,Head_Health "
+    "-v 188,raw16 "
+    "-v 200,raw48,Pressure_Limit "
+    "-v 240,msec24hour32"
+  },
+  { "Seagate Exos X18", // tested with ST12000NM000J-2TY103/SN02,
+      // ST16000NM000J-2TW103/SC02, ST18000NM000J-2TV103/SN01, .../SN02,
+      // ST18000NM002J-2TV133/PAL7 (Dell)
+    "ST1(0000NM0(18|20)G|[2468]000NM00[012]J)-.*",
+    "", "",
+    "-v 1,raw24/raw32 -v 7,raw24/raw32 "
+    "-v 18,raw48,Head_Health "
+    "-v 188,raw16 "
+    "-v 200,raw48,Pressure_Limit "
+    "-v 240,msec24hour32"
+  },
+  { "Seagate Exos X20/X22", // tested with ST20000NM007D-3DJ103/SN01, .../SN03,
+      // ST22000NM001E-3HM103/SN03, OOS20000G/OOS1
+    "ST(18|20)000NM00[0347]D-.*|" // X20
+    "ST2[02]000NM001E-.*|" // X22
+    "OOS20000G", // 20TB refurbished and rebranded
+    "", "",
+    "-v 1,raw24/raw32 -v 7,raw24/raw32 "
+    "-v 18,raw48,Head_Health "
+    "-v 188,raw16 "
+    "-v 200,raw48,Pressure_Limit "
+    "-v 240,msec24hour32"
+  },
+  { "Seagate Exos X24", // tested with ST24000NM002H-3KS133/SE03,
+      // ST24000NM000C-3WD103/SN02 (30TB HAMR recertified to 24TB CMR ?)
+    "ST((12|16|20|24)000NM002H|24000NM000C)-.*",
+    "", "",
+    "-v 1,raw24/raw32 -v 7,raw24/raw32 "
+    "-v 18,raw48,Head_Health "
+    "-v 188,raw16 "
+    "-v 200,raw48,Pressure_Limit "
+    "-v 240,msec24hour32"
+  },
+  // new models: ST8000VN0002, ST6000VN0021, ST4000VN000
+  //             ST8000VN0012, ST6000VN0031, ST4000VN003
+  // tested with ST8000VN0002-1Z8112/ZA13YGNF
+  { "Seagate NAS HDD", // tested with ST2000VN000-1H3164/SC42, ST3000VN000-1H4167/SC43
+    "ST([234]000VN000|[468]000VN00(02|21|12|31|3))-.*",
+    "", "", ""
+  },
+  // ST8000NE0001, ST8000NE0011, ST6000VN0001, ST6000VN0011, ST5000VN0001,
+  // ST5000VN0011, ST4000VN0001, ST4000VN0011, ST3000VN0001, ST3000VN0011,
+  // ST2000VN0001, ST2000VN0011
+  // tested with ST8000NE0001-1WN112/PNA2
+  { "Seagate Enterprise NAS HDD",
+    "ST(8000NE|[65432]000VN)00[01]1-.*",
+    "", "", ""
+  },
+  { "Seagate IronWolf", // tested with ST2000VN003-3CW102/SC60, ST3000VN007-2E4166/SC60,
+      // ST4000VN006-3CW104/SC60,
+      // ST4000VN008-2DR166/SC60, ST6000VN001-2BB186/SC60, ST6000VN0033-2EE110/SC60,
+      // ST6000VN0041-2EL11C/SC61, ST8000VN0022-2EL112/SC61, ST10000VN000-3AK101/SC60,
+      // ST10000VN0004-1ZD101/SC60, ST10000VN0004-2GS11L/SC60, ST12000VN0007-2GS116/SC60,
+      // ST12000VN0008-2JH101/SC60, ST16000VN001-2RV103/SC60
+    "ST([123468]|1[0246])000VN00(0?[0234678]|1|22|33|41)-.*",
+    "", "",
+    "-v 18,raw48,Head_Health "
+    "-v 188,raw16 "
+    "-v 200,raw48,Pressure_Limit "
+    "-v 240,msec24hour32"
+  },
+  { "Seagate IronWolf Pro", // tested with ST4000NE0025-2EW107/EN02,
+      // ST8000NE0004-1ZF11G/EN01, ST8000NE0021-2EN112/EN02, ST12000NT001-3LX101/EN01,
+      // ST16000NE000-2RW103/EN02, ST16000NT001-3LV101/EN01
+    "ST([24]000NE0025|4000NE001|6000NE0023|8000NE00(04|08|21)|(1[02468]|2[02])000(NE|NT)(000[478]|001)|16000NE000)-.*",
+    "", "",
+    "-v 18,raw48,Head_Health " // ST16000NE000
+    "-v 188,raw16 "
+    "-v 200,raw48,Pressure_Limit "
+    "-v 240,msec24hour32"
+  },
+  { "Seagate Archive HDD (SMR)", // tested with ST8000AS0002-1NA17Z/AR13
+    "ST[568]000AS00[01][12]-.*",
+    "", "", ""
+  },
+  { "Seagate Pipeline HD 5900.1",
+    "ST3(160310|320[34]10|500(321|422))CS",
+    "", "", ""
+  },
+  { "Seagate Pipeline HD 5900.2", // tested with ST31000322CS/SC13
+    "ST3(160316|250[34]12|320(311|413)|500(312|414)|1000(322|424))CS",
+    "", "", ""
+  },
+  { "Seagate Video 3.5 HDD", // tested with ST4000VM000-1F3168/SC23, SC25
+    "ST(10|15|20|30|40)00VM00[023]-.*",
+    "", "", ""
+  },
+  { "Seagate Medalist 17240, 13030, 10231, 8420, and 4310",
+    "ST3(17240|13030|10231|8420|4310)A",
+    "", "", ""
+  },
+  { "Seagate Medalist 17242, 13032, 10232, 8422, and 4312",
+    "ST3(1724|1303|1023|842|431)2A",
+    "", "", ""
+  },
+  { "Seagate NL35",
+    "ST3(250623|250823|400632|400832|250824|250624|400633|400833|500641|500841)NS",
+    "", "", ""
+  },
+  { "Seagate SV35.2",
+    "ST3(160815|250820|320620|500630|750640)[AS]V",
+    "", "", ""
+  },
+  { "Seagate SV35.3", // tested with ST3500320SV/SV16
+    "ST3(500320|750330|1000340)SV",
+    "", "", ""
+  },
+  { "Seagate SV35.5", // tested with ST31000525SV/CV12
+    "ST3(250311|500410|1000525)SV",
+    "", "", ""
+  },
+  // ST6000VX0001,ST6000VX0011,ST5000VX0001,ST5000VX0011,ST4000VX000
+  // ST4000VX002, ST3000VX002, ST2000VX003, ST1000VX001, ST1000VX002
+  // ST3000VX000, ST3000VX004, ST2000VX000, ST2000VX004, ST1000VX000
+  { "Seagate Surveillance", // tested with ST1000VX001-1HH162/CV11, ST2000VX000-9YW164/CV12,
+      // ST4000VX000-1F4168/CV14, ST2000VX003-1HH164/CV12
+    "ST([1-5]000VX00[01234]1?|31000526SV|3500411SV)(-.*)?",
+    "", "", ""
+  },
+  { "Seagate Skyhawk", // tested with ST3000VX010-2H916L/CV11, ST6000VX0023-2EF110/SC60
+    "ST(1000VX005|2000VX008|3000VX0(09|10)|4000VX007|6000VX00(1|23)|8000VX00(4|22))-.*",
+    "", "",
+    "-v 9,msec24hour32 " // CV* Firmware only?
+    "-v 240,msec24hour32"
+  },
+  { "Seagate DB35", // tested with ST3250823ACE/3.03, ST3300831SCE/3.03
+    "ST3(200826|250823|300831|400832)[AS]CE",
+    "", "", ""
+  },
+  { "Seagate DB35.2", // tested with ST3160212SCE/3.ACB
+    "ST3(802110|120213|160212|200827|250824|300822|400833|500841)[AS]CE",
+    "", "", ""
+  },
+  { "Seagate DB35.3",
+    "ST3(750640SCE|((80|160)215|(250|320|400)820|500830|750840)[AS]CE)",
+    "", "", ""
+  },
+  { "Seagate LD25.2", // tested with ST940210AS/3.ALC
+    "ST9(40|80)210AS?",
+    "", "", ""
+  },
+  { "Seagate ST1.2 CompactFlash", // tested with ST68022CF/3.01
+    "ST6[468]022CF",
+    "", "", ""
+  },
+  { "Seagate Nytro XF1230 SATA SSD", // tested with XF1230-1A0480/ST200354
+    "XF1230-1A(0240|0480|0960|1920)",
+    "", "",
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+    "-v 180,raw48,End_to_End_Err_Detect "
+    "-v 183,raw48,SATA_Downshift_Count "
+    "-v 189,raw48,SSD_Health_Flags "
+    "-v 190,raw48,SATA_Error_Ct "
+    "-v 201,raw48,Read_Error_Rate "
+    "-v 231,raw48,SSD_Life_Left_Perc "
+    "-v 234,raw48,Lifetime_Nand_Gb "
+    "-v 241,raw48,Total_Writes_GiB "
+    "-v 242,raw48,Total_Reads_GiB "
+    "-v 245,raw48,Read_Error_Rate "
+  },
+  { "Seagate IronWolf 110 SATA SSD", //Written to Seagate documentation
+    "ZA(240|480|960|1920|3840)NM10001",
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 100,raw48,Flash_GB_Erased "
+    "-v 102,raw48,Lifetime_PS4_Entry_Ct "
+    "-v 103,raw48,Lifetime_PS3_Exit_Ct "
+    "-v 170,raw48,Grown_Bad_Block_Ct "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 173,raw48,Avg_Program/Erase_Ct "
+    "-v 174,raw48,Unexpected_Pwr_Loss_Ct "
+    "-v 177,raw16,Wear_Range_Delta "
+    "-v 183,hex56,SATA_Downshift_Count "
+    "-v 187,raw48,Uncorrectable_ECC_Ct "
+  //"-v 194,tempminmax,Temperature_Celsius "
+    "-v 195,raw16(raw16),RAISE_ECC_Cor_Ct "
+    "-v 198,raw48,Uncor_Read_Error_Ct "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 230,raw56,Drv_Life_Protect_Status "
+    "-v 231,hex56,SSD_Life_Left "
+  //"-v 232,raw48,Available_Reservd_Space "
+    "-v 233,raw48,Lifetime_Wts_To_Flsh_GB "
+    "-v 241,raw48,Lifetime_Wts_Frm_Hst_GB "
+    "-v 242,raw48,Lifetime_Rds_Frm_Hst_GB "
+    "-v 243,hex56,Free_Space "
+  },
+  { "Seagate IronWolf (Pro) 125 SSDs", // IronWolf_Pro_125_SSD_Product_Manual_100866982_A.pdf 
+				       // IronWolf_125_SSD_Product_Manual_100866980_C.pdf
+    "Seagate IronWolf ZA(250|500|1000|2000|4000)NM10002-.*|" // tested with
+      // Seagate IronWolf ZA500NM10002-2ZG101/SU3SC013
+    "Seagate IronWolfPro ZA(240|480|960|1920|3840)NX10001-.*", // tested with
+      // Seagate IronWolfPro ZA3840NX10001-2ZH104/SU4SC01B
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 16,raw48,Spare_Blocks_Available "
+    "-v 17,raw48,Spare_Blocks_Remaining "
+    "-v 168,raw48,SATA_PHY_Error_Count "
+    "-v 170,raw16,Early/Later_Bad_Blck_Ct "
+    "-v 173,raw16,Max/Avg/Min_Erase_Ct "
+    "-v 174,raw48,Unexpect_Power_Loss_Ct "
+    "-v 177,raw16,Wear_Range_Delta "
+  //"-v 192,raw48,Power-Off_Retract_Count "
+  //"-v 194,tempminmax,Temperature_Celsius "
+    "-v 218,raw48,SATA_CRC_Error_Count "
+    "-v 231,raw48,SSD_Life_Left "
+    "-v 232,hex48,Read_Failure_Blk_Ct "
+    "-v 233,raw48,Flash_Writes_GiB "
+    "-v 234,raw48,NAND_Reads_Sectors "
+    "-v 235,raw48,Flash_Writes_Sectors "
+    "-v 241,raw48,Host_Writes_GiB "
+    "-v 242,raw48,Host_Reads_GiB "
+    "-v 246,hex64,Write_Protect_Detail " // prevents interpretation of bogus threshold 255 (ticket #1396)
+    "-v 247,raw48,Health_Check_Timer "
+  },
+  { "Seagate Nytro SATA SSD", //Written to Seagate documentation
+    // tested with XA960LE10063, XA960LE10063
+    "XA(240|480|960|1920|3840)[LM]E10(00|02|04|06|08|10)3",
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 100,raw48,Flash_GB_Erased "
+    "-v 102,raw48,Lifetime_PS4_Entry_Ct "
+    "-v 103,raw48,Lifetime_PS3_Exit_Ct "
+    "-v 170,raw48,Grown_Bad_Block_Ct "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 173,raw48,Avg_Program/Erase_Ct "
+    "-v 174,raw48,Unexpected_Pwr_Loss_Ct "
+    "-v 177,raw16,Wear_Range_Delta "
+    "-v 183,hex56,SATA_Downshift_Count "
+    "-v 187,raw48,Uncorrectable_ECC_Ct "
+  //"-v 194,tempminmax,Temperature_Celsius "
+    "-v 195,raw16(raw16),RAISE_ECC_Cor_Ct "
+    "-v 198,raw48,Uncor_Read_Error_Ct "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 230,raw56,Drv_Life_Protect_Status "
+    "-v 231,hex56,SSD_Life_Left "
+  //"-v 232,raw48,Available_Reservd_Space "
+    "-v 233,raw48,Lifetime_Wts_To_Flsh_GB "
+    "-v 241,raw48,Lifetime_Wts_Frm_Hst_GB "
+    "-v 242,raw48,Lifetime_Rds_Frm_Hst_GB "
+    "-v 243,hex56,Free_Space "
+  },
+  { "WD Blue / Red / Green SSDs", // tested with WDC WDS250G1B0A-00H9H0/X41000WD,
+      // WDC WDS250G1B0A-00H9H0/X41100WD, WDC WDS100T1B0A-00H9H0,
+      // WDC WDS120G2G0A-00JH30/UE360000, WDC WDS240G2G0A-00JH30/UF300000,
+      // WDC WDS500G2B0A-00SM50/X61130WD, WDC WDS200T2B0A-00SM50/X61130WD,
+      // WDC WDS200T2B0A/X61190WD, WDC WDS120G1G0A-00SS50/Z3311000
+      // WDC  WDS500G2B0A-00SM50/401000WD,
+      // WDC WDBNCE2500PNC/X61130WD, WDC WDBNCE0010PNC-WRSN/X41110WD,
+      // WDC  WDS200T1R0A-68A4W0/411000WR, WDC  WDS400T1R0A-68A4W0/411000WR
+    "WDC WDBNCE(250|500|00[124])0PNC(-.*)?|" // Blue 3D
+    "WDC  ?WDS((120|240|250|480|500)G|[124]00T)(1B|2B|1G|2G|1R)0[AB](-.*)?|"
+      // *B* = Blue, *G* = Green, *2B* = Blue 3D NAND, *1R* = Red SA500
+    "WD Blue SA510 2.5 1000GB|" // tested with WD Blue SA510 2.5 1000GB/52008100
+    "SanDisk Portable SSD", // tested with SanDisk Portable SSD/UM5004RL
+                            // (Sandisk SDSSDE30-2T00, 0x0781:0x55b0)
+    "", "",
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct " // Reassigned Block Count
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 165,raw48,Block_Erase_Count "
+    "-v 166,raw48,Minimum_PE_Cycles_TLC "
+    "-v 167,raw48,Max_Bad_Blocks_per_Die "
+    "-v 168,raw48,Maximum_PE_Cycles_TLC "
+    "-v 169,raw48,Total_Bad_Blocks "
+    "-v 170,raw48,Grown_Bad_Blocks "
+    "-v 171,raw48,Program_Fail_Count "
+    "-v 172,raw48,Erase_Fail_Count "
+    "-v 173,raw48,Average_PE_Cycles_TLC "
+    "-v 174,raw48,Unexpected_Power_Loss "
+  //"-v 184,raw48,End-to-End_Error " // Detection/Correction Count
+  //"-v 187,raw48,Reported_Uncorrect " // Uncorrectable Errors
+  //"-v 188,raw48,Command_Timeout "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 199,raw48,UDMA_CRC_Error_Count " // SATA CRC Errors
+    "-v 230,hex48,Media_Wearout_Indicator " // Maybe hex16
+  //"-v 232,raw48,Available_Reservd_Space"
+    "-v 233,raw48,NAND_GB_Written_TLC "
+    "-v 234,raw48,NAND_GB_Written_SLC "
+    "-v 241,raw48,Host_Writes_GiB "
+    "-v 242,raw48,Host_Reads_GiB "
+    "-v 244,raw48,Temp_Throttle_Status "
+  },
+  { "Western Digital Protege",
+  /* Western Digital drives with this comment all appear to use Attribute 9 in
+   * a  non-standard manner.  These entries may need to be updated when it
+   * is understood exactly how Attribute 9 should be interpreted.
+   * UPDATE: this is probably explained by the WD firmware bug described in the
+   * smartmontools FAQ */
+    "WDC WD([2468]00E|1[26]00A)B-.*",
+    "", "", ""
+  },
+  { "Western Digital Caviar",
+  /* Western Digital drives with this comment all appear to use Attribute 9 in
+   * a  non-standard manner.  These entries may need to be updated when it
+   * is understood exactly how Attribute 9 should be interpreted.
+   * UPDATE: this is probably explained by the WD firmware bug described in the
+   * smartmontools FAQ */
+    "WDC WD(2|3|4|6|8|10|12|16|18|20|25)00BB-.*",
+    "", "", ""
+  },
+  { "Western Digital Caviar WDxxxAB",
+  /* Western Digital drives with this comment all appear to use Attribute 9 in
+   * a  non-standard manner.  These entries may need to be updated when it
+   * is understood exactly how Attribute 9 should be interpreted.
+   * UPDATE: this is probably explained by the WD firmware bug described in the
+   * smartmontools FAQ */
+    "WDC WD(3|4|6|8|25)00AB-.*",
+    "", "", ""
+  },
+  { "Western Digital Caviar WDxxxAA",
+  /* Western Digital drives with this comment all appear to use Attribute 9 in
+   * a  non-standard manner.  These entries may need to be updated when it
+   * is understood exactly how Attribute 9 should be interpreted.
+   * UPDATE: this is probably explained by the WD firmware bug described in the
+   * smartmontools FAQ */
+    "WDC WD...?AA(-.*)?",
+    "", "", ""
+  },
+  { "Western Digital Caviar WDxxxBA",
+  /* Western Digital drives with this comment all appear to use Attribute 9 in
+   * a  non-standard manner.  These entries may need to be updated when it
+   * is understood exactly how Attribute 9 should be interpreted.
+   * UPDATE: this is probably explained by the WD firmware bug described in the
+   * smartmontools FAQ */
+    "WDC WD...BA",
+    "", "", ""
+  },
+  { "Western Digital Caviar AC", // add only 5400rpm/7200rpm (ata33 and faster)
+    "WDC AC((116|121|125|225|132|232)|([1-4][4-9][0-9])|([1-4][0-9][0-9][0-9]))00[A-Z]?.*",
+    "", "", ""
+  },
+  { "Western Digital Caviar SE",
+  /* Western Digital drives with this comment all appear to use Attribute 9 in
+   * a  non-standard manner.  These entries may need to be updated when it
+   * is understood exactly how Attribute 9 should be interpreted.
+   * UPDATE: this is probably explained by the WD firmware bug described in the
+   * smartmontools FAQ
+   * UPDATE 2: this does not apply to more recent models, at least WD3200AAJB */
+    "WDC WD(4|6|8|10|12|16|18|20|25|30|32|40|50)00(JB|PB)-.*",
+    "", "", ""
+  },
+  { "Western Digital Caviar Blue EIDE",  // WD Caviar SE EIDE
+    /* not completely accurate: at least also WD800JB, WD(4|8|20|25)00BB sold as Caviar Blue */
+    "WDC WD(16|25|32|40|50)00AAJB-.*",
+    "", "", ""
+  },
+  { "Western Digital Caviar Blue EIDE",  // WD Caviar SE16 EIDE
+    "WDC WD(25|32|40|50)00AAKB-.*",
+    "", "", ""
+  },
+  { "Western Digital RE EIDE",
+    "WDC WD(12|16|25|32)00SB-.*",
+    "", "", ""
+  },
+  { "Western Digital PiDrive Foundation Edition", // WDC WD3750LMCW-11D9GS3
+    "WDC WD(3750|2500)LMCW-.*",
+    "", "", ""
+  },
+  { "Western Digital Caviar Serial ATA",
+    "WDC WD(4|8|20|32)00BD-.*",
+    "", "", ""
+  },
+  { "Western Digital Caviar SE Serial ATA", // tested with WDC WD3000JD-98KLB0/08.05J08
+    "WDC WD(4|8|12|16|20|25|30|32|40)00(JD|KD|PD)-.*",
+    "", "", ""
+  },
+  { "Western Digital Caviar SE Serial ATA",
+    "WDC WD(8|12|16|20|25|30|32|40|50)00JS-.*",
+    "", "", ""
+  },
+  { "Western Digital Caviar SE16 Serial ATA",
+    "WDC WD(16|20|25|32|40|50|75)00KS-.*",
+    "", "", ""
+  },
+  { "Western Digital Caviar Blue Serial ATA",  // WD Caviar SE Serial ATA
+    /* not completely accurate: at least also WD800BD, (4|8)00JD sold as Caviar Blue */
+    "WDC WD((8|12|16|25|32)00AABS|(8|12|16|25|32|40|50)00AAJS)-.*",
+    "", "", ""
+  },
+  { "Western Digital Caviar Blue (SATA)",  // WD Caviar SE16 Serial ATA
+      // tested with WD1602ABKS-18N8A0/DELL/02.03B04
+    "WDC WD((16|20|25|32|40|50|64|75)00AAKS|1602ABKS|10EALS)-.*",
+    "", "", ""
+  },
+  { "Western Digital Blue (CMR)", // tested with WDC WD5000AZLX-00K4KA0/80.00A80,
+      // WDC WD10EZEX-00RKKA0/80.00A80, WDC WD10EZEX-75M2NA0/01.01A01,
+      // WDC WD40EZRZ-00WN9B0/80.00A80, WDC WD80EAZZ-00BKLB0/80.00A80,
+      // APPLE HDD WDC WD10EALX-408EA0/07.01D03
+    "(APPLE HDD )?WDC WD((25|32|50)00AAKX|5000AZ(LX|RZ)|7500A(AL|ZE)X|[123468]0E(ALX|A[ARZ]Z|Z[AE]X|ZRZ))-.*",
+    "", "", ""
+  },
+  { "Western Digital Blue (SMR)", // tested with WDC WD40EZAZ-00SF3B0/80.00A80 (TRIM: zeroed)
+    "WDC WD[2346]0EZ(AZ|BX)-.*",
+    "", "", ""
+  },
+  { "Western Digital RE Serial ATA",
+    "WDC WD(12|16|25|32)00(SD|YD|YS)-.*",
+    "", "", ""
+  },
+  { "Western Digital RE2 Serial ATA",
+    "WDC WD((40|50|75)00(YR|YS|AYYS)|(16|32|40|50)0[01]ABYS)-.*",
+    "", "", ""
+  },
+  { "Western Digital RE2-GP",
+    "WDC WD(5000AB|7500AY|1000FY)PS-.*",
+    "", "", ""
+  },
+  { "Western Digital RE3 Serial ATA", // tested with WDC WD7502ABYS-02A6B0/03.00C06,
+      // WD1002FBYS-12/03.M0300
+    "(WDC )?WD((25|32|50|75)02A|(75|10)02F)BYS-.*",
+    "", "", ""
+  },
+  { "Western Digital RE4", // tested with WDC WD2003FYYS-18W0B0/01.01D02,
+      // WDC WD1003FBYZ-010FB0/01.01V03
+      // WDC WD5003ABYZ-011FA0/01.01S03
+    "WDC WD((25|50)03ABY[XZ]|1003FBY[XZ]|(15|20)03FYYS)-.*",
+    "", "", ""
+  },
+  { "Western Digital RE4-GP", // tested with WDC WD2002FYPS-02W3B0/04.01G01,
+      // WD2003FYPS-27W9B0/01.01D02
+    "(WDC )?WD200[23]FYPS-.*",
+    "", "", ""
+  },
+  { "Western Digital Re", // tested with WDC WD1004FBYZ-01YCBB0/RR02,
+      // WDC WD2000FYYZ-01UL1B0/01.01K01, WDC WD2000FYYZ-01UL1B1/01.01K02,
+      // WDC WD4000FYYZ-01UL1B2/01.01K03, WD2000FYYX/00.0D1K2,
+      // WDC WD1004FBYZ-01YCBB1/RR04
+      // WD4000FYYZ, WD4000FDYZ, WD3000FYYZ, WD3000FDYZ, WD2000FYYZ, WD2000FDYZ
+      // WD2004FBYZ, WD1004FBYZ
+    "WDC WD((1004|2004)FBYZ|([234]000)FDYZ|[234]000FYYZ|2000FYYX)-.*",
+    "", "",
+    "-v 16,raw48,Total_LBAs_Read" // WDC WD1004FBYZ-01YCBB1/RR04
+  },
+  { "Western Digital Se", // tested with WDC WD2000F9YZ-09N20L0/01.01A01
+    // WD6001F9YZ, WD5001F9YZ, WD4000F9YZ, WD3000F9YZ, WD2000F9YZ, WD1002F9YZ
+    "WDC WD(1002|2000|3000|4000|5001|6001)F9YZ-.*",
+    "", "", ""
+  },
+  { "Western Digital Caviar Green", // tested with WDC WD7500AADS-00M2B0/01.00A01,
+      // WDC WD10EADX/77.04D77
+    "WDC WD((50|64|75)00AA[CV]S|(50|64|75)00AADS|10EA[CV]S|(10|15|20)EAD[SX])-.*",
+    "",
+    "",
+    "-F xerrorlba" // tested with WDC WD7500AADS-00M2B0/01.00A01
+  },
+  { "Western Digital Caviar Green (AF)",
+    "WDC WD(((64|75|80)00AA|(10|15|20)EA|(25|30)EZ)R|20EAC)S-.*",
+    "", "", ""
+  },
+  { "Western Digital Green", // tested with
+      // WDC WD10EZRX-00A8LB0/01.01A01, WDC WD20EZRX-00DC0B0/80.00A80,
+      // WDC WD30EZRX-00MMMB0/80.00A80, WDC WD40EZRX-00SPEB0/80.00A80,
+      // WDC WD60EZRX-00MVLB1/80.00A80, WDC WD5000AZRX-00A8LB0/01.01A01
+    "WDC WD(5000AZ|7500AA|(10|15|20)EA|(10|20|25|30|40|50|60)EZ)RX-.*",
+    "", "", ""
+  },
+  { "Western Digital Caviar Black", // tested with WDC WD7501AAES/06.01D06
+    "WDC WD((500|640)1AAL|7501AA[EL]|1001FA[EL]|2001FAS)S-.*|"
+    "WDC WD(2002|7502|1502|5003|1002|5002)(FAE|AAE|AZE|AAL)X-.*", // could be
+    // WD2002FAEX, WD7502AAEX, WD1502FAEX, WD5003AZEX, WD1002FAEX, WD5002AALX
+    "", "", "-F xerrorlba" // WDC WD6401AALS-00L3B2/01.03B01 (ticket #1558)
+  },
+  { "Western Digital Black", // tested with
+      // WDC WD1003FZEX-00MK2A0/01.01A01, WDC WD3001FAEX-00MJRA0/01.01L01,
+      // WDC WD3003FZEX-00Z4SA0/01.01A01, WDC WD4001FAEX-00MJRA0/01.01L01
+      // WDC WD4003FZEX-00Z4SA0/01.01A01, WDC WD5003AZEX-00RKKA0/80.00A80,
+      // WDC WD4004FZWX-00GBGB0/81.H0A81, WDC WD4005FZBX-00K5WB0/01.01A01
+    "WDC WD(6001|2003|5001|1003|4003|4004|4005|5003|3003|3001)(FZW|FZE|FZB|AZE)X-.*|" // could be
+    // new series  WD6001FZWX WD2003FZEX WD5001FZWX WD1003FZEX
+    //             WD4003FZEX WD5003AZEX WD3003FZEX WD4004FZWX
+    "WDC WD(4001|3001|2002|1002|5003|7500|5000|3200|2500|1600)(FAE|AZE)X-.*",
+    // old series: WD4001FAEX WD3001FAEX WD2002FAEX WD1002FAEX  WD5003AZEX
+    "", "", ""
+  },
+  { "Western Digital Black (SMR)", // ticket #1313
+    "WDC WD10SPSX-.*",
+    "", "", ""
+  },
+  { "Western Digital AV ATA", // tested with WDC WD3200AVJB-63J5A0/01.03E01
+    "WDC WD(8|16|25|32|50)00AV[BJ]B-.*",
+    "", "", ""
+  },
+  { "Western Digital AV SATA",
+    "WDC WD(16|25|32)00AVJS-.*",
+    "", "", ""
+  },
+  { "Western Digital AV-GP",
+    "WDC WD((16|25|32|50|64|75)00AV[CDV]S|(10|15|20)EV[CDV]S)-.*",
+    "", "", ""
+  },
+  { "Western Digital AV-GP (AF)", // tested with WDC WD10EURS-630AB1/80.00A80,
+      // WDC WD10EUCX-63YZ1Y0/51.0AB52, WDC WD20EURX-64HYZY0/80.00A80
+    "WDC WD(5000AUDX|7500AURS|10EUCX|(10|15|20|25|30)EUR[SX])-.*",
+    "", "", ""
+  },
+  { "Western Digital AV", // tested with DC WD10JUCT-63CYNY0/01.01A01
+    "WDC WD((16|25|32|50)00BU[CD]|5000LUC|10JUC)T-.*",
+    "", "", ""
+  },
+  { "Western Digital Raptor",
+    "WDC WD((360|740|800)GD|(360|740|800|1500)ADF[DS])-.*",
+    "", "", ""
+  },
+  { "Western Digital Raptor X",
+    "WDC WD1500AHFD-.*",
+    "", "", ""
+  },
+  { "Western Digital VelociRaptor", // tested with WDC WD1500HLHX-01JJPV0/04.05G04
+    "WDC WD(((800H|(1500|3000)[BH]|1600H|3000G)LFS)|((1500|3000|4500|6000)[BH]LHX))-.*",
+    "", "", ""
+  },
+  { "Western Digital VelociRaptor (AF)", // tested with WDC WD1000DHTZ-04N21V0/04.06A00
+    "WDC WD(2500H|5000B|5000H|1000D)HTZ-.*",
+    "", "", ""
+  },
+  { "Western Digital Scorpio EIDE",
+    "WDC WD(4|6|8|10|12|16)00(UE|VE)-.*",
+    "", "", ""
+  },
+  { "Western Digital Scorpio Blue EIDE", // tested with WDC WD3200BEVE-00A0HT0/11.01A11
+    "WDC WD(4|6|8|10|12|16|25|32)00BEVE-.*",
+    "", "", ""
+  },
+  { "Western Digital Scorpio Serial ATA",
+    "WDC WD(4|6|8|10|12|16|25)00BEAS-.*",
+    "", "", ""
+  },
+  { "Western Digital Scorpio Blue Serial ATA", // tested with WDC WD3200BEVS-08VAT2/14.01A14
+    "WDC WD((4|6|8|10|12|16|25|32)00BEVS|(8|12|16|25|32|40|50|64)00BEVT|7500KEVT|10TEVT)-.*",
+    "", "", ""
+  },
+  { "Western Digital Scorpio Blue Serial ATA (AF)", // tested with
+      // WDC WD10JPVT-00A1YT0/01.01A01
+    "WDC WD((16|25|32|50|64|75)00BPVT|10[JT]PVT)-.*",
+    "", "", ""
+  },
+  { "Western Digital Scorpio Black", // tested with WDC WD5000BEKT-00KA9T0/01.01A01
+    "WDC WD(8|12|16|25|32|50)00B[EJ]KT-.*",
+    "", "", ""
+  },
+  { "Western Digital Scorpio Black (AF)",
+    "WDC WD(50|75)00BPKT-.*",
+    "", "", ""
+  },
+  { "Western Digital Red (CMR)", // tested with WDC WD10EFRX-68JCSN0/01.01A01,
+      // WDC WD10JFCX-68N6GN0/01.01A01, WDC WD20EFZX-68AWUN0/81.00B81,
+      // WDC WD30EFRX-68EUZN0/82.00A82, WDC WD30EFZX-68AWUN0/81.00B81,
+      // WDC WD40EFPX-68C6CN0/81.00A81, WDC WD40EFRX-68WT0N0/80.00A80,
+      // WDC WD40EFZX-68AWUN0/81.00B81,
+      // WDC WD60EFRX-68MYMN1/82.00A82, WDC WD60EFPX-68C5ZN0/81.00A81,
+      // WDC WD80EFZX-68UW8N0/83.H0A83,
+      // WDC WD80EZZX-11CSGA0/83.H0A03 (My Book 0x1058:0x25ee),
+      // WDC WD120EMFZ-11A6JA0/81.00A81 (Easystore 0x1058:0x25fb)
+      // WDC WD160EMFZ-11AFXA0/81.00A81,
+    "WDC WD(7500BFCX|10JFCX|[1-6]0EFRX|[2-8]0EFPX|[23468]0E[FZ]ZX|80EFZZ|1[26]0EMFZ)-.*",
+    "", "", ""
+  //"-v 22,raw48,Helium_Level" // WD80EFAX, WD80EFZX, WD100EFAX, WD120EMFZ, WD160EMFZ
+  },
+  { "Western Digital Red (SMR)", // ticket #1313, tested with WDC WD60EFAX-68SHWN0/82.00A82
+    "WDC WD[2346]0EFAX-.*",
+    "", "", ""
+  },
+  { "Western Digital Red Plus", // tested with WDC WD80EFAX-68LHPN0/83.H0A83.
+      // WDC WD80EFBX-68AZZN0/85.00A85, WDC WD101EFAX-68LDBN0/81.00A81,
+      // WDC WD101EFBX-68B0AN0/85.00A85, WDC WD100EFAX-68LHPN0/83.H0A83,
+      // WDC WD120EFAX-68UNTN0/81.00A81, WDC WD120EFBX-68B0EN0/85.00A85,
+      // WDC WD140EFFX-68VBXN0/81.00A81
+    "WDC WD(80|10[01]|1[24]0|1[68]1)(JFC|EF[ABFR])X-.*",
+    "", "", ""
+  //"-v 22,raw48,Helium_Level" // >= 12TB
+  },
+  { "Western Digital Red Pro", // tested with WDC WD2001FFSX-68JNUN0/81.00A81,
+      // WDC WD6002FFWX-68TZ4N0/83.H0A83, WDC WD101KFBX-68R56N0/83.H0A03,
+      // WDC WD102KFBX-68M95N0/83.00A83, WDC WD121KFBX-68EF5N0/83.00A83,
+      // WDC WD141KFGX-68FH9N0/83.00A83, WDC WD142KFGX-68AFPN0/83.00A83,
+      // WDC WD161KFGX-68AFPN0/83.00A83, WDC WD181KFGX-68AFPN0/83.00A83,
+      // WDC WD201KFGX-68BKJN0/83.00A83
+    "WDC WD([2-68]00[123]FF[BSW]|1[02][12]KFB|(1[468]|20)[12]KFG)X-.*",
+    "", "",
+  //"-v 22,raw48,Helium_Level " // not WD102KFBX
+    "-v 90,hex48,NAND_Master" // WD201KFGX
+  },
+  { "Western Digital Purple (Pro)", // tested with WDC WD40PURX-64GVNY0/80.00A80,
+      // WDC WD40PURZ-85TTDY0/80.00A80
+      // WDC WD80PUZX-64NEAY0/80.H0A80
+      // WDC WD121PURP-85B5SY0/82.00A82
+    "WDC WD[1234568](0|[0248]1)PU[RZ][PXZ]-.*",
+    "", "", ""
+  //"-v 22,raw48,Helium_Level" // WD121PURP-85B5SY0, WD80PUZX-64NEAY0
+  },
+  { "Western Digital Gold", // tested with WDC WD1005FBYZ-01YCBB2/RR07,
+      // WDC WD1005VBYZ-02RRWB2/RR07, WDC WD2005VBYZ-02RRWB2/RR07
+      // WDC WD2005FBYZ-01YCBB2/RR07, WDC WD4002FYYZ-01B7CB0/01.01M02,
+      // WDC WD4003FRYZ-01F0DB0/01.01H01, WDC WD6003FRYZ-01F0DB0/01.01H01,
+      // WDC WD8003FRYZ-01JPDB1/01.01H02, WDC WD8004FRYZ-01VAEB0/01.01H01,
+      // WDC WD102KRYZ-01A5AB0/01.01H01, WDC WD121KRYZ-01W0RB0/01.01H01,
+      // WDC WD141KRYZ-01C66B0/01.01H01, WDC WD161KRYZ-01AGBB0/01.01H01
+    "WDC WD([12]005[FV]B|4002FY|4003FR|600[23]FR|800[234]FR|([12][02468]1|102)KR)YZ-.*",
+    "", "", ""
+  //"-v 22,raw48,Helium_Level" // WD121KRYZ, WD141KRYZ
+  },
+  { "Western Digital Blue Mobile", // tested with WDC WD5000LPVX-08V0TT2/03.01A03,
+      // WDC WD10JPVX-75JC3T0/0301A03,  WDC WD10JPVX-22JC3T0/01.01A01,
+      // WDC WD20NPVZ-00WFZT0/01.01A01
+    "WDC WD(3200LPCX|5000[BL]P[CV]X|7500BPVX|10JP[VZ]X|(15|20)NPVZ)-.*",
+    "", "", ""
+  },
+  { "Western Digital Blue Mobile (SMR)", // ticket #1313, tested with
+      // WDC WD10SPZX-22Z10T0/01.01A01, WDC WD10SPZX-21Z10T0/02.01A02,
+      // WDC WD20SPZX-22CRAT0/01.01A01, WDC WD20SPZX-22UA7T0/01.01A01
+    "WDC WD[12]0SPZX-.*",
+    "", "", ""
+  },
+  { "Western Digital Green Mobile", // tested with WDC WD20NPVX-00EA4T0/01.01A01
+    "WDC WD(15|20)NPV[TX]-.*",
+    "", "", ""
+  },
+  { "Western Digital Black Mobile", // tested with WDC WD7500BPKX-22HPJT0/01.01A01,
+      // WDC WD10JPLX-00MBPT0/01.01H01
+    "WDC WD((16|25|32)00BEK[TX]|(25|32|50|75)00(BPK|LPL)X|10JPLX)-.*",
+    "", "", ""
+  },
+  { "Western Digital Elements / My Passport (USB)", // tested with WDC WD5000BMVW-11AMCS0/01.01A01
+    "WDC WD(25|32|40|50)00BMV[UVW]-.*",  // *W-* = USB 3.0
+    "", "", ""
+  },
+  { "Western Digital Elements / My Passport (USB, AF)", // tested with
+      // WDC WD5000KMVV-11TK7S1/01.01A01,
+      // WDC WD5000LMVW-11CKRS0/01.01A01 (0x1058:0x07ae),
+      // WDC WD5000LMVW-11VEDS0/01.01A01 (0x1058:0x0816),
+      // WDC WD7500BMVW-11AJGS2/01.01A01,
+      // WDC WD10JMVW-11AJGS2/01.01A01 (0x1058:0x10b8),
+      // WDC WD10JMVW-11AJGS4/01.01A01 (0x1058:0x25a0/25a2),
+      // WDC WD10JMVW-11S5XS1/01.01A01,
+      // WDC WD10SMZW-11Y0TS0/01.01A01,
+      // WDC WD10TMVW-11ZSMS5/01.01A01,
+      // WDC WD20NMVW-11AV3S2/01.01A01 (0x1058:0x0822),
+      // WDC WD20NMVW-11AV3S3/01.01A01 (0x1058:0x0837),
+      // WDC WD20NMVW-11EDZS6/01.01A01 (0x1058-0x259f),
+      // WDC WD20NMVW-11EDZS7/01.01A01 (0x1058:0x259d/25a1),
+      // WDC WD20NMVW-11W68S0/01.01A01,
+      // WDC WD20NMVW-59AV3S3/01.01A01 (0x1058:0x107d),
+      // WDC WD30NMVW-11C3NS4/01.01A01,
+      // WDC WD40NMZW-11GX6S1/01.01A01 (0x1058:0x2599/25e2/25fa)
+      // WDC WD50NDZW-11A8JS1/01.01A01 (0x1058:0x2627)
+      // WDC WD50NDZW-11MR8S1/02.01A02
+      // WDC WD40NDZM-59A8KS1/01.01A01
+    "WDC WD((5000[LK]|7500[BK]|10[JST]|[234]0N)M|50ND|40ND)[VZ][VWM]-.*", // *W-* = USB 3.0
+    // Model numbers with "M" suffix denote the use of USB-C receptacles instead of Micro-B.
+    "", "", ""
+  },
+  { "Quantum Bigfoot", // tested with TS10.0A/A21.0G00, TS12.7A/A21.0F00
+    "QUANTUM BIGFOOT TS(10\\.0|12\\.7)A",
+    "", "", ""
+  },
+  { "Quantum Fireball lct15",
+    "QUANTUM FIREBALLlct15 ([123]0|22)",
+    "", "", ""
+  },
+  { "Quantum Fireball lct20",
+    "QUANTUM FIREBALLlct20 [1234]0",
+    "", "", ""
+  },
+  { "Quantum Fireball CX",
+    "QUANTUM FIREBALL CX10.2A",
+    "", "", ""
+  },
+  { "Quantum Fireball CR",
+    "QUANTUM FIREBALL CR(4.3|6.4|8.4|13.0)A",
+    "", "", ""
+  },
+  { "Quantum Fireball EX", // tested with QUANTUM FIREBALL EX10.2A/A0A.0D00
+    "QUANTUM FIREBALL EX(3\\.2|6\\.4|10\\.2)A",
+    "", "", ""
+  },
+  { "Quantum Fireball ST",
+    "QUANTUM FIREBALL ST(3.2|4.3|4300)A",
+    "", "", ""
+  },
+  { "Quantum Fireball SE",
+    "QUANTUM FIREBALL SE4.3A",
+    "", "", ""
+  },
+  { "Quantum Fireball Plus LM",
+    "QUANTUM FIREBALLP LM(10.2|15|20.[45]|30)",
+    "", "", ""
+  },
+  { "Quantum Fireball Plus AS",
+    "QUANTUM FIREBALLP AS(10.2|20.5|30.0|40.0|60.0)",
+    "", "", ""
+  },
+  { "Quantum Fireball Plus KX",
+    "QUANTUM FIREBALLP KX27.3",
+    "", "", ""
+  },
+  { "Quantum Fireball Plus KA",
+    "QUANTUM FIREBALLP KA(9|10).1",
+    "", "", ""
+  },
+
+  ////////////////////////////////////////////////////
+  // USB ID entries
+  ////////////////////////////////////////////////////
+
+  // 0x0080 (JMicron/Toshiba ?)
+  { "USB: ; JMicron JMS578",
+    "0x0080:0x0578",
+    "", // 0x0104
+    "",
+    "-d sat"
+  },
+  { "USB: ; ",
+    "0x0080:0xa001",
+    "", // ORICO 2588US3: 0x0101, 0x0203
+    "",
+    "-d sat"
+  },
+  // 0x0350 (?)
+  { "USB: ViPowER USB3.0 Storage; ",
+    "0x0350:0x0038",
+    "", // 0x1905
+    "",
+    "-d sat,12" // ATA output registers missing
+  },
+  // Hewlett-Packard
+  { "USB: HP Personal Media Drive; ",
+    "0x03f0:0x070c",
+    "",
+    "",
+    "-d usbsunplus"
+  },
+  { "USB: HP x911w; ",
+    "0x03f0:0x0c5c",
+    "",
+    "",
+     "-d sat"
+  },
+  { "USB: HP Desktop HD BD07; ", // 2TB
+    "0x03f0:0xbd07",
+    "",
+    "",
+    "-d sat"
+  },
+  // ALi
+  { "USB: ; ALi M5621", // USB->PATA
+    "0x0402:0x5621",
+    "",
+    "",
+    "" // unsupported
+  },
+  // VIA
+  { "USB: Connectland BE-USB2-35BP-LCM; VIA VT6204",
+    "0x040d:0x6204",
+    "",
+    "",
+    "" // unsupported
+  },
+  // Buffalo / Melco
+  { "USB: Buffalo; ",
+    "0x0411:0x0(157|181|1ce|1[df]9|1e[7a]|240|251|27e)", // 0x0157: HD-PEU2, 0x0181: HD-PVU2,
+      // 0x01ce: Duo, 0x01d9: HD-PCTU2 (0x0108), 0x01e7: HD-PNTU3, 0x01ea: HD-LBU2,
+      // 0x01f9: HD-PZU3 (0x0100), 0x0240: HD-PCFU3, 0x0251: HD-PNFU3, 0x027e: HD-LC3
+    "",
+    "",
+    "-d sat"
+  },
+  { "USB: Buffalo SSD-PSTA/N; ASMedia",
+    "0x0411:0x039d",
+    "",
+    "",
+    "-d sntasmedia"
+  },
+  // LG Electronics
+  { "USB: LG Mini HXD5; JMicron",
+    "0x043e:0x70f1",
+    "", // 0x0100
+    "",
+    "-d usbjmicron"
+  },
+  // Hitachi / Renesas
+  { "USB: ; Renesas uPD720231A", // USB2/3->SATA
+    // 0x0229: Pi-102 Raspberry Pi USB to mSATA Converter Board
+    // 0x022a: DeLock 62652 converter SATA 6GB/s > USB 3.0
+    "0x045b:0x022[9a]",
+    "",
+    "",
+    "-d sat"
+  },
+  // Philips
+  { "USB: Philips; ", // SDE3273FC/97 2.5" SATA HDD enclosure
+    "0x0471:0x2021",
+    "", // 0x0103
+    "",
+    "-d sat"
+  },
+  // Toshiba
+  { "USB: Toshiba Canvio 500GB; SunPlus",
+    "0x0480:0xa004",
+    "",
+    "",
+    "-d usbsunplus"
+  },
+  { "USB: Toshiba; ",
+    "0x0480:0x....",
+    "",
+    "",
+    "-d sat"
+  },
+  // Cypress
+  { "USB: ; Cypress CY7C68300A (AT2)",
+    "0x04b4:0x6830",
+    "0x0001",
+    "",
+    "" // unsupported
+  },
+  { "USB: ; Cypress CY7C68300B/C (AT2LP)",
+    "0x04b4:0x6830",
+    "0x0240",
+    "",
+    "-d usbcypress"
+  },
+  // Fujitsu
+  { "USB: Fujitsu; ",
+    "0x04c5:0x(11bc|201d|2028)", "", // 0x11bc (0x0101), 0x201d: DeLock 42475 (0x0001),
+    "", // 0x2028: Zalman ZM-VE300 (0x0001)
+    ""
+    "-d sat"
+  },
+  // Myson Century
+  { "USB: ; Myson Century CS8818",
+    "0x04cf:0x8818",
+    "", // 0xb007
+    "",
+    "" // unsupported
+  },
+  // Samsung
+  { "USB: Samsung S2 Portable; JMicron",
+    "0x04e8:0x1f0[568a]", // 0x1f0a: SAMSUNG HN-M101XBB
+    "",
+    "",
+    "-d usbjmicron" // 0x1f0a: works also with "-d sat"
+  },
+  { "USB: Samsung S1; JMicron",
+    "0x04e8:0x2f0[36]", // 0x2f03: S1 Portable, 0x2f06: S1 Mini (SAMSUNG HS20YJZ/3AU10-01)
+    "",
+    "",
+    "-d usbjmicron"
+  },
+  { "USB: Samsung Portable SSD T7; ASMedia ASM2362",
+    "0x04e8:0x(4001|61fb)", // 0x61fb: T7 Shield
+    "", // 0x0100
+    "",
+    "-d sntasmedia"
+  },
+  { "USB: Samsung Story Station; ",
+    "0x04e8:0x5f0[56]",
+    "",
+    "",
+    "-d sat"
+  },
+  { "USB: Samsung G2 Portable; JMicron",
+    "0x04e8:0x6032",
+    "0x0000",
+    "",
+    "-d usbjmicron" // ticket #132
+  },
+  { "USB: Samsung G2 Portable; ",
+    "0x04e8:0x6032",
+    "0x...[1-9]", // >= 0x0001
+    "",
+    "-d sat"
+  },
+  { "USB: Samsung Story Station 3.0; ",
+    "0x04e8:0x6052",
+    "",
+    "",
+    "-d sat"
+  },
+  { "USB: Samsung Story Station 3.0; ",
+    "0x04e8:0x6054",
+    "",
+    "",
+    "-d sat"
+  },
+  { "USB: Samsung M2 Portable 3.0; ",
+    "0x04e8:0x60c5",
+    "",
+    "",
+    "-d sat"
+  },
+  { "USB: Samsung D3 Station; ",
+    "0x04e8:0x612[45]", // 3TB, 4TB
+    "", // 0x200, 0x202
+    "",
+    "-d sat"
+  },
+  { "USB: Samsung M3 Portable USB 3.0; ", // 1.5/2TB: SpinPoint M9TU
+    "0x04e8:0x61b[3456]", // 500MB, 2TB, 1.5TB, 1TB
+    "", // 0x0e00
+    "",
+    "-d sat"
+  },
+  { "USB: Samsung S3 Portable; ",
+    "0x04e8:0x61c8", // ST1000LM025 HN-M101ABB
+    "", // 0x1301
+    "",
+    "-d sat"
+  },
+  { "USB: Samsung Portable SSD T5; ",
+    "0x04e8:0x61f5",
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  { "USB: Samsung Portable SSD T9; ASMedia ASM2362",
+    "0x04e8:0x61fd",
+    "", // 0x0100
+    "",
+    "-d sntasmedia"
+  },
+  { "USB: Samsung; ",
+    "0x04e8:0x8003", // USB3 Adapter from SSD EVO 850 Starter Kit
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  // Sony
+  { "USB: Sony HD-E1; ",
+    "0x054c:0x05bf", //  Sony HD-E1B - 1TB USB3.0
+    "", // 0x6610
+    "",
+    "-d sat"
+  },
+  // Sunplus
+  { "USB: ; SunPlus",
+    "0x04fc:0x0c05",
+    "",
+    "",
+    "-d usbsunplus"
+  },
+  { "USB: ; SunPlus SPDIF215",
+    "0x04fc:0x0c15",
+    "", // 0xf615
+    "",
+    "-d usbsunplus"
+  },
+  { "USB: ; SunPlus SPDIF225", // USB+SATA->SATA
+    "0x04fc:0x0c25",
+    "", // 0x0103
+    "",
+    "-d usbsunplus"
+  },
+  // Intrinsix
+  { "USB: ; Intrinsix",
+    "0x0578:0x0578",
+    "", // 0x0202
+    "",
+    "-d sat" // ATA output registers missing
+  },
+  // Iomega
+  { "USB: Iomega Prestige Desktop USB 3.0; ",
+    "0x059b:0x0070",
+    "", // 0x0004
+    "",
+    "-d sat" // ATA output registers missing
+  },
+  { "USB: Iomega LPHD080-0; ",
+    "0x059b:0x0272",
+    "",
+    "",
+    "-d usbcypress"
+  },
+  { "USB: Iomega MDHD500-U; JMicron",
+    "0x059b:0x0274",
+    "", // 0x0000
+    "",
+    "-d usbjmicron,0"
+  },
+  { "USB: Iomega MDHD500-U; ",
+    "0x059b:0x0275",
+    "", // 0x0001
+    "",
+    "" // unsupported
+  },
+  { "USB: Iomega; JMicron",
+    "0x059b:0x027[78]",  // 0x0277: MDHD-UE, 0x0278: LDHD-UPS
+    "", // 0x0000
+    "",
+    "-d usbjmicron"
+  },
+  { "USB: Iomega LDHD-UP; Sunplus",
+    "0x059b:0x0370",
+    "",
+    "",
+    "-d usbsunplus"
+  },
+  { "USB: Iomega; JMicron",
+    "0x059b:0x0(47[05]|57[15])", // 0x0470: LPHD-UP, 0x0475: GDHDU2 (0x0100),
+      // 0x0575: LDHD-UP
+    "",
+    "",
+    "-d usbjmicron"
+  },
+  { "USB: Iomega; JMicron",
+    "0x059b:0x047a",
+    "", // 0x0100
+    "",
+    "-d sat" // works also with "-d usbjmicron"
+  },
+  // LaCie
+  { "USB: LaCie hard disk (FA Porsche design);",
+    "0x059f:0x0651",
+    "",
+    "",
+    "" // unsupported
+  },
+  { "USB: LaCie d2 Quadra; Oxford OXUF934SSA-LQAG ", // USB+IEEE1394+eSATA->SATA
+    "0x059f:0x0828",
+    "",
+    "",
+    "-d sat"
+  },
+  { "USB: LaCie hard disk; JMicron",
+    "0x059f:0x0951",
+    "",
+    "",
+    "-d usbjmicron"
+  },
+  { "USB: LaCie Rugged Triple Interface; ",
+    "0x059f:0x100c",
+    "", // 0x0001
+    "",
+    "-d sat"
+  },
+  { "USB: LaCie Desktop Hard Drive;",
+    "0x059f:0x1010",
+    "",
+    "",
+    "-d usbsunplus"
+  },
+  { "USB: LaCie Desktop Hard Drive; ",
+    "0x059f:0x101[68]", // 0x1016: SAMSUNG HD103UJ
+    "", // 0x0001
+    "",
+    "-d sat"
+  },
+  { "USB: LaCie Desktop Hard Drive; JMicron",
+    "0x059f:0x1019",
+    "",
+    "",
+    "-d usbjmicron"
+  },
+  { "USB: LaCie Rugged Hard Drive; JMicron",
+    "0x059f:0x101d",
+    "", // 0x0001
+    "",
+    "-d usbjmicron,x"
+  },
+  { "USB: LaCie Little Disk USB2; JMicron",
+    "0x059f:0x1021",
+    "",
+    "",
+    "-d usbjmicron"
+  },
+  { "USB: LaCie hard disk; ",
+    "0x059f:0x1029",
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  { "USB: Lacie rikiki; JMicron",
+    "0x059f:0x102a",
+    "",
+    "",
+    "-d usbjmicron,x"
+  },
+  { "USB: LaCie D2 USB3; LucidPort USB300 ",
+    "0x059f:0x103d",
+    "",
+    "",
+    "-d sat"
+  },
+  { "USB: LaCie rikiki USB 3.0; ",
+    "0x059f:0x10(49|57)",
+    "",
+    "",
+    "-d sat"
+  },
+  { "USB: LaCie minimus USB 3.0; ",
+    "0x059f:0x104a",
+    "",
+    "",
+    "-d sat"
+  },
+  { "USB: LaCie Rugged Mini USB 3.0; ",
+    "0x059f:0x1051",
+    "", // 0x0000
+    "",
+    "-d sat"
+  },
+  { "USB: LaCie P9230 (LAC302002); ",
+    "0x059f:0x1053",
+    "", // 0x0000
+    "",
+    "-d sat"
+  },
+  { "USB: LaCie Rugged Mini HDD; ",
+    "0x059f:0x106b",
+    "",
+    "",
+    "-d sat"
+  },
+  { "USB: LaCie; ", // 0x1070: ASMedia 1053 ?
+    "0x059f:0x10(6f|7[05]|b8)", // 0x0x10b8: d2 PROFESSIONAL
+    "", // 6f/70/b8=0x0001, 75=0x0000
+    "",
+    "-d sat"
+  },
+  // In-System Design
+  { "USB: ; In-System/Cypress ISD-300A1",
+    "0x05ab:0x0060",
+    "", // 0x1101
+    "",
+    "-d usbcypress"
+  },
+  // Apple
+  { "USB: Apple; ",
+    "0x05ac:0x8406", // TOSHIBA MQ01UBB200
+    "",
+    "",
+    "-d sat"
+  },
+  // Genesys Logic
+  { "USB: ; Genesys Logic GL881E",
+    "0x05e3:0x0702",
+    "",
+    "",
+    "" // unsupported
+  },
+  { "USB: ; Genesys Logic",
+    "0x05e3:0x(07(18|3[15]|61)|2013)", // 0x0718(0x0041): Requires '-T permissive',
+    "", // 0x0731: Genesys Logic GL3310, Chieftec USB 3.0 2.5" case, 0x0735(0x1003): ?,
+    "", // 0x0761(0x2402): Other World Computing SATA Adapter PA023U3,
+        // 0x2013(0x0100): Sharkoon QuickPort Duo Clone USB 3.1 Type-C
+    "-d sat"
+  },
+  // Micron
+  { "USB: Micron USB SSD; ",
+    "0x0634:0x0655",
+    "",
+    "",
+    "" // unsupported
+  },
+  // Prolific
+  { "USB: ; Prolific PL2507", // USB->PATA
+    "0x067b:0x2507",
+    "",
+    "",
+    "-d usbjmicron,0" // Port number is required
+  },
+  { "USB: ; Prolific PL2571/2771/2773/2775", // USB->SATA, USB3->SATA,
+    "0x067b:0x(2571|277[135])",              // USB3+eSATA->SATA, USB3->2xSATA
+    "",
+    "",
+    "-d usbprolific"
+  },
+  { "USB: ; Prolific PL3507", // USB+IEEE1394->PATA
+    "0x067b:0x3507",
+    "", // 0x0001
+    "",
+    "-d usbjmicron,p"
+  },
+  // Imation
+  { "USB: Imation ; ", // Imation Odyssey external USB dock
+    "0x0718:0x1000",
+    "", // 0x5104
+    "",
+    "-d sat"
+  },
+  // Jess-Link
+  { "USB: Packard Bell Carbon; SunPlus",
+    "0x0766:0x0017",
+    "", // 0x0108
+    "",
+    "-d usbsunplus"
+  },
+  // Logitec
+  { "USB: Logitec LGB-4BNHUC; ",
+    "0x0789:0x0296",
+    "",
+    "",
+    "-d sat"
+  },
+  // SanDisk
+  { "USB: SanDisk; ",
+    "0x0781:0x55(8[08]|b0)", // 0x5580: SanDisk SDCZ80 (SanDisk pSSD)
+    "", // 0x55b0: Sandisk SDSSDE30-2T00 (SanDisk Portable SSD)
+    "",
+    "-d sat"
+  },
+  { "USB: SanDisk Extreme; ASMedia ASM2362",
+    "0x0781:0x55ae", // SanDisk Extreme (Western Digital SN580E 1TB)
+    "", // 0x3008
+    "",
+    "-d sntasmedia"
+  },
+  // Freecom
+  { "USB: ; Innostor IS631", // No Name USB3->SATA Enclosure
+    "0x07ab:0x0621",
+    "",
+    "",
+    "-d sat"
+  },
+  { "USB: Freecom; ",
+    "0x07ab:0xfc17",
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  { "USB: Freecom Quattro 3.0; ", // USB3.0+IEEE1394+eSATA->SATA
+    "0x07ab:0xfc77",
+    "",
+    "",
+    "-d sat"
+  },
+  { "USB: Freecom Mobile Drive XXS; JMicron",
+    "0x07ab:0xfc88",
+    "", // 0x0101
+    "",
+    "-d usbjmicron,x"
+  },
+  { "USB: Freecom Hard Drive XS; Sunplus",
+    "0x07ab:0xfc8e",
+    "", // 0x010f
+    "",
+    "-d usbsunplus"
+  },
+  { "USB: Freecom; ", // Intel labeled
+    "0x07ab:0xfc8f",
+    "", // 0x0000
+    "",
+    "-d sat"
+  },
+  { "USB: Freecom Classic HD 120GB; ",
+    "0x07ab:0xfccd",
+    "",
+    "",
+    "" // unsupported
+  },
+  { "USB: Freecom; JMicron", // 0xfc85: Freecom FHD-2 Pro / JMicron JM20316
+    "0x07ab:0xfc(85|d[6a])",
+    "",
+    "",
+    "-d usbjmicron"
+  },
+  // Fast Point Technologies
+  { "USB: ; ",
+    "0x0850:0x00(03|31)",
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  // 0x0860 (?)
+  { "USB: ; ",
+    "0x0860:0x0001",
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  // Oxford Semiconductor, Ltd
+  { "USB: ; Oxford",
+    "0x0928:0x0000",
+    "",
+    "",
+    "" // unsupported
+  },
+  { "USB: ; Oxford OXU921DS",
+    "0x0928:0x0002",
+    "",
+    "",
+    "" // unsupported
+  },
+  { "USB: ; Oxford", // Zalman ZM-VE200
+    "0x0928:0x0010",
+    "", // 0x0304
+    "",
+    "-d sat"
+  },
+  // Toshiba
+  { "USB: Toshiba PX1270E-1G16; Sunplus",
+    "0x0930:0x0b03",
+    "",
+    "",
+    "-d usbsunplus"
+  },
+  { "USB: Toshiba PX1396E-3T01; Sunplus", // similar to Dura Micro 501
+    "0x0930:0x0b09",
+    "",
+    "",
+    "-d usbsunplus"
+  },
+  { "USB: Toshiba Stor.E Steel; Sunplus",
+    "0x0930:0x0b11",
+    "",
+    "",
+    "-d usbsunplus"
+  },
+  { "USB: Toshiba Stor.E; ",
+    "0x0930:0x0b1[9ab]",
+    "", // 0x0001
+    "",
+    "-d sat"
+  },
+  { "USB: Toshiba; Sunplus",
+    "0x0930:0xa002",
+    "", // 0x0103
+    "",
+    "-d usbsunplus"
+  },
+  // Lumberg, Inc.
+  { "USB: Toshiba Stor.E; Sunplus",
+    "0x0939:0x0b1[56]",
+    "",
+    "",
+    "-d usbsunplus"
+  },
+  { "USB: Toshiba Stor.E D10; Initio INIC-1610PL",
+    "0x0939:0x0b13",
+    "",
+    "",
+    "-d sat,12"
+  },
+  // Kingston
+  { "USB: Kingston DataTraveller; ",
+    "0x0951:0x177f",
+    "",
+    "",
+    "-d sat,12"
+  },
+  { "USB: Kingston; ",
+    "0x0951:0x1780", // XS1000
+    "", // 0x100
+    "",
+    "-d sat"
+  },
+  // Apricorn
+  { "USB: Apricorn; ",
+    "0x0984:0x0(040|301|320)", // 0x0040: Apricorn SATA Wire
+    "", // 0x0301 (0x0201): Corsair SSD & HDD Cloning Kit
+    "", // 0x0320 (0x0133): Apricorn EZ-UP3 (Initio INIC-3607)
+    "-d sat"
+  },
+  // Neodio Technologies
+  { "USB: Neodio; Initio INIC-1810PL",
+    "0x0aec:0x3050",
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  // Asus (?)
+  { "USB: ; ",
+    "0x0b05:0x17f8", // ASUSTek T100TA
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  { "USB: ; ASMedia ASM236x",
+    "0x0b05:0x1932", // Asus ROG Strix Arion enclosure
+    "", // 0x0100
+    "",
+    "-d sntasmedia"
+  },
+  // Seagate
+  { "USB: Seagate External Drive; Cypress",
+    "0x0bc2:0x0503",
+    "", // 0x0240
+    "",
+    "-d usbcypress"
+  },
+  { "USB: Seagate FreeAgent; ",
+    "0x0bc2:0x(3008|50(31|a1))",
+    "",
+    "",
+    "-d sat,12" // 0x50a1: "-d sat" does not work (ticket #151)
+  },
+  { "USB: Seagate FireCuda Gaming SSD; ASMedia ASM2364",
+    "0x0bc2:0xaa1a",
+    "", // 0x100
+    "",
+    "-d sntasmedia"
+  },
+  { "USB: Seagate; ",
+    "0x0bc2:0x....",
+    "",
+    "",
+    "-d sat"
+  },
+  // Realtek
+  { "USB: ; Realtek RTL9201", // USB->SATA
+    "0x0bda:0x9201",
+    "", // 0xf200
+    "",
+    "-d sat"
+  },
+  { "USB: ; Realtek RTL9210", // USB->PCIe (NVMe)
+    "0x0bda:0x9210",
+    "", // 0x2100
+    "",
+    "-d sntrealtek"
+  },
+  { "USB: ; Realtek RTL9211", // USB->PCIe (NVMe) or SATA
+    "0x(0bda|2eb9):0x9211", // 0x0bda: guessed, 0x2eb9: Sabrent EC-WPTF
+    ".*", // fall through to next entry and report ambiguous result
+    "",
+    "-d sntrealtek" // NVMe or ...
+  },
+  { "USB: ; Realtek RTL9211",
+    "0x(0bda|2eb9):0x9211",
+    "",
+    "",
+    "" // ... SATA (unsupported)
+  },
+  { "USB: ; Realtek RTL9220", // USB->PCIe (NVMe) or SATA
+    "0x0bda:0x9220",
+    "",
+    "",
+    "-d sntrealtek" // ... SATA (requires `-d sat`)
+  },
+  // Addonics
+  { "USB: Addonics HDMU3; ", // (ticket #609)
+    "0x0bf6:0x1001",
+    "", // 0x0100
+    "",
+    ""
+  },
+  // Dura Micro
+  { "USB: Dura Micro; Cypress",
+    "0x0c0b:0xb001",
+    "", // 0x1110
+    "",
+    "-d usbcypress"
+  },
+  { "USB: Dura Micro; Initio",
+    "0x0c0b:0xb136",
+    "", // 0x0108
+    "",
+    "-d sat"
+  },
+  { "USB: Dura Micro 509; Sunplus",
+    "0x0c0b:0xb159",
+    "", // 0x0103
+    "",
+    "-d usbsunplus"
+  },
+  // Maxtor
+  { "USB: Maxtor OneTouch 200GB; ",
+    "0x0d49:0x7010",
+    "",
+    "",
+    "" // unsupported
+  },
+  { "USB: Maxtor OneTouch; ",
+    "0x0d49:0x7300",
+    "", // 0x0121
+    "",
+    "-d sat"
+  },
+  { "USB: Maxtor OneTouch 4; ",
+    "0x0d49:0x7310",
+    "", // 0x0125
+    "",
+    "-d sat"
+  },
+  { "USB: Maxtor OneTouch 4 Mini; ",
+    "0x0d49:0x7350",
+    "", // 0x0125
+    "",
+    "-d sat"
+  },
+  { "USB: Maxtor BlackArmor Portable; ",
+    "0x0d49:0x7550",
+    "",
+    "",
+    "-d sat"
+  },
+  { "USB: Maxtor Basics Desktop; ",
+    "0x0d49:0x7410",
+    "", // 0x0122
+    "",
+    "-d sat"
+  },
+  { "USB: Maxtor Basics Portable; ",
+    "0x0d49:0x7450",
+    "", // 0x0122
+    "",
+    "-d sat"
+  },
+  // Jess-Link International
+  { "USB: ; Cypress", // Medion HDDrive2Go
+    "0x0dbf:0x9001",
+    "", // 0x0240
+    "",
+    "-d usbcypress"
+  },
+  // Oyen Digital
+  { "USB: Oyen Digital MiniPro USB 3.0; ",
+    "0x0dc4:0x020a",
+    "",
+    "",
+    "-d sat"
+  },
+  // Netac Technology
+  { "USB: Netac Z Slim; ",
+    "0x0dd8:0x0562",
+    "", // 0x1101
+    "",
+    "-d sat"
+  },
+  // Cowon Systems, Inc.
+  { "USB: Cowon iAudio X5; ",
+    "0x0e21:0x0510",
+    "",
+    "",
+    "-d usbcypress"
+  },
+  // TerraMaster (?)
+  { "USB: ; ",
+    "0x1000:0x1352", // TerraMaster D5-300C 5-Bay Box
+    "",
+    "",
+    "-d sat"
+  },
+  // Apacer
+  { "USB: Apacer; ",
+    "0x1005:0xc004", // Apacer AC633
+    "",
+    "",
+    "-d sat"
+  },
+  // iRiver
+  { "USB: iRiver iHP-120/140 MP3 Player; Cypress",
+    "0x1006:0x3002",
+    "", // 0x0100
+    "",
+    "-d usbcypress"
+  },
+  // Western Digital
+  { "USB: WD My Passport (IDE); Cypress",
+    "0x1058:0x0701",
+    "", // 0x0240
+    "",
+    "-d usbcypress"
+  },
+  { "USB: Western Digital; ASMedia ASM236x",
+    "0x1058:0x266e", // WD Elements SE SSD
+    "",
+    "",
+    "-d sntasmedia"
+  },
+  { "USB: Western Digital; ",
+    "0x1058:0x....",
+    "",
+    "",
+    "-d sat"
+  },
+  // Atech Flash Technology
+  { "USB: ; Atech", // Kingston
+    "0x11b0:0x6(298|388)",
+    "", // 0x0108, 0x5408
+    "",
+    "-d sat"
+  },
+  // Brain Actuated Technologies
+  { "USB: ; Atech", // ICY BOX 2x Raid enclosure IB-RD2253-U31
+    "0x1234:0x5678",
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  // ADATA
+  { "USB: ADATA; ",
+    "0x125f:0xa(1[135]|21|31|3[57]|68|7[56]|8[35])a", // 0xa11a: Classic CH11 1TB, 0xa13a: NH13 1TB,
+    "", // 0xa15a: HD710 1TB, 0xa21a: HV610 (0x4504), 0xa31a: HV620 2TB (0x0100),
+    "", // 0xa35a: HD650 2TB (0x6503), 0xa37a: Silverstone MS10 M.2 (0x3103), 0xa75a: HD710P 4TB,
+        // 0xa68a: SD600, 0xa76a: ED600 (0x0204), 0xa83a: HD330 (0x0100),
+        // 0xa85a: HD680 (0x100)
+    "-d sat"
+  },
+  { "USB: ADATA; Cypress",
+    "0x125f:0xa9[34]a", // 0xa93a: SH93 (0x0150)
+    "",
+    "",
+    "-d usbcypress"
+  },
+  // 0x1352 (?)
+  { "USB: ; ",
+    "0x1352:0xa006", // TerraMaster D2-320
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  // Initio
+  { "USB: ; Initio",
+    "0x13fd:0x(054|1(04|15))0", // 0x0540: Initio 316000
+    "", // 0x1040 (0x0106): USB->SATA+PATA, Chieftec CEB-25I
+    "", // 0x1150: Initio 6Y120L0, CoolerMaster XCraft RX-3HU
+    "" // unsupported
+  },
+  { "USB: ; Initio",
+    "0x13fd:0x16[45]0",
+    "", // 0x1640: 0x0864, 0x1650: 0x0436
+    "",
+    "-d sat,12" // some SMART commands fail, see ticket #295
+  },
+  { "USB: ; Initio",
+    "0x13fd:0x....",
+    "",
+    "",
+    "-d sat"
+  },
+  // Phison
+  { "USB: ; ",
+    "0x13fe:0x6500", // TeamGroup C212 USB flash drive
+    "", // 0x0110
+    "",
+    "-d sntasmedia" // limited info only
+  },
+  // Super Top
+  { "USB: Super Top generic enclosure; ",
+    "0x14cd:0x6116",
+    "", // 0x0150, older report suggests -d usbcypress
+    "", // 0x0160 also reported as unsupported
+    "-d sat"
+  },
+  // JMicron
+  { "USB: ; JMicron JMS539", // USB2/3->SATA (old firmware)
+    "0x152d:0x0539",
+    "0x0100",      // 1.00, various devices support -d usbjmicron
+    "",            // 1.00, SSI SI-1359RUS3 supports -d sat,
+    ""             //       -d usbjmicron may disconnect drive (ticket #552)
+  },
+  { "USB: ; JMicron JMS539", // USB2/3->SATA (new firmware)
+    "0x152d:0x0539",
+    "0x020[56]|"   //  2.05, ZTC USB 3.0 enclosure (ticket #338)
+    "0x28(01|03|12)", // 28.01, DATOptic U3eSATA (USB3.0 bridge with port multiplier)
+    "",               // 28.03, Mediasonic ProBox HF2-SU3S2 Rev 2 (port multiplier, ticket #504)
+    "-d sat"          // 28.12, Mediasonic ProBox H82-SU3S2 (port multiplier)
+  },
+  { "USB: ; JMicron ", // USB->SATA->4xSATA (port multiplier)
+    "0x152d:0x0551",   // JMS539? (old firmware may use 0x152d:0x0539, ticket #552)
+    "", // 0x0100
+    "",
+    "-d usbjmicron,x"
+  },
+  { "USB: ; JMicron",
+    "0x152d:0x0561",
+    "", // 0x0003, ODROID CloudShell 2
+    "",
+    "-d sat"
+  },
+  { "USB: ; JMicron JMS562", // USB2/3+eSATA->2xSATA, USB2/3->3xSATA (RAID0/1)
+    "0x152d:0x0562",
+    "", // 0x0106, Fantec QB-X2US3R (ticket #966)
+    "", // only ATA IDENTIFY works, SMART commands don't work
+    "-d sat"
+  },
+  { "USB: ; JMicron", // USB2/3->2xSATA
+    "0x152d:0x0565",
+    "", // 0x9114, Akasa DuoDock X (ticket #607)
+    "",
+    "-d sat"
+  },
+  { "USB: ; JMicron JMS567", // USB2/3->SATA
+    "0x152d:0x0567",
+    "", // 0x0114
+    "", // 0x0205, 2.05, Mediasonic ProBox HF2-SU3S2 Rev 3 (port multiplier, ticket #504)
+    "-d sat"
+  },
+  { "USB: ; JMicron JMS578", // USB->SATA
+    "0x152d:0x0578",
+    "", // 0x0100, 0x0204
+    "",
+    "-d sat"
+  },
+  { "USB: ; JMicron",
+    "0x152d:0x05(79|80)", // 0x0579(0x0100): Intenso External
+    "", // 0x0100, 0x0201
+    "",
+    "-d sat"
+  },
+  { "USB: ; JMicron JMS583", // USB->PCIe (NVMe)
+    "0x152d:0x[0a]583",
+    "", // 0x214
+    "",
+    "-d sntjmicron"
+  },
+  { "USB: OCZ THROTTLE OCZESATATHR8G; JMicron JMF601",
+    "0x152d:0x0602",
+    "",
+    "",
+    "" // unsupported
+  },
+  { "USB: ; JMicron",
+    "0x152d:0x1337",
+    "", // 0x0508, Digitus DA-71106
+    "",
+    "-d sat"
+  },
+  { "USB: ; JMicron JMS561", // USB2/3->2xSATA
+    "0x152d:0x[19]561", // 0x1561(0x0106), Sabrent USB 3.0 Dual Bay SATA Dock
+    "",  // 0x9561(0x0105), Orico 6629US3-C USB 3.0 Dual Bay SATA Dock
+    "",
+    "-d sat"
+  },
+  { "USB: ; JMicron JMS576", // USB3.1->SATA
+    "0x152d:0x[01]576",
+    "", // 0x0204, ICY BOX IB-223U3a-B
+    "",
+    "-d sat"
+  },
+  { "USB: ; JMicron JM20329", // USB->SATA
+    "0x152d:0x2329",
+    "", // 0x0100
+    "",
+    "-d usbjmicron"
+  },
+  { "USB: ; JMicron JM20336", // USB+SATA->SATA, USB->2xSATA
+    "0x152d:0x2336",
+    "", // 0x0100
+    "",
+    "-d usbjmicron,x"
+  },
+  { "USB: Generic JMicron adapter; JMicron",
+    "0x152d:0x2337",
+    "",
+    "",
+    "-d usbjmicron"
+  },
+  { "USB: ; JMicron JM20337/8", // USB->SATA+PATA, USB+SATA->PATA
+    "0x152d:0x2338",
+    "", // 0x0100
+    "",
+    "-d usbjmicron"
+  },
+  { "USB: ; JMicron JM20339", // USB->SATA
+    "0x152d:0x2339",
+    "", // 0x0100
+    "",
+    "-d usbjmicron,x"
+  },
+  { "USB: ; JMicron", // USB+SATA->SATA
+    "0x152d:0x2351",  // e.g. Verbatim Portable Hard Drive 500Gb
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  { "USB: ; JMicron", // USB->SATA
+    "0x152d:0x2352",
+    "", // 0x0100
+    "",
+    "-d usbjmicron,x"
+  },
+  { "USB: ; JMicron", // USB->SATA
+    "0x152d:0x2509",
+    "0x0100", // old firmware
+    "",
+    "-d usbjmicron,x"
+  },
+  { "USB: ; JMicron", // USB->SATA
+    "0x152d:0x2509",
+    "0x0107", // newer firmware supports SAT
+    "",
+    "-d sat"
+  },
+  { "USB: ; JMicron JMS566", // USB3->SATA
+    "0x152d:0x2566", // e.g. Chieftec CEB-7035S
+    "", // 0x0114
+    "",
+    "-d usbjmicron,x"
+  },
+  { "USB: ; JMicron JMS567", // USB3->SATA
+    "0x152d:0x2567",
+    "", // 0x0117, Chieftec CEB-7053S
+    "",
+    "-d sat"
+  },
+  { "USB: ; JMicron",
+    "0x152d:0x2590",
+    "", // 0x0x8105 (ticket #550)
+    "",
+    "-d sat"
+  },
+  { "USB: ; JMicron JMS567", // USB2/3->SATA
+    "0x152d:0x3562",
+    "", // 0x0310, StarTech S358BU33ERM (port multiplier, ticket #508)
+    "",
+    "-d sat"
+  },
+  { "USB: ; JMicron", // USB3->SATA
+    "0x152d:0x3569",
+    "", // 0x0203
+    "",
+    "-d sat"
+  },
+  { "USB: ; JMicron",
+    "0x152d:0x(578e|a5(78|80)|b567)",
+    "", // 0x578e(0x1402): Intenso Memory Center, 0xa578: Sabrent EC-DFLT,
+    "", // 0xa580(0x003): CENMATE 2 Bay RAID Enclosure, 0xb567: Fantec AD-U3S
+    "-d sat"
+  },
+  { "USB: ; JMicron JMS561", // USB3->2xSATA
+    "0x152d:0x[8a]561",
+    "", // 0x8561: 0x0107
+    "",
+    "-d sat"
+  },
+  { "USB: ; JMicron JMS581", // USB3.2->SATA+PCIe (NVMe)
+    "0x152d:0xb581",
+    "", // 0x4403: Unitek M.2 NVMe/SATA USB adapter
+    "",
+    "-d sntjmicron/sat"
+  },
+  // PNY
+  { "USB: ; PNY",
+    "0x154b:0x(5678|8001|f009)",
+    "", // 0x5678: 0x5408
+    "",
+    "-d sat"
+  },
+  // Pinas
+  { "USB: ; Pinas",
+    "0x1741:0x1156", // Argon EON, device #2
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  // ASMedia
+  { "USB: ; ASMedia ASM236x", // USB->PCIe (NVMe)
+    "0x174c:0x236[24]",
+    "",
+    "",
+    "-d sntasmedia"
+  },
+  { "USB: ; ASMedia",
+    "0x174c:0x....",
+    "",
+    "",
+    "-d sat"
+  },
+  // ASMedia
+  { "USB: ; ASMedia ASM1352-PM", // USB3->2xSATA
+    "0x174d:0x1352",
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  // Pinas
+  { "USB: ; Pinas",
+    "0x174e:0x1155", // Argon EON, device #1
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  // LucidPort
+  { "USB: ; LucidPORT USB300", // RaidSonic ICY BOX IB-110StU3-B, Sharkoon SATA QuickPort H3
+    "0x1759:0x500[02]", // 0x5000: USB 2.0, 0x5002: USB 3.0
+    "",
+    "",
+    "-d sat"
+  },
+  { "USB: ; LucidPort", // Fuj:tech SATA-USB3 dock
+    "0x1759:0x5100",
+    "", // 0x2580
+    "",
+    "-d sat"
+  },
+  // Verbatim
+  { "USB: Verbatim Portable Hard Drive; Sunplus",
+    "0x18a5:0x0214",
+    "", // 0x0112
+    "",
+    "-d usbsunplus"
+  },
+  { "USB: Verbatim FW/USB160; Oxford OXUF934SSA-LQAG", // USB+IEEE1394->SATA
+    "0x18a5:0x0215",
+    "", // 0x0001
+    "",
+    "-d sat"
+  },
+  { "USB: Verbatim External Hard Drive 47519; Sunplus", // USB->SATA
+    "0x18a5:0x0216",
+    "",
+    "",
+    "-d usbsunplus"
+  },
+  { "USB: Verbatim Pocket Hard Drive; JMicron", // SAMSUNG HS25YJZ/3AU10-01
+    "0x18a5:0x0227",
+    "",
+    "",
+    "-d usbjmicron" // "-d usbjmicron,x" does not work
+  },
+  { "USB: Verbatim External Hard Drive; JMicron", // 2TB
+    "0x18a5:0x022a",
+    "",
+    "",
+    "-d usbjmicron"
+  },
+  { "USB: Verbatim Store'n'Go; JMicron", // USB->SATA
+    "0x18a5:0x022b",
+    "", // 0x0100
+    "",
+    "-d usbjmicron"
+  },
+  { "USB: Verbatim Pocket Hard Drive; ", // 1TB USB 3.0
+    "0x18a5:0x0237",
+    "",
+    "",
+    "-d sat,12"
+  },
+  { "USB: Verbatim External Hard Drive; ", // USB 3.0
+    "0x18a5:0x04(0[08]|46)", // 00=3TB, 08=1TB, 46=500MB Mobile
+    "",
+    "",
+    "-d sat"
+  },
+  // Silicon Image
+  { "USB: Vantec NST-400MX-SR; Silicon Image 5744",
+    "0x1a4a:0x1670",
+    "",
+    "",
+    "" // unsupported
+  },
+  // Corsair
+  { "USB: Voyager GTX; ",
+    "0x1b1c:0x1a0e",
+    "",
+    "",
+    "-d sat"
+  },
+  // SunplusIT
+  { "USB: ; SunplusIT",
+    "0x1bcf:0x0c31",
+    "",
+    "",
+    "-d usbsunplus"
+  },
+  // Actions Microelectronics
+  { "USB: ; Actions AM8180", // rebranded Realtek RTL9210
+    "0x1de1:0xe101",
+    "", // 0x2001
+    "",
+    "-d sntrealtek"
+  },
+  // Kanguru Solutions
+  { "USB: ; ", // ICY BOX IB-256WP
+    "0x1e1d:0x20a0",
+    "", // 0x3203
+    "",
+    "-d sat" // ATA output registers missing
+  },
+  // TrekStor
+  { "USB: TrekStor DataStation; ", // DataStation maxi light (USB 3.0)
+    "0x1e68:0x0050",
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  // Other World Computing
+  { "USB: OWC Envoy Pro; ",
+    "0x1e91:0xa2a5",
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  { "USB: OWC Mercury Elite Pro Quad; ",
+    "0x1e91:0xa4a7",
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  // Innostor
+  { "USB: ; Innostor IS611", // USB3->SATA+PATA
+    "0x1f75:0x0611", // SMART access via PATA does not work
+    "",
+    "",
+    "-d sat"
+  },
+  { "USB: ; Innostor IS621", // USB3->SATA
+    "0x1f75:0x0621", // Dynex 2.5" USB 3.0 Exclosure DX-HD302513
+    "",
+    "",
+    "-d sat"
+  },
+  { "USB: ; Innostor IS888", // USB3->SATA
+    "0x1f75:0x0888",
+    "", // 0x0034, Sharkoon SATA QuickDeck Pro USB 3.0 (unsupported)
+    "", // 0x0036, works with -d sat (ticket #827)
+    "-d sat"
+  },
+  // VIA Labs
+  { "USB: ; VIA VL700", // USB2/3->SATA
+    "0x2109:0x0700", // Diginote 2.5" USB-3.0 HDD enclosure 80000894
+    "", // 0x0005
+    "",
+    "-d sat,12" // ATA output registers missing
+  },
+  { "USB: ; VIA VL701", // USB2/3->SATA
+    "0x2109:0x0701", // Intenso 2,5" 1TB USB3
+    "", // 0x0107
+    "",
+    "-d sat" // ATA output registers missing
+  },
+  { "USB: ; VIA VL711", // USB2/3->SATA
+    "0x2109:0x0711",
+    "", // 0x0114, Mediasonic ProBox K32-SU3 (ticket #594)
+    "", // 0x0507, Intenso 2,5" Memory Case 2TB USB3
+    "-d sat"
+  },
+  { "USB: ; VIA VL715/6/7", // USB2/3->SATA, USB-C->SATA
+    "0x2109:0x071[567]",
+    "", // 0x0336/0x0000
+    "",
+    "-d sat"
+  },
+  // Transcend (?)
+  { "USB: Transcend ESD310/400; ",
+    "0x2174:0x2[01]00", // 0x2000: TS256GESD400K. 0x2100: TS512GESD310C
+    "", // 0x1000, 0x0100
+    "",
+    "-d sat"
+  },
+  // 0x235c (?)
+  { "USB: ; ",
+    "0x235c:0xa006", // Terramaster D4-320 (see also 0x5432:0x235c)
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  // Norelsys
+  { "USB: ; ", // USB 3.0
+    "0x2537:0x106[68]", // 0x1066: Orico 2599US3, 0x1068: Fantec ER-35U3
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  // 0x2bdf (?)
+  { "USB: ; ",
+    "0x2bdf:0x0580", // HIKSEMI
+    "", // 0x1601
+    "",
+    "-d sat"
+  },
+  // InX8 / AKiTiO
+  { "USB: AkiTio NT2 U3.1C; ",
+    "0x2ce5:0x0014",
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  // 0x2eb9 (?): See Realtek (0x0bda) above
+  // KIOXIA (?)
+  { "USB: ; ", // KIOXIA EXCERIA PLUS
+    "0x30de:0x1000",
+    "",
+    "",
+    "-d sntjmicron"
+  },
+  // 0x31db (?)
+  { "USB: ; ",
+    "0x31db:0x0716", // DockCase 10s PLP 2.5" Enclosure
+    "", // 0x0148
+    "",
+    "-d sat"
+  },
+  // Power Quotient International
+  { "USB: PQI bridge; ",
+    "0x3538:0x0064",
+    "",
+    "",
+    "-d usbsunplus"
+  },
+  { "USB: PQI H560; ",
+    "0x3538:0x0902",
+    "", // 0x0000
+    "",
+    "-d sat"
+  },
+  // Sharkoon
+  { "USB: Sharkoon QuickPort XT USB 3.0; ",
+    "0x357d:0x7788",
+    "",
+    "",
+    "-d sat"
+  },
+  // Hitachi/SimpleTech
+  { "USB: Hitachi Touro Desk; JMicron", // 3TB
+    "0x4971:0x1011",
+    "",
+    "",
+    "-d usbjmicron"
+  },
+  { "USB: Hitachi Touro; ",
+    "0x4971:0x101[345]", // 14=1TB, 15=2TB, 13=Touro Desk Pro 3TB
+    "", // 0x0000
+    "",
+    "-d sat" // ATA output registers missing
+  },
+  { "USB: Hitachi Touro Mobile; ", // 1TB
+    "0x4971:0x102[034]",
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  { "USB: SimpleTech;", // USB 3.0 HDD BOX Agestar,  Rock External HDD 3,5" UASP
+    "0x4971:0x8017",
+    "",
+    "",
+    "-d sat"
+  },
+  { "USB: Hitachi/SimpleTech; JMicron", // 1TB
+    "0x4971:0xce17",
+    "",
+    "",
+    "-d usbjmicron,x"
+  },
+  // 0x5432 (?)
+  { "USB: ; ",
+    "0x5432:0x235c", // TerraMaster D4-320 (see also 0x235c:0xa006)
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  // OnSpec
+  { "USB: ; OnSpec", // USB->PATA
+    "0x55aa:0x2b00",
+    "", // 0x0100
+    "",
+    "" // unsupported
+  },
+  // 0x5910 (?)
+  { "USB: ; ",
+    "0x5910:0x13fd", // Sabrent EC-SSHD
+    "", // 0x0153
+    "",
+    "-d sat"
+  },
+  // 0x6795 (?)
+  { "USB: Sharkoon 2-Bay RAID Box; ", // USB 3.0
+    "0x6795:0x2756",
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
+  // Transcend
+  { "USB: ; ",
+    "0x8564:0x7000",
+    "", // 0x8000
+    "",
+    "-d sat"
+  },
+  // Other World Computing
+  { "USB: USB3 to SATA; ",
+    "0x7825:0xa2a4",
+    "", // 0x4101
+    "",
+    "-d sat"
+  },
+  // JMicron II
+  { "USB: ; JMicron JMS566",
+    "0xa152:0xb566",
+    "", // 0x0223
+    "",
+    "-d sat"
+  },
+  // 0xab12 (?)
+  { "USB: ; JMicron JMS578",
+    "0xab12:0x34cd",
+    "", // 0x0405
+    "",
+    "-d sat"
+  },
+  // Logilink
+  { "USB: ; ",
+    "0xabcd:0x610[34]", // 0x6103: LogiLink AU0028A V1.0 USB 3.0 to IDE & SATA Adapter
+      // 0x6104: LogiLink PCCloneEX Lite
+    "",
+    "",
+    "-d sat"
+  },
+/*
+}; // builtin_knowndrives[]
+ */
+

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,13 @@
 $Id$
 
+2025-05-31  Christian Franke  <franke@computer.org>
+
+	Prepare the move of smartmontools from SourceForge svn to GitHub
+
+	Create svn tag 'PRE_MOVE_TO_GIT' from svn 'trunk'.
+	Retire the git 'master' branch.
+	The git HEAD will be switched to a new independent 'main' branch.
+
 2025-04-30  Christian Franke  <franke@computer.org>
 
 	smartmontools 7.5

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,10 @@
 $Id$
 
+2024-10-05  Christian Franke  <franke@computer.org>
+
+	scsicmds.cpp: Fix range checks of mode page offset and VPD inquiry
+	(GH issues/272).
+
 2024-09-29  Ru Wang  <ru.wang@seagate.com>
 
 	farmprint.cpp (GH pull/285):

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,12 @@
 $Id$
 
+2025-04-21  Christian Franke  <franke@computer.org>
+
+	smartd.cpp: Handle only 'Available Spare' as prefailure value.
+
+	Enable logging of 'Percentage Used' and 'Media and Data Integrity
+	Errors' with '-u' instead of '-p'.  Enable LOG_CRIT with '-f'.
+
 2025-04-19  Christian Franke  <franke@computer.org>
 
 	smartd.cpp: Report changes of prefailure NVMe SMART/Health values.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,8 @@ $Id$
 
 2025-04-22  Christian Franke  <franke@computer.org>
 
+	smartd.cpp: Fix validity check for SCSI attribute log (#1245).
+
 	smartd.cpp: Add missing 'static'.
 
 	smartd.8.in, smartd.conf.5.in: Update EXPERIMENTAL notes.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,12 @@
 $Id$
 
+2024-11-20  Eaton Zveare  <eaton@eaton-works.com>
+
+	Increase WMI timeout on Windows to address issues when
+	reading USB device ID.
+
+	(GH pull/277)
+
 2024-11-20  Robin Schneider  <ypid@riseup.net>
 
 	man pages: Fix typo, '-l directory,q' was mentioned but only

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,8 @@ $Id$
 
 2024-10-15  Christian Franke  <franke@computer.org>
 
+	nvmecmds.cpp: Map 'Set Feature' related errors to EINVAL (#1835).
+
 	ataprint.cpp: Don't return failure if '-l scterc' is not supported.
 
 	Only return failure (exit status 4) if a SCT command failed or an

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,8 @@ $Id$
 
 2025-04-21  Christian Franke  <franke@computer.org>
 
+	smartd.conf.5.in: Rework '-H -f -p -u -t -a' and add NVMe info.
+
 	smartd.cpp: Handle only 'Available Spare' as prefailure value.
 
 	Enable logging of 'Percentage Used' and 'Media and Data Integrity

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,9 @@
 $Id$
 
+2024-10-26  Christian Franke  <franke@computer.org>
+
+	autogen.sh: Add check for CR/LF, remove Cygwin specific check.
+
 2024-10-26  Aleksander Jan Bajkowski  <olek2@wp.pl>
 
 	autogen.sh: Allow to build with automake 1.17 (GH pull/292).

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,11 @@
 $Id$
 
+2025-03-14  ThunderEX  <thunderex@gmail.com>
+
+	farmprint.cpp: Fix unit of write power on time.
+
+	(GH pull/328)
+
 2025-02-24  Ross Lagerwall  <ross.lagerwall@citrix.com>
 
 	scsicmds.cpp:

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,14 @@
 $Id$
 
+2025-03-20  Christian Franke  <franke@computer.org>
+
+	smartctl.cpp: Exclude '-g wcreorder' from '-x' (#1702).
+
+	ATA ACS only offers a support check for the SCT FEATURE CONTROL
+	command, but not for its GET WRITE CACHE REORDERING subcommand.
+	If this subcommand fails, the next ATA command (SMART READ DATA)
+	may also fail in some cases.
+
 2025-03-17  Christian Franke  <franke@computer.org>
 
 	drivedb.h:

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,12 @@ $Id$
 
 2025-02-02  Christian Franke  <franke@computer.org>
 
+	*print.cpp: Add JSON values for endurance and available spare.
+
+	'endurance_used.current_percent' is added for ATA, SCSI and NVMe,
+	'spare_available.{current,threshold}_percent' are added for ATA and
+	NVMe.
+
 	smartd.cpp: Drop support for platforms without 'sigaction()'.
 
 	configure.ac: Fail if '--with-signal-func' is used.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,8 @@ $Id$
 
 2025-04-22  Christian Franke  <franke@computer.org>
 
+	smartd.conf.5.in: Document '-H MASK'.
+
 	smartd.cpp: Allow to configure checked NVMe Critical Warning bits.
 
 	Add optional MASK parameter to '-H' directive to specify the bits

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,11 @@
 $Id$
 
+2024-09-29  Ru Wang  <ru.wang@seagate.com>
+
+	farmprint.cpp (GH pull/285):
+	- Fix SATA decode of dateOfAssembly.
+	- Uninitialized string (part from GH issues/272).
+
 2024-09-23  Christian Franke  <franke@computer.org>
 
 	os_win32.cpp: Decode Windows 11 23H2 and 24H2 build numbers.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,16 @@
 $Id$
 
+2025-02-05  Christian Franke  <franke@computer.org>
+
+	drivedb.h:
+	- USB: HP x911w (0x03f0:0x0c5c) (GH issues/315).
+	- USB: Add Samsung Portable SSD T9 (0x04e8:0x61fd) (#1904).
+	- USB: Asus Arion (0x0b05:0x1932) (GH issues/303).
+	- USB: WD Elements SE SSD (0x1058:0x266e) (GH issues/230).
+	- USB: TeamGroup C212 flash drive (0x13fe:0x6500) (GH issues/302).
+	- USB: TerraMaster D4-320 (0x5432:0x235c) (#1925).
+	- USB: Sabrent EC-SSHD (0x5910:0x13fd).
+
 2025-02-02  Christian Franke  <franke@computer.org>
 
 	*print.cpp: Add JSON values for endurance and available spare.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,8 @@ $Id$
 
 2025-04-21  Christian Franke  <franke@computer.org>
 
+	smartd.8.in: Rework '-A' and '-s' and add NVMe info.
+
 	smartd.conf.5.in: Rework '-H -f -p -u -t -a' and add NVMe info.
 
 	smartd.cpp: Handle only 'Available Spare' as prefailure value.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,11 @@
 $Id$
 
+2025-04-02  Lucas Holt  <luke@foolishgames.com>
+
+	configure.ac: Treat MidnightBSD like FreeBSD for host detection.
+
+	(GH pull/333)
+
 2025-03-27  Christian Franke  <franke@computer.org>
 
 	farmprint.cpp: Suppress serial and WWN if '-q noserial' is used.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,9 @@
 $Id$
 
+2024-12-10  Christian Franke  <franke@computer.org>
+
+	smartctl.8.in, smartd.conf.5.in: Document '-d jmb39x-q2,...'.
+
 2024-12-10  Rodrigo Araujo  <araujo.rm@gmail.com>
 
 	dev_jmb39x_raid.cpp: support QNAP-TR002 NAS

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,10 @@
 $Id$
 
+2025-02-24  Ross Lagerwall  <ross.lagerwall@citrix.com>
+
+	scsicmds.cpp:
+	- Fix buffer overflow parsing VPD page 0x83 (#1934)
+
 2025-02-15  Christian Franke  <franke@computer.org>
 
 	ataprint.cpp: Add support for '-l farm -T permissive'.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -10,6 +10,9 @@ $Id$
 	- Phison Driven SSDs: DGSR2*GP13T (#1917), PS3110 256GB (#1829),
 	  S11-*-PHISON-SSD-B27.
 	- Phison Driven OEM SSDs: Goodram CX400 G2 (#1928).
+	- USB: Buffalo (0x0411:0x0...): Merge '-d sat' entries.
+	- USB: Buffalo SSD-PSTA/N (0x0411:0x039d) (GH pull/307).
+	- USB: Packard Bell Carbon (0x0766:0x0017) (#1933).
 
 2025-03-17  Glucy2 <glucy-2@outlook.com>
 

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,8 @@ $Id$
 
 2025-04-21  Christian Franke  <franke@computer.org>
 
+	man pages: Enable NVMe related information for all platforms.
+
 	smartd.conf.5.in: Remove outdated information about old controllers.
 
 	smartd.8.in: Rework '-A' and '-s' and add NVMe info.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,9 @@
 $Id$
 
+2025-04-22  Christian Franke  <franke@computer.org>
+
+	smartd.8.in, smartd.conf.5.in: Update EXPERIMENTAL notes.
+
 2025-04-21  Christian Franke  <franke@computer.org>
 
 	man pages: Enable NVMe related information for all platforms.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,8 @@ $Id$
 
 2025-04-29  Christian Franke  <franke@computer.org>
 
+	ataprint.cpp: ACS-6 updates.
+
 	popen_as_ugid.cpp: Add missing config.h.
 
 	os_win32/update-smart-drivedb.ps1.in: Print download command if

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,8 @@ $Id$
 
 2025-01-26  Christian Franke  <franke@computer.org>
 
+	drivedb.h: Drop maintenance of 6.5-6.6 branches.
+
 	drivedb.h:
 	- SandForce Driven SSDs: OCZ-VERTEX3.20 (#1924).
 	- Intel/Solidigm S46x0/S45x0 Series SSDs: Rename, add Solidigm (#1878).

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,10 @@ $Id$
 
 2024-10-23  Christian Franke  <franke@computer.org>
 
+	nvmeprint.cpp: Support SMART/Health Information per namespace.
+	nvmecmds.*: Add parameter 'nsid' to 'nvme_read_smart_log()'.
+	smartctl.8.in: Document this new feature.
+
 	nvmecmds.h: Add 'nvme_broadcast_nsid' and use it where applicable.
 
 	smartctl.8.in: Update documentation of NVMe '-l selftest'.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,9 @@
 $Id$
 
+2025-01-02  Christian Franke  <franke@computer.org>
+
+	smartd.cpp: Avoid invalid "old test ... not run" message.
+
 2025-01-01  Christian Franke  <franke@computer.org>
 
 	Happy New Year!  Update copyright year in version info.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,16 @@
 $Id$
 
+2024-11-12  Christian Franke  <franke@computer.org>
+
+	smartd.cpp: Add support for NVMe self-tests.
+
+	Support '-l selftest', '-l selfteststs' and '-s ...' for NVMe
+	(#1649, #1813, GH issues/218, GH pull/219).
+	Minor rework of ATA/SCSI self-test code to re-use its count/hours
+	heuristics which detects new self-test errors.
+
+	smartd.conf.5.in: Document this new feature.
+
 2024-10-26  Christian Franke  <franke@computer.org>
 
 	autogen.sh: Add check for CR/LF, remove Cygwin specific check.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,11 @@
 $Id$
 
+2025-04-15  Christian Franke  <franke@computer.org>
+
+	smartd.cpp: Add NVMe attribute logs.
+
+	(#1190, GH pull/221, GH pull/281)
+
 2025-04-14  Christian Franke  <franke@computer.org>
 
 	nvmeprint.cpp: Add JSON support for NVMe capabilities.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,18 @@
 $Id$
 
+2025-04-26  Christian Franke  <franke@computer.org>
+
+	drivedb.h:
+	- Micron 5100 / 52x0 / 5300 / 5400 SSDs: 5400 *_SED variant (#1950).
+	- Phison Driven OEM SSDs: Gigastone GSTB512G (#1947).
+	- Silicon Motion based SSDs: Transcend SSD230S 2/4TB
+	  (GH issues/240, GH pull/241).
+	- Silicon Motion based OEM SSDs: Intenso M.2 SSD High (#1945),
+	  Intenso SSD Sata III/S0222A0 (#1948).
+	- SSSTC ERX GD/CD Series SSDs: 7.68TB, 15.36TB (#1946).
+	- Seagate Exos 7E8: OOS6000G (GH issues/320).
+	- Seagate Exos X20: OOS20000G.
+
 2025-04-26  Michael Brünen  <mibruenen@gmail.com>
 
 	drivedb.h:

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,21 @@ $Id$
 
 2024-10-15  Christian Franke  <franke@computer.org>
 
+	drivedb.h:
+	- USB: Genesis Logic (0x05e3:0x0761) (GH issues/259).
+	- USB: SanDisk Extreme (0x0781:0x55ae) (GH issues/273).
+	- USB: Kingston XS1000 (0x0951:0x1780) (part of #1834).
+	- USB: Realtek RTL9201 (0x0bda:0x9201) (part of #1841,
+	  GH issues/268, /270).
+	- USB: Apacer AC633 (0x1005:0xc004) (#1893).
+	- USB: TerraMaster D2-320 (0x1352:0xa006) (GH issues/283).
+	- USB: JMicron (0x152d:0xa578).
+	- USB: JMicron (0x152d:0xa580) (GH pull/276, GH issues/289).
+	- USB: Terramaster D4-320 (0x235c:0xa006) (#1856, #1874).
+	- USB: HIKSEMI (0x2bdf:0x0580) (#1883).
+	- USB: DockCase 10s PLP (0x31db:0x0716) (GH issues/284).
+	- USB: Hitachi Touro Desk Pro (0x4971:0x1013).
+
 	nvmecmds.cpp: Map 'Set Feature' related errors to EINVAL (#1835).
 
 	ataprint.cpp: Don't return failure if '-l scterc' is not supported.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,9 @@
 $Id$
 
+2025-04-14  Christian Franke  <franke@computer.org>
+
+	nvmeprint.cpp: Add JSON support for NVMe capabilities.
+
 2025-04-13  Christian Franke  <franke@computer.org>
 
 	do_release: Set SOURCE_DATE_EPOCH for reproducible tarball.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,8 @@ $Id$
 
 2025-04-21  Christian Franke  <franke@computer.org>
 
+	smartd.conf.5.in: Remove outdated information about old controllers.
+
 	smartd.8.in: Rework '-A' and '-s' and add NVMe info.
 
 	smartd.conf.5.in: Rework '-H -f -p -u -t -a' and add NVMe info.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,12 @@
 $Id$
 
+2024-11-18  Martin Ziemer  <horrad@horrad.de>
+
+	openbsd_nvme_ioctl.h, os_openbsd.cpp: Enable NVMe on OpenBSD
+	smartctl.8.in, smartd.8.in: Add OpenBSD in documentation for NVMe
+
+	(#729, GH pull/299)
+
 2024-11-17  Christian Franke  <franke@computer.org>
 
 	smartd.cpp: Ignore NSID in duplicate check of single namespace

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,9 @@
 $Id$
 
+2025-01-01  Christian Franke  <franke@computer.org>
+
+	Happy New Year!  Update copyright year in version info.
+
 2024-12-10  Christian Franke  <franke@computer.org>
 
 	smartctl.8.in, smartd.conf.5.in: Document '-d jmb39x-q2,...'.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,11 @@
 $Id$
 
+2025-03-17  Daniel SWB  <daniel.swb.gh@gmail.com>
+
+	drivedb.h: Swissbit X-7x, X-8x family SATA SSD
+
+	(GH pull/322)
+
 2025-03-14  Christian Franke  <franke@computer.org>
 
 	os_linux.cpp: Drop autodetection of deprecated type 'marvell'.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,9 @@
 $Id$
 
+2024-11-30  Christian Franke  <franke@computer.org>
+
+	os_win32.cpp: Decode Windows Server 2025 build number.
+
 2024-11-20  Eaton Zveare  <eaton@eaton-works.com>
 
 	Increase WMI timeout on Windows to address issues when

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,11 @@
 $Id$
 
+2025-01-24  Andrew Sayers  <andrew-github.com@pileofstuff.org>
+
+	smartd.service: silence "Referenced but unset environment variable" warning
+
+	(GH pull/316)
+
 2025-01-15  Oleksii Samorukov <samm@os2.kiev.ua>
 
 	sntjmicron: workaround to avoid USB reset on selftest log query (GH: #256).

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,9 @@
 $Id$
 
+2025-03-14  Christian Franke  <franke@computer.org>
+
+	os_linux.cpp: Drop autodetection of deprecated type 'marvell'.
+
 2025-03-14  ThunderEX  <thunderex@gmail.com>
 
 	farmprint.cpp: Fix unit of write power on time.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,13 @@
 $Id$
 
+2024-10-16  Christian Franke  <franke@computer.org>
+
+	drivedb.h:
+	- Micron 5100 / 52x0 / 5300 / 5400 SSDs: 5300 variant without vendor
+	  prefix (#1877).
+	- WD Blue / Red / Green SSDs: SanDisk Portable SSD (#1743).
+	- USB: Sandisk SDSSDE30-2T00 (0x0781:0x55b0) (#1743).
+
 2024-10-15  Christian Franke  <franke@computer.org>
 
 	drivedb.h:

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,16 @@
 $Id$
 
+2025-04-26  Michael Brünen  <mibruenen@gmail.com>
+
+	drivedb.h:
+	- WD Ultrastar DC HC530: Attribute 188.
+	- Seagate Enterprise Capacity 3.5 HDD v7 SED.
+	- Seagate Exos 7E8: Attribute 188.
+	- Seagate Exos X16: Attributes 1, 7 and 188.
+	- Seagate IronWolf Pro: Attribute 188, 22TB, *NT001 variant.
+
+	(GH pull/247)
+
 2025-04-25  Christian Franke  <franke@computer.org>
 
 	drivedb.h:

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,8 @@ $Id$
 
 2025-03-20  Christian Franke  <franke@computer.org>
 
+	scsinvme.cpp: Remove unneeded function 'sntjmicron_device::open()'.
+
 	scsinvme.cpp: Remove outdated check for 'sntjmicron#please_try'.
 
 	smartctl.cpp: Exclude '-g wcreorder' from '-x' (#1702).

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,8 @@ $Id$
 
 2025-03-20  Christian Franke  <franke@computer.org>
 
+	scsinvme.cpp: Add NVMe/SAT autodetection if '-d snt*/sat' is used.
+
 	dev_interface.h: Make 'smart_interface::get_sat_device()' public.
 	This allows usage within 'autodetect_open()' functions.
 

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,9 @@
 $Id$
 
+2025-04-13  Christian Franke  <franke@computer.org>
+
+	do_release: Set SOURCE_DATE_EPOCH for reproducible tarball.
+
 2025-04-02  Lucas Holt  <luke@foolishgames.com>
 
 	configure.ac: Treat MidnightBSD like FreeBSD for host detection.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,19 @@
 $Id$
 
+2025-04-27  Christian Franke  <franke@computer.org>
+
+	drivedb.h:
+	- Phison Driven SSDs: PNY CS900/1311/2211 1TB, 2TB (GH pull/201).
+	- Hitachi/HGST Ultrastar 7K4000: HITACHI variant (#1791),
+	  4.5TB (GH pull/305).
+	- Western Digital Ultrastar HC*: Attribute 22 is in "DEFAULT" entry.
+	- Seagate Exos X20/X22: Rename, add X22 (#1932).
+	- Seagate IronWolf: Attribute 188 (GH issues/319), *VN000,
+	  *VN002 (GH issues/246), *VN006 (#1687, GH issues/157), 14TB, 16TB.
+	- Seagate IronWolf Pro: 16TB (#1836), 18TB, 20TB.
+	- USB: Fujitsu (0x04c5:0x11bc) (#1938).
+	- USB: ADATA HD680 (0x125f:0xa85a) (#1764).
+
 2025-04-26  Christian Franke  <franke@computer.org>
 
 	drivedb.h:

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,10 @@ $Id$
 
 2025-04-25  Christian Franke  <franke@computer.org>
 
+	drivedb.h:
+	- Bump branch VERSION to 7.5.
+	- JMicron JMS581 (0x152d:0xb581) (GH issues/275).
+
 	configure.ac: Use RELEASE_7_5_DRIVEDB for drivedb.h updates.
 
 	update-smart-drivedb.*: Use current gpg key also for 7.5 branch.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,9 +2,10 @@ $Id$
 
 2025-02-02  Christian Franke  <franke@computer.org>
 
+	configure.ac: Remove defunct '--with-solaris-sparc-ata'.
+
 	configure.ac: Change default for '--with-nvme-devicescan' to 'yes' on
 	NetBSD.  Update related warnings.
-
 
 2025-01-26  Christian Franke  <franke@computer.org>
 

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,9 @@
 $Id$
 
+2025-04-25  Christian Franke  <franke@computer.org>
+
+	Create new branch RELEASE_7_5_DRIVEDB.
+
 2025-04-22  Christian Franke  <franke@computer.org>
 
 	smartd.conf.5.in: Document '-H MASK'.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -5,6 +5,8 @@ $Id$
 	drivedb.h:
 	- Micron 5100 / 52x0 / 5300 / 5400 SSDs: 5300 variant without vendor
 	  prefix (#1877).
+	- Toshiba 2.5" HDD MQ04UBB... (USB, SMR) (#1400, #1821, #1832).
+	- Toshiba MG11 Cloud-scale Capacity HDD.
 	- WD Blue / Red / Green SSDs: SanDisk Portable SSD (#1743).
 	- USB: Sandisk SDSSDE30-2T00 (0x0781:0x55b0) (#1743).
 

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,8 @@ $Id$
 
 2025-04-25  Christian Franke  <franke@computer.org>
 
+	configure.ac: Use RELEASE_7_5_DRIVEDB for drivedb.h updates.
+
 	update-smart-drivedb.*: Use current gpg key also for 7.5 branch.
 
 	Create new branch RELEASE_7_5_DRIVEDB.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,9 @@
 $Id$
 
+2025-04-19  Christian Franke  <franke@computer.org>
+
+	smartd.cpp: Fix format string of NVMe attribute log.
+
 2025-04-15  Christian Franke  <franke@computer.org>
 
 	smartd.cpp: Add NVMe attribute logs.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,9 @@
 $Id$
 
+2025-04-29  Christian Franke  <franke@computer.org>
+
+	os_win32/smartd_mailer.conf.sample.ps1: Add encryption sample.
+
 2025-04-27  Christian Franke  <franke@computer.org>
 
 	drivedb.h:

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,9 @@
 $Id$
 
+2024-10-26  Aleksander Jan Bajkowski  <olek2@wp.pl>
+
+	autogen.sh: Allow to build with automake 1.17 (GH pull/292).
+
 2024-10-23  Christian Franke  <franke@computer.org>
 
 	nvmeprint.cpp: Support SMART/Health Information per namespace.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,13 @@
 $Id$
 
+2025-03-17  Christian Franke  <franke@computer.org>
+
+	drivedb.h:
+	- Swissbit X-7x Family SATA SSD: Simplify regex, add testcase
+	  comments (from #1781, #1800, GH pull/322).
+	- Swissbit X-8x Family SATA SSD: Add testcase comments
+	  (from #1801, GH pull/322).
+
 2025-03-17  Glucy2 <glucy-2@outlook.com>
 
 	drivedb.h: add Realtek RTL9220 (0x0bda:0x9220)

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,12 @@
 $Id$
 
+2025-02-15  Christian Franke  <franke@computer.org>
+
+	ataprint.cpp: Add support for '-l farm -T permissive'.
+
+	Overrides the FARM support check for rebranded Seagate drives
+	(see GH issues/320).
+
 2025-02-05  Christian Franke  <franke@computer.org>
 
 	drivedb.h:

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,9 @@
 $Id$
 
+2025-03-27  Christian Franke  <franke@computer.org>
+
+	ataprint.cpp: Add JSON values 'power_mode.*' (based on GH/pull 239).
+
 2025-03-20  Christian Franke  <franke@computer.org>
 
 	scsinvme.cpp: Add NVMe/SAT autodetection if '-d snt*/sat' is used.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,8 @@ $Id$
 
 2025-03-20  Christian Franke  <franke@computer.org>
 
+	scsinvme.cpp: Remove outdated check for 'sntjmicron#please_try'.
+
 	smartctl.cpp: Exclude '-g wcreorder' from '-x' (#1702).
 
 	ATA ACS only offers a support check for the SCT FEATURE CONTROL

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,11 @@
 $Id$
 
+2025-02-02  Christian Franke  <franke@computer.org>
+
+	configure.ac: Change default for '--with-nvme-devicescan' to 'yes' on
+	NetBSD.  Update related warnings.
+
+
 2025-01-26  Christian Franke  <franke@computer.org>
 
 	drivedb.h: Drop maintenance of 6.5-6.6 branches.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -4,6 +4,7 @@ $Id$
 
 	scsicmds.cpp:
 	- Fix buffer overflow parsing VPD page 0x83 (#1934)
+	- Fix handling multiple designators in VPD page (#1934)
 
 2025-02-15  Christian Franke  <franke@computer.org>
 

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,9 @@
 $Id$
 
+2025-01-15  Oleksii Samorukov <samm@os2.kiev.ua>
+
+	sntjmicron: workaround to avoid USB reset on selftest log query (GH: #256).
+
 2025-01-02  Christian Franke  <franke@computer.org>
 
 	smartd.cpp: Avoid invalid "old test ... not run" message.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,10 @@ $Id$
 
 2025-02-02  Christian Franke  <franke@computer.org>
 
+	smartd.cpp: Drop support for platforms without 'sigaction()'.
+
+	configure.ac: Fail if '--with-signal-func' is used.
+
 	configure.ac: Remove defunct '--with-solaris-sparc-ata'.
 
 	configure.ac: Change default for '--with-nvme-devicescan' to 'yes' on

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,16 @@
 $Id$
 
+2025-01-26  Christian Franke  <franke@computer.org>
+
+	drivedb.h:
+	- SandForce Driven SSDs: OCZ-VERTEX3.20 (#1924).
+	- Intel/Solidigm S46x0/S45x0 Series SSDs: Rename, add Solidigm (#1878).
+	- Marvell based SanDisk SSDs: SDSSDH3* with extra space char (#1918).
+	- Silicon Motion based SSDs: AMD R5SL (#1744), DEXP C100 (#1919),
+	  TCSUNBOW X3 480GB (#1786).
+	- Silicon Motion based OEM SSDs: INTENSO SSD/W0413A0 (#1740),
+	  W0714A0 (#1858), SPCC M.2 SSD/U1209A0 (#1841), Vi550 S3 (#1899).
+
 2025-01-24  Christian Franke  <franke@computer.org>
 
 	scsiprint.cpp: Re-add JSON value 'model_name'.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,9 @@ $Id$
 
 2025-04-29  Christian Franke  <franke@computer.org>
 
+	os_win32/update-smart-drivedb.ps1.in: Print download command if
+	'-Verbose' is used.
+
 	os_win32/smartd_mailer.conf.sample.ps1: Add encryption sample.
 
 2025-04-27  Christian Franke  <franke@computer.org>

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -7,6 +7,9 @@ $Id$
 	  comments (from #1781, #1800, GH pull/322).
 	- Swissbit X-8x Family SATA SSD: Add testcase comments
 	  (from #1801, GH pull/322).
+	- Phison Driven SSDs: DGSR2*GP13T (#1917), PS3110 256GB (#1829),
+	  S11-*-PHISON-SSD-B27.
+	- Phison Driven OEM SSDs: Goodram CX400 G2 (#1928).
 
 2025-03-17  Glucy2 <glucy-2@outlook.com>
 

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,11 @@
 $Id$
 
+2024-11-13  Christian Franke  <franke@computer.org>
+
+	smartd.cpp: Ignore individual temperature sensors (#1850).
+	Some devices use these to report other values like maximum
+	temperature.
+
 2024-11-12  Christian Franke  <franke@computer.org>
 
 	smartd.cpp: Add support for NVMe self-tests.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,13 @@
 $Id$
 
+2024-12-10  Rodrigo Araujo  <araujo.rm@gmail.com>
+
+	dev_jmb39x_raid.cpp: support QNAP-TR002 NAS
+
+	Add '-d jmb39x-q2,...' device type for JMB39x
+	protocol variant used by QNAP-TR002 NAS.
+	(#1290, GH pull/306)
+
 2024-11-30  Christian Franke  <franke@computer.org>
 
 	os_win32.cpp: Decode Windows Server 2025 build number.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,9 @@
 $Id$
 
+2024-10-23  Christian Franke  <franke@computer.org>
+
+	smartctl.8.in: Update documentation of NVMe '-l selftest'.
+
 2024-10-23  Ameer Hamza  <ahamza@ixsystems.com>
 
 	nvmeprint.cpp: fix self-test for devices with multiple namespaces.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,8 @@ $Id$
 
 2024-10-23  Christian Franke  <franke@computer.org>
 
+	nvmecmds.h: Add 'nvme_broadcast_nsid' and use it where applicable.
+
 	smartctl.8.in: Update documentation of NVMe '-l selftest'.
 
 2024-10-23  Ameer Hamza  <ahamza@ixsystems.com>

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,12 @@
 $Id$
 
+2024-11-20  Robin Schneider  <ypid@riseup.net>
+
+	man pages: Fix typo, '-l directory,q' was mentioned but only
+	'-l directory,g' is supported.
+
+	(GH pull/298)
+
 2024-11-18  Martin Ziemer  <horrad@horrad.de>
 
 	openbsd_nvme_ioctl.h, os_openbsd.cpp: Enable NVMe on OpenBSD

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,8 @@ $Id$
 
 2025-04-25  Christian Franke  <franke@computer.org>
 
+	update-smart-drivedb.*: Use current gpg key also for 7.5 branch.
+
 	Create new branch RELEASE_7_5_DRIVEDB.
 
 2025-04-22  Christian Franke  <franke@computer.org>

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,8 @@ $Id$
 
 2025-03-27  Christian Franke  <franke@computer.org>
 
+	smartctl.8.in: Document that '-x' no longer includes '-g wcreorder'.
+
 	ataprint.cpp: Add JSON values 'power_mode.*' (based on GH/pull 239).
 
 2025-03-20  Christian Franke  <franke@computer.org>

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,8 @@ $Id$
 
 2025-04-29  Christian Franke  <franke@computer.org>
 
+	nvmeprint.cpp: Add NSID to JSON output of SMART/Health information.
+
 	ataprint.cpp: ACS-6 updates.
 
 	popen_as_ugid.cpp: Add missing config.h.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,8 @@ $Id$
 
 2025-03-27  Christian Franke  <franke@computer.org>
 
+	farmprint.cpp: Suppress serial and WWN if '-q noserial' is used.
+
 	smartctl.8.in: Document that '-x' no longer includes '-g wcreorder'.
 
 	ataprint.cpp: Add JSON values 'power_mode.*' (based on GH/pull 239).

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,13 @@
 $Id$
 
+2025-01-24  Christian Franke  <franke@computer.org>
+
+	scsiprint.cpp: Re-add JSON value 'model_name'.
+
+	This fixes a regression from r5286 (smartmontools 7.3).
+	Keep 'scsi_model_name' to provide backward compatibility with
+	release 7.3 and 7.4.
+
 2025-01-24  Andrew Sayers  <andrew-github.com@pileofstuff.org>
 
 	smartd.service: silence "Referenced but unset environment variable" warning

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,11 @@ $Id$
 
 2025-04-22  Christian Franke  <franke@computer.org>
 
+	smartd.cpp: Allow to configure checked NVMe Critical Warning bits.
+
+	Add optional MASK parameter to '-H' directive to specify the bits
+	to check (#1715).
+
 	smartd.cpp: Fix validity check for SCSI attribute log (#1245).
 
 	smartd.cpp: Add missing 'static'.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,8 @@ $Id$
 
 2025-04-22  Christian Franke  <franke@computer.org>
 
+	smartd.cpp: Add missing 'static'.
+
 	smartd.8.in, smartd.conf.5.in: Update EXPERIMENTAL notes.
 
 2025-04-21  Christian Franke  <franke@computer.org>

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -7,6 +7,9 @@ $Id$
 	  prefix (#1877).
 	- Toshiba 2.5" HDD MQ04UBB... (USB, SMR) (#1400, #1821, #1832).
 	- Toshiba MG11 Cloud-scale Capacity HDD.
+	- Seagate Exos X18 (#1552, #1742, #1763, #1871, #1872, GH pull/225).
+	- Seagate Exos X20 (#1567, #1882).
+	- Seagate Exos X24.
 	- WD Blue / Red / Green SSDs: SanDisk Portable SSD (#1743).
 	- USB: Sandisk SDSSDE30-2T00 (0x0781:0x55b0) (#1743).
 

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,12 @@ $Id$
 
 2025-04-19  Christian Franke  <franke@computer.org>
 
+	smartd.cpp: Report changes of prefailure NVMe SMART/Health values.
+
+	If '-p' directive is enabled (default), changes of 'Available Spare'
+	(#1716), 'Percentage Used' and 'Media and Data Integrity Errors' are
+	logged as LOG_INFO or LOG_CRIT.
+
 	smartd.cpp: Fix format string of NVMe attribute log.
 
 2025-04-15  Christian Franke  <franke@computer.org>

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,9 @@ $Id$
 
 2025-03-20  Christian Franke  <franke@computer.org>
 
+	dev_interface.h: Make 'smart_interface::get_sat_device()' public.
+	This allows usage within 'autodetect_open()' functions.
+
 	scsinvme.cpp: Remove unneeded function 'sntjmicron_device::open()'.
 
 	scsinvme.cpp: Remove outdated check for 'sntjmicron#please_try'.

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,10 @@
 $Id$
 
+2024-11-17  Christian Franke  <franke@computer.org>
+
+	smartd.cpp: Ignore NSID in duplicate check of single namespace
+	devices.
+
 2024-11-13  Christian Franke  <franke@computer.org>
 
 	smartd.cpp: Ignore individual temperature sensors (#1850).

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,13 @@
 $Id$
 
+2024-10-23  Ameer Hamza  <ahamza@ixsystems.com>
+
+	nvmeprint.cpp: fix self-test for devices with multiple namespaces.
+	Use broadcast NSID for (06h) log page access to prevent `Invalid
+	Field in Command` error when accessing the log page. Also, use
+	device NSID for both single and multi namespace devices when
+	issuing the Device Self-test (14h) command.
+
 2024-10-16  Christian Franke  <franke@computer.org>
 
 	drivedb.h:

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,11 @@
 $Id$
 
+2025-03-17  Glucy2 <glucy-2@outlook.com>
+
+	drivedb.h: add Realtek RTL9220 (0x0bda:0x9220)
+
+	(GH pull/327)
+
 2025-03-17  Daniel SWB  <daniel.swb.gh@gmail.com>
 
 	drivedb.h: Swissbit X-7x, X-8x family SATA SSD

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,12 @@
 $Id$
 
+2024-10-15  Christian Franke  <franke@computer.org>
+
+	ataprint.cpp: Don't return failure if '-l scterc' is not supported.
+
+	Only return failure (exit status 4) if a SCT command failed or an
+	attempt to set ERC ('-l scterc,...') failed (#1892).
+
 2024-10-05  Christian Franke  <franke@computer.org>
 
 	scsicmds.cpp: Fix range checks of mode page offset and VPD inquiry

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -2,6 +2,8 @@ $Id$
 
 2025-04-29  Christian Franke  <franke@computer.org>
 
+	popen_as_ugid.cpp: Add missing config.h.
+
 	os_win32/update-smart-drivedb.ps1.in: Print download command if
 	'-Verbose' is used.
 

--- a/smartmontools/ChangeLog
+++ b/smartmontools/ChangeLog
@@ -1,5 +1,9 @@
 $Id$
 
+2025-04-30  Christian Franke  <franke@computer.org>
+
+	smartmontools 7.5
+
 2025-04-29  Christian Franke  <franke@computer.org>
 
 	nvmeprint.cpp: Add NSID to JSON output of SMART/Health information.

--- a/smartmontools/Makefile.am
+++ b/smartmontools/Makefile.am
@@ -131,6 +131,7 @@ EXTRA_smartctl_SOURCES = \
         dev_areca.h \
         dev_legacy.cpp \
         linux_nvme_ioctl.h \
+        openbsd_nvme_ioctl.h \
         megaraid.h \
         sssraid.h
 
@@ -205,6 +206,7 @@ EXTRA_smartd_SOURCES = \
         linux_nvme_ioctl.h \
         freebsd_nvme_ioctl.h \
         netbsd_nvme_ioctl.h \
+        openbsd_nvme_ioctl.h \
         megaraid.h \
         sssraid.h
 

--- a/smartmontools/NEWS
+++ b/smartmontools/NEWS
@@ -10,12 +10,29 @@ Summary: smartmontools release 7.5
 -----------------------------------------------------------
 - CI and release builds are now reproducible if same SOURCE_DATE_EPOCH,
   build recipes and toolchains are used.
+- smartctl '-H -A': Support for NVMe SMART/Health Information per
+  namespace.
+- smartctl '-x', '-l scterc': No longer returns exit status 4 if SCT ERC
+  is not supported by the device.
 - smartctl '-l error': No longer prints bogus ATA error log entries if
   the error index is nonzero but the error count is zero.
 - smartctl '-l ssd': Fixed corruption of the output of the SCSI Format
   Status log page.
 - smartctl '-l ssd': Now detects 'no format since manufacture' from the
   SCSI Format Status log page.
+- smartctl '-l farm': Fixed the byte order of ATA 'Assembly Date'.
+- smartctl '-l farm': Fixed a possible segfault.
+- smartctl '-t TEST': Fixed self-tests of single namespace NVMe devices.
+- smartd: NVMe self-test support ('-l selftest -l selfteststs -s ...').
+- smartd: No longer includes individual sensors in NVMe temperature
+  check as some devices report other values there.
+- smartd: Ignores NSID in duplicate check of single namespace devices.
+- smartd: No longer issues LOG_CRIT warnings for 'Set Feature' related
+  NVMe error information log entries.
+- smartd: No longer hangs on systems with large file descriptor limits.
+- SCSI: Fixed range checks of mode page offset and VPD inquiry.
+- USB/NVMe: '-d sntasmedia' now supports log pages > 512 bytes.
+- Fixed segfault on missing option argument on systems using musl libc.
 - HDD, SSD and USB additions to drive database.
 - automake < 1.13 are no longer supported.
 - Custom make rules are now silenced if 'make V=0' is used.
@@ -23,8 +40,12 @@ Summary: smartmontools release 7.5
   tarballs.
 - The makefile no longer uses GNU make specific syntax elements
   (exception: reproducible builds for macOS).
+- Version information is now also set if build from GH R/O mirror.
 - macOS: Support for reproducible builds of the DMG image.
+- OpenBSD: NVMe support.
+- Windows: Increased WMI timeout.
 - Windows: Support for reproducible builds of the installer.
+- Windows: Uninstaller is no longer damaged if the installer is signed.
 - Windows 'update-smartd-drivedb.ps1': Fixed call of 'gpg.exe' if it
   appears more than once in the PATH.
 

--- a/smartmontools/NEWS
+++ b/smartmontools/NEWS
@@ -5,7 +5,7 @@ $Id$
 The most up-to-date version of this file is:
 https://www.smartmontools.org/browser/trunk/smartmontools/NEWS
 
-Date <Not released yet, please try current SVN or a recent CI build>
+Date 2025-04-30
 Summary: smartmontools release 7.5
 -----------------------------------------------------------
 - CI and release builds are now reproducible if same SOURCE_DATE_EPOCH,

--- a/smartmontools/NEWS
+++ b/smartmontools/NEWS
@@ -18,6 +18,7 @@ Summary: smartmontools release 7.5
 - smartctl '-j -n ...': New JSON values 'power_mode.*' (ATA only).
 - smartctl '-H -A': Support for NVMe SMART/Health Information per
   namespace.
+- smartctl '-i': ATA ACS-6 updates.
 - smartctl '-x': No longer includes '-g wcreorder'.
 - smartctl '-x', '-l scterc': No longer returns exit status 4 if SCT ERC
   is not supported by the device.
@@ -34,15 +35,21 @@ Summary: smartmontools release 7.5
 - smartctl '-l farm -T permissive': Overrides false negative FARM support
   check for rebranded drives.
 - smartctl '-t TEST': Fixed self-tests of single namespace NVMe devices.
-- smartd: NVMe self-test support ('-l selftest -l selfteststs -s ...').
-- smartd: No longer includes individual sensors in NVMe temperature
-  check as some devices report other values there.
+- smartd '-A': NVMe attribute log support.
 - smartd: Ignores NSID in duplicate check of single namespace devices.
 - smartd: No longer issues LOG_CRIT warnings for 'Set Feature' related
   NVMe error information log entries.
 - smartd: No longer hangs on systems with large file descriptor limits.
 - smartd: No longer logs invalid "old test ... not run" messages if
   staggered self-tests are used.
+- smartd.conf '-l selftest[sts] -s ...': NVMe self-test support.
+- smartd.conf '-H MASK': Ability to ignore specific bits of NVMe
+  SMART/Health value 'Critical Warning'.
+- smartd.conf '-p': Checks NVMe SMART/Health value 'Available Spare'.
+- smartd.conf '-u [-f]': Checks NVMe SMART/Health values 'Percentage Used'
+  and 'Media and Data Integrity Errors'.
+- smartd.conf '-W ...': No longer includes individual sensors in NVMe
+  temperature check as some devices report other values there.
 - ATA: Device type '-d jmb39x-q2,N' for another JMB39x protocol variant
   used by QNAP-TR002 NAS devices.
 - SCSI: Fixed range checks of mode page offset and VPD inquiry.
@@ -77,6 +84,8 @@ Summary: smartmontools release 7.5
 - Windows: Uninstaller is no longer damaged if the installer is signed.
 - Windows 'update-smartd-drivedb.ps1': Fixed call of 'gpg.exe' if it
   appears more than once in the PATH.
+- Windows 'update-smartd-drivedb.ps1 -Verbose': Now also prints the
+  download command.
 
 Date 2023-08-01
 Summary: smartmontools release 7.4

--- a/smartmontools/NEWS
+++ b/smartmontools/NEWS
@@ -14,8 +14,11 @@ Summary: smartmontools release 7.5
 - smartctl '-j -A': New JSON value 'spare_available' (ATA/NVMe).
 - smartctl '-j -i': Re-added the JSON value 'model_name' also for SCSI
   devices (regression).
+- smartctl '-j -c': NVMe support.
+- smartctl '-j -n ...': New JSON values 'power_mode.*' (ATA only).
 - smartctl '-H -A': Support for NVMe SMART/Health Information per
   namespace.
+- smartctl '-x': No longer includes '-g wcreorder'.
 - smartctl '-x', '-l scterc': No longer returns exit status 4 if SCT ERC
   is not supported by the device.
 - smartctl '-l error': No longer prints bogus ATA error log entries if
@@ -24,8 +27,12 @@ Summary: smartmontools release 7.5
   Status log page.
 - smartctl '-l ssd': Now detects 'no format since manufacture' from the
   SCSI Format Status log page.
+- smartctl '-l farm': Fixed the unit of 'Write Power On' time.
 - smartctl '-l farm': Fixed the byte order of ATA 'Assembly Date'.
 - smartctl '-l farm': Fixed a possible segfault.
+- smartctl '-l farm -q noserial': Suppresses serial and WWN also from FARM.
+- smartctl '-l farm -T permissive': Overrides false negative FARM support
+  check for rebranded drives.
 - smartctl '-t TEST': Fixed self-tests of single namespace NVMe devices.
 - smartd: NVMe self-test support ('-l selftest -l selfteststs -s ...').
 - smartd: No longer includes individual sensors in NVMe temperature
@@ -39,24 +46,30 @@ Summary: smartmontools release 7.5
 - ATA: Device type '-d jmb39x-q2,N' for another JMB39x protocol variant
   used by QNAP-TR002 NAS devices.
 - SCSI: Fixed range checks of mode page offset and VPD inquiry.
+- SCSI: Fixed buffer overflow parsing of VPD page.
+- SCSI: Fixed handling of multiple designators in VPD page.
 - USB/NVMe: '-d sntjmicron' no longer triggers USB resets on queries of
   the self-test log.
 - USB/NVMe: '-d sntasmedia' now supports log pages > 512 bytes.
+- USB/NVMe/SAT: New experimental NVMe/SAT autodetection options
+  '-d snt*/sat'.
 - Fixed segfault on missing option argument on systems using musl libc.
 - HDD, SSD and USB additions to drive database.
 - automake < 1.13 are no longer supported.
 - Custom make rules are now silenced if 'make V=0' is used.
 - Enhanced makefile targets 'dist-*' to create reproducible source
-  tarballs.
+  tarballs if SOURCE_DATE_EPOCH is set.
 - The makefile no longer uses GNU make specific syntax elements
   (exception: reproducible builds for macOS).
 - Dropped support for platforms without 'sigaction()'.
+- configure: Now also detects MidnightBSD.
 - configure: Dropped option '--with-signal-func'.
 - configure: Default for '--with-nvme-devicescan' is now 'yes' also on
   NetBSD.
 - Version information is now also set if build from GH R/O mirror.
 - Linux: 'smartd.service' now avoids a warning about an unset environment
   variable.
+- Linux: Dropped autodetection of deprecated device type '-d marvell'.
 - macOS: Support for reproducible builds of the DMG image.
 - OpenBSD: NVMe support.
 - Windows: Increased WMI timeout.

--- a/smartmontools/NEWS
+++ b/smartmontools/NEWS
@@ -10,6 +10,10 @@ Summary: smartmontools release 7.5
 -----------------------------------------------------------
 - CI and release builds are now reproducible if same SOURCE_DATE_EPOCH,
   build recipes and toolchains are used.
+- smartctl '-j -A': New JSON value 'endurance_used' (ATA/SCSI/NVMe).
+- smartctl '-j -A': New JSON value 'spare_available' (ATA/NVMe).
+- smartctl '-j -i': Re-added the JSON value 'model_name' also for SCSI
+  devices (regression).
 - smartctl '-H -A': Support for NVMe SMART/Health Information per
   namespace.
 - smartctl '-x', '-l scterc': No longer returns exit status 4 if SCT ERC
@@ -30,7 +34,13 @@ Summary: smartmontools release 7.5
 - smartd: No longer issues LOG_CRIT warnings for 'Set Feature' related
   NVMe error information log entries.
 - smartd: No longer hangs on systems with large file descriptor limits.
+- smartd: No longer logs invalid "old test ... not run" messages if
+  staggered self-tests are used.
+- ATA: Device type '-d jmb39x-q2,N' for another JMB39x protocol variant
+  used by QNAP-TR002 NAS devices.
 - SCSI: Fixed range checks of mode page offset and VPD inquiry.
+- USB/NVMe: '-d sntjmicron' no longer triggers USB resets on queries of
+  the self-test log.
 - USB/NVMe: '-d sntasmedia' now supports log pages > 512 bytes.
 - Fixed segfault on missing option argument on systems using musl libc.
 - HDD, SSD and USB additions to drive database.
@@ -40,7 +50,13 @@ Summary: smartmontools release 7.5
   tarballs.
 - The makefile no longer uses GNU make specific syntax elements
   (exception: reproducible builds for macOS).
+- Dropped support for platforms without 'sigaction()'.
+- configure: Dropped option '--with-signal-func'.
+- configure: Default for '--with-nvme-devicescan' is now 'yes' also on
+  NetBSD.
 - Version information is now also set if build from GH R/O mirror.
+- Linux: 'smartd.service' now avoids a warning about an unset environment
+  variable.
 - macOS: Support for reproducible builds of the DMG image.
 - OpenBSD: NVMe support.
 - Windows: Increased WMI timeout.

--- a/smartmontools/ataprint.cpp
+++ b/smartmontools/ataprint.cpp
@@ -4,7 +4,7 @@
  * Home page of code is: https://www.smartmontools.org
  *
  * Copyright (C) 2002-11 Bruce Allen
- * Copyright (C) 2008-23 Christian Franke
+ * Copyright (C) 2008-24 Christian Franke
  * Copyright (C) 1999-2000 Michael Cornwell <cornwell@acm.org>
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
@@ -4429,7 +4429,8 @@ int ataPrintMain (ata_device * device, const ata_print_options & options)
   if (sct_ok && (options.sct_erc_get || options.sct_erc_set)) {
     if (!isSCTErrorRecoveryControlCapable(&drive)) {
       pout("SCT Error Recovery Control command not supported\n\n");
-      failuretest(OPTIONAL_CMD, returnval|=FAILSMART);
+      if (options.sct_erc_set)
+        failuretest(OPTIONAL_CMD, returnval|=FAILSMART);
     }
     else {
       int sct_erc_get = options.sct_erc_get;

--- a/smartmontools/ataprint.cpp
+++ b/smartmontools/ataprint.cpp
@@ -410,7 +410,7 @@ static const char * get_form_factor(unsigned short word168)
   // Bits 0:3 are the form factor
   // Table A.32 of T13/2161-D (ACS-3) Revision 5, October 28, 2013
   // Table 247 of T13/BSR INCITS 529 (ACS-4) Revision 20, October 26, 2017
-  // Table 265 of T13/BSR INCITS 574 (ACS-6) Revision 3, March 30, 2023
+  // Table 265 of T13/BSR INCITS 574 (ACS-6) Revision 13, April 17, 2025
   switch (word168 & 0xF) {
     case 0x1: return "5.25 inches";
     case 0x2: return "3.5 inches";
@@ -439,10 +439,11 @@ static const char * get_ata_major_version(const ata_identify_device * drive)
   // Table 29 of T13/1699-D (ATA8-ACS) Revision 6a, September 6, 2008
   // Table 55 of T13/BSR INCITS 529 (ACS-4) Revision 20, October 26, 2017
   // Table 57 of T13/BSR INCITS 558 (ACS-5) Revision 10, March 3, 2021
+  // Table 57 of T13/BSR INCITS 574 (ACS-6) Revision 13, April 17, 2025
   switch (find_msb(drive->major_rev_num)) {
-    case 15: return "ACS >5 (15)";
-    case 14: return "ACS >5 (14)";
-    case 13: return "ACS >5 (13)";
+    case 15: return "ACS >6 (15)";
+    case 14: return "ACS >6 (14)";
+    case 13: return "ACS-6";
     case 12: return "ACS-5";
     case 11: return "ACS-4";
     case 10: return "ACS-3";
@@ -468,7 +469,7 @@ static const char * get_ata_minor_version(const ata_identify_device * drive)
   // Table 47 of T13/2161-D (ACS-3) Revision 5, October 28, 2013
   // Table 57 of T13/BSR INCITS 529 (ACS-4) Revision 20, October 26, 2017
   // Table 59 of T13/BSR INCITS 558 (ACS-5) Revision 10, March 3, 2021
-  // Table 59 of T13/BSR INCITS 574 (ACS-6) Revision 3, March 30, 2023
+  // Table 59 of T13/BSR INCITS 574 (ACS-6) Revision 13, April 17, 2025
   switch (drive->minor_rev_num) {
     case 0x0001: return "ATA-1 X3T9.2/781D prior to revision 4";
     case 0x0002: return "ATA-1 published, ANSI X3.221-1994";
@@ -505,12 +506,13 @@ static const char * get_ata_minor_version(const ata_identify_device * drive)
     case 0x0021: return "ATA/ATAPI-7 T13/1532D revision 4a";
     case 0x0022: return "ATA/ATAPI-6 published, ANSI INCITS 361-2002";
 
-    case 0x0030: return "ACS-5 T13/BSR INCITS 558 revision 10";
+    case 0x0025: return "ACS-6 T13/BSR INCITS 574 revision 7";
 
     case 0x0027: return "ATA8-ACS T13/1699-D revision 3c";
     case 0x0028: return "ATA8-ACS T13/1699-D revision 6";
     case 0x0029: return "ATA8-ACS T13/1699-D revision 4";
 
+    case 0x0030: return "ACS-5 T13/BSR INCITS 558 revision 10";
     case 0x0031: return "ACS-2 T13/2015-D revision 2";
 
     case 0x0033: return "ATA8-ACS T13/1699-D revision 3e";
@@ -525,7 +527,9 @@ static const char * get_ata_minor_version(const ata_identify_device * drive)
 
     case 0x006d: return "ACS-3 T13/2161-D revision 5";
 
-    case 0x0073: return "ACS-6 T13/BSR INCITS 558 revision 2";
+    case 0x0070: return "ACS-6 T13/BSR INCITS 574 revision 11";
+
+    case 0x0073: return "ACS-6 T13/BSR INCITS 574 revision 2";
 
     case 0x0082: return "ACS-2 published, ANSI INCITS 482-2012";
 
@@ -563,9 +567,10 @@ static const char * get_sata_version(unsigned short word222)
   // Table 45 of T13/2161-D (ACS-3) Revision 5, October 28, 2013
   // Table 55 of T13/BSR INCITS 529 (ACS-4) Revision 20, October 26, 2017
   // Table 57 of T13/BSR INCITS 558 (ACS-5) Revision 10, March 3, 2021
+  // Table 57 of T13/BSR INCITS 574 (ACS-6) Revision 13, April 17, 2025
   switch (find_msb(word222 & 0x0fff)) {
     case 11: return "SATA >3.5 (11)";
-    case 10: return "SATA 3.5"; // ACS-5
+    case 10: return "SATA 3.5"; // ACS-5 (ACS-6: "SATA 3.5a")
     case  9: return "SATA 3.4"; // ACS-5
     case  8: return "SATA 3.3"; // ACS-4
     case  7: return "SATA 3.2"; // ACS-4
@@ -1454,7 +1459,7 @@ static const char * GetLogName(unsigned logaddr)
     // Table A.2 of T13/2161-D (ACS-3) Revision 5, October 28, 2013
     // Table 213 of T13/BSR INCITS 529 (ACS-4) Revision 20, October 26, 2017
     // Table 213 of T13/BSR INCITS 558 (ACS-5) Revision 10, March 3, 2021
-    // Table 223 of T13/BSR INCITS 574 (ACS-6) Revision 3, March 30, 2023
+    // Table 223 of T13/BSR INCITS 574 (ACS-6) Revision 13, April 17, 2025
     switch (logaddr) {
       case 0x00: return "Log Directory";
       case 0x01: return "Summary SMART error log";
@@ -1491,7 +1496,7 @@ static const char * GetLogName(unsigned logaddr)
       case 0x24: return "Current Device Internal Status Data log"; // ACS-3
       case 0x25: return "Saved Device Internal Status Data log"; // ACS-3
 
-      case 0x2f: return "Set Sector Configuration"; // ACS-4
+      case 0x2f: return "Sector Configuration log"; // ACS-4
       case 0x30: return "IDENTIFY DEVICE data log"; // ACS-3
 
       case 0x42: return "Mutate Configurations log"; // ACS-5

--- a/smartmontools/ataprint.cpp
+++ b/smartmontools/ataprint.cpp
@@ -4553,7 +4553,7 @@ int ataPrintMain (ata_device * device, const ata_print_options & options)
   if (options.farm_log || options.farm_log_suggest) {
     bool farm_supported = true;
     // Check if drive is a Seagate drive
-    if (ataIsSeagate(drive, dbentry)) {
+    if (ataIsSeagate(drive, dbentry) || (options.farm_log && is_permissive())) {
       unsigned nsectors = GetNumLogSectors(gplogdir, 0xA6, true);
       // Check if the Seagate drive is one that supports FARM
       if (!nsectors) {
@@ -4578,9 +4578,9 @@ int ataPrintMain (ata_device * device, const ata_print_options & options)
         }
       }
     } else {
-      if (options.farm_log) {
-        jout("FARM log (GP Log 0xa6) not supported for non-Seagate drives\n\n");
-      }
+      if (options.farm_log)
+        jout("FARM log (GP Log 0xa6) not supported for non-Seagate drives\n"
+             "(override with '-T permissive' option)\n\n");
       farm_supported = false;
     }
     jglb["seagate_farm_log"]["supported"] = farm_supported;

--- a/smartmontools/ataprint.cpp
+++ b/smartmontools/ataprint.cpp
@@ -3435,6 +3435,10 @@ int ataPrintMain (ata_device * device, const ata_print_options & options)
         break;
     }
     if (powername) {
+      jglb["power_mode"] += {
+        { "ata_value", powermode },
+        { "name", powername }
+      };
       if (options.powermode >= powerlimit) {
         jinf("Device is in %s mode, exit(%d)\n", powername, options.powerexit);
         return options.powerexit;

--- a/smartmontools/ataprint.cpp
+++ b/smartmontools/ataprint.cpp
@@ -4,7 +4,7 @@
  * Home page of code is: https://www.smartmontools.org
  *
  * Copyright (C) 2002-11 Bruce Allen
- * Copyright (C) 2008-24 Christian Franke
+ * Copyright (C) 2008-25 Christian Franke
  * Copyright (C) 1999-2000 Michael Cornwell <cornwell@acm.org>
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
@@ -1142,6 +1142,7 @@ static int find_failed_attr(const ata_smart_values * data,
 
 static void set_json_globals_from_smart_attrib(int id, const char * name,
                                                const ata_vendor_attr_defs & defs,
+                                               uint8_t normval, uint8_t threshold,
                                                uint64_t rawval)
 {
   switch (id) {
@@ -1173,7 +1174,7 @@ static void set_json_globals_from_smart_attrib(int id, const char * name,
         if (minutes >= 0)
           jglb["power_on_time"]["minutes"] = minutes;
       }
-      break;
+      return;
     case 12:
       if (strcmp(name, "Power_Cycle_Count"))
         return;
@@ -1185,9 +1186,31 @@ static void set_json_globals_from_smart_attrib(int id, const char * name,
       if (rawval > 0x00ffffffULL)
         return; // assume bogus value
       jglb["power_cycle_count"] = rawval;
-      break;
+      return;
     //case 194:
     // Temperature set separately from ata_return_temperature_value() below
+  }
+
+  // Guess available spare and endurance from normalized value of related attributes
+  // (In many cases, the normalized value starts at 100)
+  static const regular_expression spare_regex(
+    "Reallocated_Sector_C.*|Retired_Block_C.*|"
+    "(Remain.*_)?Spare_Blocks(_(Avail|Remain).*)?" // TODO: Unify names in drivedb.h
+  );
+  if ((id == 5 || id == 17 || id >= 100) && spare_regex.full_match(name)) {
+    jglb["spare_available"]["current_percent"] = (normval <= 100 ? normval : 100);
+    if (0 < threshold && threshold < 50)
+      jglb["spare_available"]["threshold_percent"] = threshold;
+    return;
+  }
+
+  static const regular_expression endurance_regex(
+    "SSD_Life_Left.*|Wear_Leveling.*"
+  );
+  if (id >= 100 && endurance_regex.full_match(name)) {
+    // May be later overridden by Device Statistics
+    jglb["endurance_used"]["current_percent"] = (normval <= 100 ? 100 - normval : 0);
+    return;
   }
 }
 
@@ -1324,7 +1347,8 @@ static void PrintSmartAttribWithThres(const ata_smart_values * data,
     jref["raw"]["value"] = rawval;
     jref["raw"]["string"] = rawstr;
 
-    set_json_globals_from_smart_attrib(attr.id, attrname.c_str(), defs, rawval);
+    set_json_globals_from_smart_attrib(attr.id, attrname.c_str(), defs,
+      attr.current, threshold, rawval);
   }
 
   if (!needheader) {
@@ -1789,6 +1813,11 @@ static void set_json_globals_from_device_statistics(int page, int offset, int64_
         case 0x058: jglb["temperature"]["op_limit_max"] = val; break;
         case 0x060: jglb["temperature"]["lifetime_under_limit_minutes"] = val; break;
         case 0x068: jglb["temperature"]["op_limit_min"] = val; break;
+      }
+      break;
+    case 7:
+      switch (offset) {
+        case 0x008: jglb["endurance_used"]["current_percent"] = val; break;
       }
       break;
   }

--- a/smartmontools/autogen.sh
+++ b/smartmontools/autogen.sh
@@ -13,15 +13,10 @@ while [ $# -gt 0 ]; do case $1 in
   *) echo "Usage: $0 [--force] [--warnings=CATEGORY ...]"; exit 1 ;;
 esac; done
 
-# Cygwin?
-test -x /usr/bin/uname && /usr/bin/uname | grep -i CYGWIN >/dev/null &&
-{
-    # Check for Unix text file type
-    echo > dostest.tmp
-    test "`wc -c < dostest.tmp`" -eq 1 ||
-        echo "Warning: DOS text file type set, 'make dist' and related targets will not work."
-    rm -f dostest.tmp
-}
+# Check for CR/LF line endings
+if od -A n -t x1 smartctl.h | grep ' 0d' >/dev/null; then
+  echo "Warning: Checkout with CR/LF line endings, 'make dist' and related targets will not work."
+fi
 
 # Find automake
 if [ -n "$AUTOMAKE" ]; then

--- a/smartmontools/autogen.sh
+++ b/smartmontools/autogen.sh
@@ -28,7 +28,7 @@ if [ -n "$AUTOMAKE" ]; then
   ver=$("$AUTOMAKE" --version) || exit 1
 else
   maxver=
-  for v in 1.16 1.15 1.14 1.13; do
+  for v in 1.17 1.16 1.15 1.14 1.13; do
     minver=$v; test -n "$maxver" || maxver=$v
     ver=$(automake-$v --version 2>/dev/null) || continue
     AUTOMAKE="automake-$v"
@@ -64,7 +64,7 @@ case "$ver" in
     # OK
     ;;
 
-  1.14|1.14.1|1.15|1.15.1|1.16|1.16.[1-5])
+  1.14|1.14.1|1.15|1.15.1|1.16|1.16.[1-5]|1.17)
     # TODO: Enable 'subdir-objects' in configure.ac
     # For now, suppress 'subdir-objects' forward-incompatibility warning
     test -n "$warnings" || amwarnings="--warnings=no-unsupported"

--- a/smartmontools/configure.ac
+++ b/smartmontools/configure.ac
@@ -3,15 +3,15 @@
 #
 dnl Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.64])
-AC_INIT([smartmontools],[7.5],[smartmontools-support@listi.jpberlin.de],[],[https://www.smartmontools.org/])
+AC_INIT([smartmontools],[7.6],[smartmontools-support@listi.jpberlin.de],[],[https://www.smartmontools.org/])
 AM_INIT_AUTOMAKE([1.13 foreign])
 
 # Version of drive database branch
 smartmontools_drivedb_version=7.5
 
 # Set by 'do_release' script, commented out when release number is bumped.
-smartmontools_release_date=2025-04-30
-smartmontools_release_time="07:42:55 UTC"
+smartmontools_release_date= # 2025-04-30
+smartmontools_release_time= # "07:42:55 UTC"
 
 if test -n "$smartmontools_release_date"; then
   AC_DEFINE_UNQUOTED(SMARTMONTOOLS_RELEASE_DATE, "$smartmontools_release_date",    [smartmontools Release Date])

--- a/smartmontools/configure.ac
+++ b/smartmontools/configure.ac
@@ -7,7 +7,7 @@ AC_INIT([smartmontools],[7.5],[smartmontools-support@listi.jpberlin.de],[],[http
 AM_INIT_AUTOMAKE([1.13 foreign])
 
 # Version of drive database branch
-smartmontools_drivedb_version=7.3
+smartmontools_drivedb_version=7.5
 
 # Set by 'do_release' script, commented out when release number is bumped.
 smartmontools_release_date= # 2023-08-01
@@ -204,7 +204,7 @@ AC_ARG_WITH(update-smart_drivedb,
     [Install update-smart-drivedb script (and backport it to branches/RELEASE_X_Y_DRIVEDB) [yes]])],
   [ case "$withval" in
       yes|no) ;;
-      5.4[[0-3]]|6.[[0-6]]|7.[[023]]) drivedb_version=$withval; with_update_smart_drivedb=yes ;;
+      5.4[[0-3]]|6.[[0-6]]|7.[[0235]]) drivedb_version=$withval; with_update_smart_drivedb=yes ;;
       *) AC_MSG_ERROR([Invalid drivedb branch version: $withval]) ;;
     esac
   ],

--- a/smartmontools/configure.ac
+++ b/smartmontools/configure.ac
@@ -388,23 +388,13 @@ AC_ARG_WITH(nvme-devicescan,
   [AS_HELP_STRING([--with-nvme-devicescan@<:@=yes|no@:>@],
     [Include NVMe devices in smartctl --scan and smartd DEVICESCAN [yes]])])
 
-# TODO: Remove after smartmontools 7.4
+# TODO: Remove after smartmontools 7.5
 AC_ARG_WITH(signal-func,
-  [AS_HELP_STRING([--with-signal-func=@<:@sigaction|sigset|signal@:>@],
-    [Function to set signal(2) action [sigaction]])],
-  [], [with_signal_func=sigaction])
-
-case "$host:$with_signal_func" in
-  *-*-mingw*:*) ;;
-  *:sigaction)
-    AC_CHECK_FUNCS([sigaction], [], AC_MSG_ERROR([Missing function 'sigaction()'.
-Try '--with-signal-func=sigset' or '--with-signal-func=signal'.
-Please send info about your system to $PACKAGE_BUGREPORT.])) ;;
-  *:sigset)
-    AC_CHECK_FUNCS([sigset], [], AC_MSG_ERROR([Missing function 'sigset()'])) ;;
-  *:signal) ;;
-  *) AC_MSG_ERROR([Invalid option '--with-signal-func=$with_signal_func']) ;;
-esac
+  [AS_HELP_STRING([--with-signal-func], [(removed)])],
+  [AC_MSG_ERROR([
+The option '--with-signal-func' is no longer supported.  If this option is
+still needed, please inform $PACKAGE_BUGREPORT.
+])])
 
 AC_ARG_WITH(cxx11-option,
   [AS_HELP_STRING([--with-cxx11-option=@<:@OPTION|auto|no@:>@],
@@ -1006,16 +996,6 @@ The default for the inclusion of NVME devices in smartd.conf
 If option '--without-nvme-devicescan' is still needed, please inform
 $PACKAGE_BUGREPORT - Thanks!
 ])  ;;
-esac
-
-# TODO: Remove after smartmontools 7.4
-case "$host:$with_signal_func" in
-  *-*-mingw*:*|*:sigaction) ;;
-  *) AC_MSG_WARN([
-The option '--with-signal-func=$with_signal_func' is deprecated and will be
-removed in a future version of smartmontools.  If this option is
-still needed, please inform $PACKAGE_BUGREPORT.
-]) ;;
 esac
 
 case "$host_os:$with_libsystemd:$use_libsystemd:$PKG_CONFIG" in

--- a/smartmontools/configure.ac
+++ b/smartmontools/configure.ac
@@ -386,7 +386,7 @@ AC_SUBST(systemdenvfile)
 # TODO: Remove when NVMe support is no longer EXPERIMENTAL
 AC_ARG_WITH(nvme-devicescan,
   [AS_HELP_STRING([--with-nvme-devicescan@<:@=yes|no@:>@],
-    [Include NVMe devices in smartctl --scan and smartd DEVICESCAN [Darwin,FreeBSD,Linux,Windows:yes;NetBSD:no]])])
+    [Include NVMe devices in smartctl --scan and smartd DEVICESCAN [yes]])])
 
 # TODO: Remove after smartmontools 7.4
 AC_ARG_WITH(signal-func,
@@ -640,8 +640,6 @@ case "${host}" in
     AC_CHECK_LIB(usb, libusb20_dev_get_device_desc)
     os_man_filter=FreeBSD
     os_nvme_devicescan=yes
-    # TODO: Remove after smartmontools 7.4
-    os_nvme_devicescan_changed=yes
     ;;
   *-*-solaris*)
     os_deps='os_solaris.o'
@@ -653,7 +651,9 @@ case "${host}" in
     os_deps='os_netbsd.o'
     os_libs='-lutil'
     os_man_filter=NetBSD
-    os_nvme_devicescan=no
+    os_nvme_devicescan=yes
+    # TODO: Remove after smartmontools 7.5
+    os_nvme_devicescan_changed=yes
     ;;
   *-*-openbsd*)
     os_deps='os_openbsd.o'
@@ -694,8 +694,6 @@ case "${host}" in
     os_darwin=yes
     os_man_filter=Darwin
     os_nvme_devicescan=yes
-    # TODO: Remove after smartmontools 7.4
-    os_nvme_devicescan_changed=yes
     ;;
   *-*-nto-qnx*)
     os_deps='os_qnxnto.o'

--- a/smartmontools/configure.ac
+++ b/smartmontools/configure.ac
@@ -10,8 +10,8 @@ AM_INIT_AUTOMAKE([1.13 foreign])
 smartmontools_drivedb_version=7.5
 
 # Set by 'do_release' script, commented out when release number is bumped.
-smartmontools_release_date= # 2023-08-01
-smartmontools_release_time= # "10:59:45 UTC"
+smartmontools_release_date=2025-04-30
+smartmontools_release_time="07:42:55 UTC"
 
 if test -n "$smartmontools_release_date"; then
   AC_DEFINE_UNQUOTED(SMARTMONTOOLS_RELEASE_DATE, "$smartmontools_release_date",    [smartmontools Release Date])

--- a/smartmontools/configure.ac
+++ b/smartmontools/configure.ac
@@ -81,7 +81,7 @@ AC_CHECK_HEADERS([locale.h])
 AC_CHECK_HEADERS([byteswap.h], [], [], [])
 
 case "$host" in
-  *-*-freebsd*|*-*-dragonfly*|*-*-kfreebsd*-gnu*)
+  *-*-freebsd*|*-*-dragonfly*|*-*-kfreebsd*-gnu*|*-*-midnightbsd*)
     # Check for FreeBSD twe and twa include files
     AC_CHECK_HEADERS([sys/tweio.h sys/twereg.h sys/tw_osl_ioctl.h])
     # Check for the FreeBSD CCISS system header and use internal one if not found
@@ -157,7 +157,7 @@ AM_CONDITIONAL(INSTALL_INITSCRIPT, [test -n "$initddir"])
 
 # use different init script templates for different OS
 case "${host}" in
-  *-*-freebsd*)
+  *-*-freebsd*|*-*-midnightbsd*)
     initdfile="smartd.freebsd.initd"
     ;;
   *-apple-darwin*)
@@ -615,7 +615,7 @@ case "${host}" in
     os_man_filter=Linux
     os_nvme_devicescan=yes
     ;;
-  *-*-freebsd*|*-*-dragonfly*|*-*-kfreebsd*-gnu*)
+  *-*-freebsd*|*-*-dragonfly*|*-*-kfreebsd*-gnu*|*-*-midnightbsd*)
     os_deps='os_freebsd.o cciss.o dev_areca.o'
     os_libs='-lcam -lsbuf'
     os_dltools='fetch curl wget lynx svn'

--- a/smartmontools/configure.ac
+++ b/smartmontools/configure.ac
@@ -601,14 +601,6 @@ else
 fi
 AM_CONDITIONAL(NEED_REGEX, [test "$need_regex" = "yes"])
 
-# TODO: Remove after smartmontools 7.4
-AC_ARG_WITH(solaris-sparc-ata,
-  [AS_HELP_STRING([--with-solaris-sparc-ata], [(removed)])],
-  [AC_MSG_ERROR([
-The option '--with@<:@out@:>@-solaris-sparc-ata' is no longer supported.
-If you still need legacy ATA support on Solaris SPARC, please inform
-$PACKAGE_BUGREPORT.])])
-
 # Set platform-specific modules and symbols
 os_libs=
 os_dltools='curl wget lynx svn'

--- a/smartmontools/dev_interface.cpp
+++ b/smartmontools/dev_interface.cpp
@@ -3,7 +3,7 @@
  *
  * Home page of code is: https://www.smartmontools.org
  *
- * Copyright (C) 2008-23 Christian Franke
+ * Copyright (C) 2008-25 Christian Franke
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
@@ -305,8 +305,8 @@ std::string smart_interface::get_valid_dev_types_str()
   // default
   std::string s =
     "ata, scsi[+TYPE], nvme[,NSID], sat[,auto][,N][+TYPE], usbasm1352r,N, usbcypress[,X], "
-    "usbjmicron[,p][,x][,N], usbprolific, usbsunplus, sntasmedia, sntjmicron[,NSID], "
-    "sntrealtek, jmb39x[-q[2]],N[,sLBA][,force][+TYPE], "
+    "usbjmicron[,p][,x][,N], usbprolific, usbsunplus[/sat], sntasmedia[/sat], "
+    "sntjmicron[,NSID][/sat], sntrealtek[/sat], jmb39x[-q[2]],N[,sLBA][,force][+TYPE], "
     "jms56x,N[,sLBA][,force][+TYPE]";
   // append custom
   std::string s2 = get_valid_custom_dev_types_str();

--- a/smartmontools/dev_interface.cpp
+++ b/smartmontools/dev_interface.cpp
@@ -306,7 +306,7 @@ std::string smart_interface::get_valid_dev_types_str()
   std::string s =
     "ata, scsi[+TYPE], nvme[,NSID], sat[,auto][,N][+TYPE], usbasm1352r,N, usbcypress[,X], "
     "usbjmicron[,p][,x][,N], usbprolific, usbsunplus, sntasmedia, sntjmicron[,NSID], "
-    "sntrealtek, jmb39x[-q],N[,sLBA][,force][+TYPE], "
+    "sntrealtek, jmb39x[-q[2]],N[,sLBA][,force][+TYPE], "
     "jms56x,N[,sLBA][,force][+TYPE]";
   // append custom
   std::string s2 = get_valid_custom_dev_types_str();

--- a/smartmontools/dev_interface.h
+++ b/smartmontools/dev_interface.h
@@ -3,7 +3,7 @@
  *
  * Home page of code is: https://www.smartmontools.org
  *
- * Copyright (C) 2008-22 Christian Franke
+ * Copyright (C) 2008-25 Christian Franke
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
@@ -1055,6 +1055,7 @@ protected:
   /// Return 0 and delete 'scsidev' on error.
   virtual smart_device * get_scsi_passthrough_device(const char * type, scsi_device * scsidev);
 
+public:
   /// Return ATA->SCSI filter for a SAT or USB 'type'.
   /// Device 'scsidev' is used for SCSI access.
   /// Return 0 and delete 'scsidev' on error.
@@ -1062,6 +1063,7 @@ protected:
   virtual ata_device * get_sat_device(const char * type, scsi_device * scsidev);
   //{ implemented in scsiata.cpp }
 
+protected:
   /// Return NVMe->SCSI filter for a SNT or USB 'type'.
   /// Device 'scsidev' is used for SCSI access.
   /// Return 0 and delete 'scsidev' on error.

--- a/smartmontools/dev_jmb39x_raid.cpp
+++ b/smartmontools/dev_jmb39x_raid.cpp
@@ -179,7 +179,9 @@ static void jmb_set_request_sector(uint8_t (& data)[512], uint8_t version, uint3
   switch (version) {
     default:
     case 0: scrambled_cmd_code = 0x197b0322; break; // JMB39x: various devices
-    case 1: scrambled_cmd_code = 0x197b0393; break; // JMB39x: QNAP TR-004 NAS
+    case 1:                                         // JMB39x: QNAP TR-004 NAS
+    case 3:                                         // JMB39x: QNAP TR-002 NAS
+            scrambled_cmd_code = 0x197b0393; break;
     case 2: scrambled_cmd_code = 0x197b0562; break; // JMS562
   }
   jmb_put_le32(data, 0, scrambled_cmd_code);
@@ -704,6 +706,8 @@ ata_device * smart_interface::get_jmb39x_device(const char * type, smart_device 
     version = 1;
   else if (!strcmp(prefix, "jms56x"))
     version = 2;
+  else if (!strcmp(prefix, "jmb39x-q2"))
+    version = 3;
   else
     n1 = -1;
   if (n1 < 0) {

--- a/smartmontools/do_release
+++ b/smartmontools/do_release
@@ -2,7 +2,7 @@
 #
 # do a smartmontools release
 # (C) 2003-11 Bruce Allen, Guido Guenther
-# (C) 2006-22 Christian Franke
+# (C) 2006-25 Christian Franke
 # $Id$
 
 # Notes on generating releases:
@@ -24,7 +24,7 @@ usage()
 {
   cat <<EOF
 Usage: $myname --checkout[=URL] DESTDIR
-       $myname [--nocheck] [--commit] RC[1-9]|FINAL
+       [SOURCE_DATE_EPOCH=...] $myname [--nocheck] [--commit] RC[1-9]|FINAL
 EOF
   exit 1
 }
@@ -83,18 +83,17 @@ if [ -n "${REV//[0-9]/}" ]; then
   echo "Working directory not clean: $REVX"; exit 1
 fi
 
-(cd $WDROOT && svn status) | while read s; do
+CHANGED="configure.ac"
+while read s; do
   # shellcheck disable=SC2254
   case "`echo $s | tr -s ' '`" in
-    "M "$DIRPAT/smartmontools/ChangeLog)    echo "$s: OK";;
-    "M "$DIRPAT/smartmontools/NEWS)         echo "$s: OK";;
+    "") ;;
+    "M "$DIRPAT/smartmontools/ChangeLog)    echo "$s: OK"; CHANGED+=" ChangeLog" ;;
+    "M "$DIRPAT/smartmontools/NEWS)         echo "$s: OK"; CHANGED+=" NEWS" ;;
     "M "$DIRPAT/smartmontools/configure.ac) echo "$s: OK";;
     *) echo "$s: not allowed"; exit 1;;
   esac
-done
-if [ $? -ne 0 ]; then
-  exit 1
-fi
+done <<<"`cd $WDROOT && svn status`"
 
 # Get release number
 VERSION=`sed -n 's|^AC_INIT[^,]*, *\[\([0-9.]*\)\] *,.*$|\1|p' configure.ac`
@@ -115,9 +114,16 @@ fi
 
 echo "r$REV: Release $VERSIONRC $RELEASE"
 
+# Use SOURCE_DATE_EPOCH or current time as release time
+if [ -z "$SOURCE_DATE_EPOCH" ]; then
+  SOURCE_DATE_EPOCH=`date +%s`
+fi
+export -n SOURCE_DATE_EPOCH # export not required
+
 # Update timestamp
-smartmontools_release_date=`date -u +"%Y-%m-%d"`
-smartmontools_release_time=`date -u +"%T %Z"`
+# (requires GNU version of 'date')
+smartmontools_release_date=`date -d @"$SOURCE_DATE_EPOCH" -u +"%Y-%m-%d"`
+smartmontools_release_time=`date -d @"$SOURCE_DATE_EPOCH" -u +"%T %Z"`
 sed -e "s|^smartmontools_release_date=.*$|smartmontools_release_date=${smartmontools_release_date}|" \
     -e "s|^smartmontools_release_time=.*$|smartmontools_release_time=\"${smartmontools_release_time}\"|" \
     configure.ac > configure.tmp
@@ -128,21 +134,34 @@ svn diff
 echo "==================================================================="
 echo ">>> Continuing in 20 seconds ..."
 sleep 20
-set -v
 
 # Create tag and commit
 if [ "$COMMIT" = "yes" ]; then
   svn mkdir $WDROOT/tags/$RELEASE
   svn copy ../smartmontools $WDROOT/tags/$RELEASE/smartmontools
   svn commit -m "Release $VERSIONRC $RELEASE" $WDROOT
+  last_changed=`svn info --show-item last-changed-date configure.ac`
+  SOURCE_DATE_EPOCH=`date -d "$last_changed" +%s`
+else
+  SOURCE_DATE_EPOCH=$((SOURCE_DATE_EPOCH + 1))
 fi
+
+# Ensure reproducible timestamp of changed files
+# (requires GNU version of 'touch')
+touch -d @"$SOURCE_DATE_EPOCH" $CHANGED
+
+# Add one second for files generated below
+SOURCE_DATE_EPOCH=$((SOURCE_DATE_EPOCH + 1))
+echo ">>> SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH # `date -d @"$SOURCE_DATE_EPOCH" -Is`"
+sleep 2
+set -v
 
 # Build
 ./autogen.sh
 
 mkdir build
 cd build
-../configure
+../configure SOURCE_DATE_EPOCH="$SOURCE_DATE_EPOCH"
 make $DIST || exit 1
 make maintainer-clean
 cd ..

--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -68,7 +68,7 @@
 /*
 const drive_settings builtin_knowndrives[] = {
  */
-  { "VERSION: 7.3 $Id$",
+  { "VERSION: 7.5 $Id$",
     "-", "-",
     "Version information",
     ""
@@ -6538,6 +6538,12 @@ const drive_settings builtin_knowndrives[] = {
     "", // 0x8561: 0x0107
     "",
     "-d sat"
+  },
+  { "USB: ; JMicron JMS581", // USB3.2->SATA+PCIe (NVMe)
+    "0x152d:0xb581",
+    "", // 0x4403: Unitek M.2 NVMe/SATA USB adapter
+    "",
+    "-d sntjmicron/sat"
   },
   // PNY
   { "USB: ; PNY",

--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -4,7 +4,7 @@
  * Home page of code is: https://www.smartmontools.org
  *
  * Copyright (C) 2003-11 Philip Williams, Bruce Allen
- * Copyright (C) 2008-24 Christian Franke
+ * Copyright (C) 2008-25 Christian Franke
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
@@ -752,8 +752,8 @@ const drive_settings builtin_knowndrives[] = {
       // OCZ VERTEX2-PRO/1.10 (Bogus thresholds for attribute 232 and 235)
     "D2[CR]STK251...-....(\\.C)?|" // OCZ Deneva 2 C/R, SF-22xx/25xx,
       // tested with D2CSTK251M11-0240/2.08, D2CSTK251A10-0240/2.15, D2RSTK251M11-0100.C/3.22
-    "OCZ-(AGILITY3|SOLID3|VERTEX3( LT| MI)?)|"  // SF-2200, tested with OCZ-VERTEX3/2.02,
-      // OCZ-AGILITY3/2.11, OCZ-SOLID3/2.15, OCZ-VERTEX3 MI/2.15, OCZ-VERTEX3 LT/2.22
+    "OCZ-(AGILITY3|SOLID3|VERTEX3(\\.20| LT| MI)?)|" // SF-2200, tested with OCZ-VERTEX3/2.02,
+      // OCZ-AGILITY3/2.11, OCZ-SOLID3/2.15, OCZ-VERTEX3 MI/2.15, OCZ-VERTEX3 LT/2.22, OCZ-VERTEX3.20/2.60
     "OCZ Z-DRIVE R4 [CR]M8[48]|" // PCIe, SF-2282/2582, tested with OCZ Z-DRIVE R4 CM84/2.13
       // (Bogus attributes under Linux)
     "OCZ Z-DRIVE 4500|"
@@ -1736,11 +1736,12 @@ const drive_settings builtin_knowndrives[] = {
     "-v 234,raw24/raw32:04321,Thermal_Throttle_Status "
     "-v 245,raw48,Percent_Life_Remaining"
   },
-  { "Intel S4510/S4610/S4500/S4600 Series SSDs", // INTEL SSDSC2KB480G7/SCV10100,
+  { "Intel/Solidigm S46x0/S45x0 Series SSDs", // INTEL SSDSC2KB480G7/SCV10100,
       // INTEL SSDSC2KB960G7/SCV10100, INTEL SSDSC2KB038T7/SCV10100,
       // INTEL SSDSC2KB038T7/SCV10121, INTEL SSDSC2KG240G7/SCV10100,
-      // INTEL SSDSC2KB480GZ/7CV10100, INTEL SSDSC2KB076T8/XCV10132
-    "INTEL SSDSC(2K|KK)(B|G)(240G|480G|960G|019T|038T|076T)[78Z].?",
+      // INTEL SSDSC2KB480GZ/7CV10100, INTEL SSDSC2KB076T8/XCV10132,
+      // SOLIDIGM SSDSC2KB960GZ/7CV10130
+    "(INTEL|SOLIDIGM) SSDSC(2K|KK)(B|G)(240G|480G|960G|019T|038T|076T)[78Z].?",
     "", "",
   //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
   //"-v 9,raw24(raw8),Power_On_Hours "
@@ -2094,10 +2095,10 @@ const drive_settings builtin_knowndrives[] = {
     "SanDisk (SDSSDHII|Ultra II )[0-9]*GB?|" // Ultra II (88SS9190/88SS9189), tested with
       // SanDisk SDSSDHII120G/X31200RL, SanDisk Ultra II 960GB/X41100RL
     "SanDisk SDSSDH2(128|256)G|" // SanDisk SDSSDH2128G/X211200
-    "SanDisk SDSSDH3((250|500| 512|1000|1024|2000)G| [124]T00)|" // Ultra 3D, tested with SanDisk SDSSDH3250G/X61170RL,
-      // SanDisk SDSSDH3500G/X61110RL, SanDisk SDSSDH31024G/X6107000, SanDisk SDSSDH3 2T00/411040RL,
-      // SanDisk SDSSDH3 4T00/411040RL, SanDisk SDSSDH3 1T00/415020RL,
-      // SanDisk SDSSDH3 512G/40101000
+    "SanDisk SDSSDH3 ?((250|500|512|1000|1024|2000)G|[124]T00)|" // Ultra 3D, tested with SanDisk SDSSDH3250G/X61170RL,
+      // SanDisk SDSSDH3 250G/401120RL, SanDisk SDSSDH3500G/X61110RL, SanDisk SDSSDH3 512G/40101000,
+      // SanDisk SDSSDH31024G/X6107000, SanDisk SDSSDH3 1T00/415020RL, SanDisk SDSSDH3 2T00/411040RL,
+      // SanDisk SDSSDH3 4T00/411040RL
     "SanDisk SDSSDXPS?[0-9]*G|" // Extreme II/Pro (88SS9187), tested with SanDisk SDSSDXP480G/R1311,
       // SanDisk SDSSDXPS480G/X21200RL
     "SanDisk SSD G5 BICS4|" // WD Blue SSD WDS100T2B0A (#1378), tested with SanDisk SSD G5 BICS4/415000WD
@@ -2225,6 +2226,7 @@ const drive_settings builtin_knowndrives[] = {
       // ADATA SU650/S0212B0, ADATA SU650/V8X01c45, ADATA SU650/V8X21c64, ADATA SU650NS38/P191202a,
       // ADATA SU655/V8X01c55, ADATA SU800/Q0913A, ADATA SU800/R0427A, ADATA SU800/R0918B, ADATA SU900/Q0125A,
       // ADATA SU900/Q0710B
+    "AMD R5SL512G|"// tested with AMD R5SL512G/V0929A0
     "CORSAIR FORCE LX SSD|" // tested with CORSAIR FORCE LX SSD/N0307A
     "CHN mSATAM3 (128|256|512)|" // Zheino M3, tested with CHN mSATAM3 128/Q1124A0
     "CIS 2S M305 (16|32|64|128|256)GB|" // Ceroz M305, tested with CIS 2S M305 64GB/P0316B
@@ -2233,6 +2235,7 @@ const drive_settings builtin_knowndrives[] = {
     "CT(240|480|960)BX200SSD1|" // Crucial BX200 Solid State Drive, tested with CT480BX200SSD1/MU02.6
     "DREVO X1 SSD|" // tested with DREVO X1 SSD/Q0111A
     "Drevo X1 pro (64|128|256)G|" // tested with Drevo X1 pro 64G/Q0303B
+    "DEXP SSD C100 (128|256|512)Gb|" // tested with DEXP SSD C100 256Gb/V0218A0
     "JAJS[56]00M((12[08]|240|256|480|512|960)C|1TB)(-1)?|" // J&A LEVEN JS500/600 (Intenso TOP), tested with
       // JAJS500M120C-1/P0614D, JAJS600M1TB/T0529A0, JAJS600M256C/U0803A0
     "KingDian S100 (32|64)GB|" // SM2244LT, tested with KingDian S100 32GB/0311A
@@ -2258,8 +2261,8 @@ const drive_settings builtin_knowndrives[] = {
     "SED2QII-LP SATA SSD ((64|128|256|512)GB|[12]TB)|" // ACPI SED2QII-LP, tested with
       // SED2QII-LP SATA SSD 64GB/S0410A
     "T60|" // KingSpec T60, tested with T60/20151120
-    "TCSUNBOW [MX]3 (60|120|240)GB|" // TC-Sunbow M3/X3, tested with TCSUNBOW M3 240GB/R0327B0,
-      // TCSUNBOW X3 120GB/R1211A0
+    "TCSUNBOW [MX]3 (60|120|240|480)GB|" // TC-Sunbow M3/X3, tested with TCSUNBOW M3 240GB/R0327B0,
+      // TCSUNBOW X3 120GB/R1211A0, TCSUNBOW X3 480GB/S0509A0
     "TEAM( T253(TD|X6)|L5Lite3D)((120|240|256|480|512)G|[12]T)|" // TEAMGROUP, tested with
       // TEAML5Lite3D240G/R0302A0 (L5Lite 3D), TEAM T253TD480G/Q0410A, TEAM T253X6256G/U1014A0 (CX2)
     "TS((16|32|64|128|256|512)G|1T)(SSD|MS[AM])(230S?|3[67]0[SI]?|420[IK]?)|" // Transcend SSD230/360/370/420
@@ -2355,7 +2358,7 @@ const drive_settings builtin_knowndrives[] = {
     "Dogfish SSD (128|256|512)GB|" // tested with Dogfish SSD 128GB/S1211A0
     "GIM(16|32|64|128|256|512)|"// GUDGA GIM, tested with GIM128/U0401A0
     "INTENSO( SSD)?|" // tested with INTENSO/S1211A0 (Portable SSD 256GB premium edition),
-      // INTENSO/V0609A0, INTENSO SSD/V0823A0, INTENSO/V0718B0 
+      // INTENSO/V0609A0, INTENSO SSD/V0823A0, INTENSO/V0718B0, INTENSO SSD/W0413A0, INTENSO SSD/W0714A0,
     "Intenso  ?SSD( S(ata|ATA) ?III)?|" // tested with Intenso SSD/Q1107A0, Intenso  SSD Sata III/P0510E,
       // Intenso SSD Sata III/R0817B0, Intenso SSD Sata III/V0303B0, Intenso SSD SATAIII/W0825A0
     "KingFast|" // tested with KingFast/P0725A (F6M), KingFast/S0424A0 (120GB), KingFast/S1128B0 (512GB)
@@ -2368,12 +2371,15 @@ const drive_settings builtin_knowndrives[] = {
       // SATA3 1TB SSD/S1230A0,
       // KingDian S370, tested with SATA3 128GB SSD/T0311A0, SATA3 256GB SSD/S1127B0
       // KingDian S280, tested with SATA3 240GB SSD/T0519A0
-    "SPCC M\\.2 SSD|" // Silicon Power A/M55, tested with SPCC M.2 SSD/Q0627A0, SPCC M.2 SSD/U0506A0
+    "SPCC M\\.2 SSD|" // Silicon Power A/M55, tested with SPCC M.2 SSD/Q0627A0, SPCC M.2 SSD/U0506A0,
+      // SPCC M.2 SSD/U1209A0
     "T-FORCE (128|256|512)GB|" // tested with T-FORCE 512GB/T0910A0
-    "Verbatim Vi550 S3", // may also exist with different controller (tickets #1626 <> #1629),
+    "Verbatim Vi550 S3|" // may also exist with different controller (tickets #1626 <> #1629),
       // tested with Verbatim Vi550 S3/U1124A0 (128GB)
-    "HPS2227I|KFS03005|P0510E|P0725A|Q(0627|1107)A0|R0817B0|S(0424|0509|0618|1211|1230)A0|"
-    "S112[78]B0|T0(311|519|910)A0|U(0202|0401|0506|1124)A0|V0((609|823)A|(303|718)B)0|V1027A0|W0825A0",
+    "Vi550 S3", // another variant (ticket #1899), tested with Vi550 S3/HP3418C5
+    "HP(3418C5|S2227I)|KFS03005|P0510E|P0725A|Q(0627|1107)A0|R0817B0|S(0424|0509|0618|1211|1230)A0|"
+    "S112[78]B0|T0(311|519|910)A0|U(0202|0401|0506|1124|1209)A0|V0((609|823)A|(303|718)B)0|V1027A0|"
+    "W(0413|0714|0825)A0",
     "",
     "-v 148,raw48,Total_SLC_Erase_Ct "
     "-v 149,raw48,Max_SLC_Erase_Ct "

--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -935,9 +935,9 @@ const drive_settings builtin_knowndrives[] = {
       // Patriot Blaze/S9FM02, Patriot Flare/SBFM91.2, Patriot Ignite/SAFM01.7
     "Patriot Burst( (120|240|480|960)GB)?|" // tested with Patriot Burst/SBFM11.2,
       // Patriot Burst 480GB/SBFMLA.5
-    "PNY CS(900|1311|2211) (120|240|480|500|960)GB SSD|" // tested with PNY CS900 120GB SSD/CS900612,
-      // PNY CS900 240GB SSD/CS900613, PNY CS900 500GB SSD/CS900Y13, PNY CS1311 120GB SSD/CS131122,
-      // PNY CS2211 240GB SSD/CS221016 (CS900 1TB has different attribute set)
+    "PNY CS(900|1311|2211) (120G|240G|480G|960G|1T|2T)B SSD|" // tested with PNY CS900 120GB SSD/CS900612,
+      // PNY CS900 240GB SSD/CS900613, PNY CS900 500GB SSD/CS900Y13, PNY CS900 1TB SSD/CS900615,
+      // PNY CS1311 120GB SSD/CS131122, PNY CS2211 240GB SSD/CS221016
     "PNY ELITE PSSD|" // tested with PNY ELITE PSSD/CS105P13 (240G)
     "S11-(128|256|512)G-PHISON-SSD-B27|" // tested with: S11-512G-PHISON-SSD-B27/SBFMJ1.3
     "SSD Smartbuy (60|64|120|128|240|256|480|512|960|1024|2000)GB|" // PS3111-S11, tested with
@@ -3833,8 +3833,9 @@ const drive_settings builtin_knowndrives[] = {
   },
   { "Hitachi/HGST Ultrastar 7K4000", // tested with Hitachi HUS724040ALE640/MJAOA3B0,
       // HGST HUS724040ALE640/MJAOA580, HGST HUS724020ALA640/MF6OAA70,
-      // HUS724030ALA640/MF8OAAZ0
-    "(Hitachi |HGST )?HUS7240(20|30|40)AL[AE]64[01]",
+      // HUS724030ALA640/MF8OAAZ0, HITACHI HUS724040ALE640/MJAONS04,
+      // HGST HUS724045ALE640/MJBOA5G0
+    "(Hitachi |HITACHI |HGST )?HUS7240([234]0|45)AL[AE]64[01]",
     "", "", ""
   },
   { "Hitachi/HGST Ultrastar 7K2",
@@ -3900,14 +3901,14 @@ const drive_settings builtin_knowndrives[] = {
     // WDC WUH722020BLE6L4
     "(WDC  ?)?WUH722020[AB]L[EN]6[0L][014]",
     "", "",
-    "-v 22,raw48,Helium_Level "
+  //"-v 22,raw48,Helium_Level "
     "-v 82,raw16,Head_Health_Score "
     "-v 90,hex48,NAND_Master"
   },
   { "Western Digital Ultrastar DC HC570", // tested with WUH722222ALE604
     "(WDC  ?)?WUH722222[AB]L[EN]6[0L]4",
     "", "",
-    "-v 22,raw48,Helium_Level "
+  //"-v 22,raw48,Helium_Level "
     "-v 71,raw16,Milli_Micro_Actuator "
     "-v 82,raw16,Head_Health_Score "
     "-v 90,hex48,NAND_Master"
@@ -3920,7 +3921,7 @@ const drive_settings builtin_knowndrives[] = {
   { "Western Digital Ultrastar DC HC670", // WSH722626ALE604
     "(WDC  ?)?WSH722222[AB]L[EN]6[0L]4",
     "", "",
-    "-v 22,raw48,Helium_Level "
+  //"-v 22,raw48,Helium_Level "
     "-v 71,raw16,Milli_Micro_Actuator "
     "-v 82,raw16,Head_Health_Score "
     "-v 90,hex48,NAND_Master"
@@ -4746,9 +4747,10 @@ const drive_settings builtin_knowndrives[] = {
     "-v 200,raw48,Pressure_Limit "
     "-v 240,msec24hour32"
   },
-  { "Seagate Exos X20", // tested with ST20000NM007D-3DJ103/SN01, .../SN03,
-      // OOS20000G/OOS1
-    "ST(18|20)000NM00[0347]D-.*|"
+  { "Seagate Exos X20/X22", // tested with ST20000NM007D-3DJ103/SN01, .../SN03,
+      // ST22000NM001E-3HM103/SN03, OOS20000G/OOS1
+    "ST(18|20)000NM00[0347]D-.*|" // X20
+    "ST2[02]000NM001E-.*|" // X22
     "OOS20000G", // 20TB refurbished and rebranded
     "", "",
     "-v 1,raw24/raw32 -v 7,raw24/raw32 "
@@ -4782,19 +4784,23 @@ const drive_settings builtin_knowndrives[] = {
     "ST(8000NE|[65432]000VN)00[01]1-.*",
     "", "", ""
   },
-  { "Seagate IronWolf", // tested with ST3000VN007-2E4166/SC60, ST4000VN008-2DR166/SC60,
-      // ST6000VN001-2BB186/SC60, ST6000VN0033-2EE110/SC60, ST6000VN0041-2EL11C/SC61,
-      // ST8000VN0022-2EL112/SC61, ST10000VN0004-1ZD101/SC60,
-      // ST12000VN0007-2GS116/SC60, ST12000VN0008-2JH101/SC60
-    "ST(1|2|3|4|6|8|10|12)000VN00(0?[2478]|1|22|33|41)-.*",
+  { "Seagate IronWolf", // tested with ST2000VN003-3CW102/SC60, ST3000VN007-2E4166/SC60,
+      // ST4000VN006-3CW104/SC60,
+      // ST4000VN008-2DR166/SC60, ST6000VN001-2BB186/SC60, ST6000VN0033-2EE110/SC60,
+      // ST6000VN0041-2EL11C/SC61, ST8000VN0022-2EL112/SC61, ST10000VN000-3AK101/SC60,
+      // ST10000VN0004-1ZD101/SC60, ST10000VN0004-2GS11L/SC60, ST12000VN0007-2GS116/SC60,
+      // ST12000VN0008-2JH101/SC60, ST16000VN001-2RV103/SC60
+    "ST([123468]|1[0246])000VN00(0?[0234678]|1|22|33|41)-.*",
     "", "",
     "-v 18,raw48,Head_Health "
+    "-v 188,raw16 "
     "-v 200,raw48,Pressure_Limit "
     "-v 240,msec24hour32"
   },
   { "Seagate IronWolf Pro", // tested with ST4000NE0025-2EW107/EN02,
-      // ST8000NE0004-1ZF11G/EN01, ST8000NE0021-2EN112/EN02, ST12000NT001-3LX101/EN01, ST16000NE000-2RW103/EN02
-    "ST([24]000NE0025|4000NE001|6000NE0023|8000NE00(04|08|21)|(10|12|14|22)000(NE|NT)(000[478]|001)|16000NE000)-.*",
+      // ST8000NE0004-1ZF11G/EN01, ST8000NE0021-2EN112/EN02, ST12000NT001-3LX101/EN01,
+      // ST16000NE000-2RW103/EN02, ST16000NT001-3LV101/EN01
+    "ST([24]000NE0025|4000NE001|6000NE0023|8000NE00(04|08|21)|(1[02468]|2[02])000(NE|NT)(000[478]|001)|16000NE000)-.*",
     "", "",
     "-v 18,raw48,Head_Health " // ST16000NE000
     "-v 188,raw16 "
@@ -5562,16 +5568,10 @@ const drive_settings builtin_knowndrives[] = {
     "-d usbcypress"
   },
   // Fujitsu
-  { "USB: Fujitsu/Zalman ZM-VE300; ", // USB 3.0
-    "0x04c5:0x2028",
-    "", // 0x0001
-    "",
-    "-d sat"
-  },
-  { "USB: ; Fujitsu", // DeLock 42475, USB 3.0
-    "0x04c5:0x201d",
-    "", // 0x0001
-    "",
+  { "USB: Fujitsu; ",
+    "0x04c5:0x(11bc|201d|2028)", "", // 0x11bc (0x0101), 0x201d: DeLock 42475 (0x0001),
+    "", // 0x2028: Zalman ZM-VE300 (0x0001)
+    ""
     "-d sat"
   },
   // Myson Century
@@ -6327,10 +6327,11 @@ const drive_settings builtin_knowndrives[] = {
   },
   // ADATA
   { "USB: ADATA; ",
-    "0x125f:0xa(1[135]|21|31|3[57]|68|7[56]|83)a", // 0xa11a: Classic CH11 1TB, 0xa13a: NH13 1TB,
+    "0x125f:0xa(1[135]|21|31|3[57]|68|7[56]|8[35])a", // 0xa11a: Classic CH11 1TB, 0xa13a: NH13 1TB,
     "", // 0xa15a: HD710 1TB, 0xa21a: HV610 (0x4504), 0xa31a: HV620 2TB (0x0100),
     "", // 0xa35a: HD650 2TB (0x6503), 0xa37a: Silverstone MS10 M.2 (0x3103), 0xa75a: HD710P 4TB,
-        // 0xa68a: SD600, 0xa76a: ED600 (0x0204), 0xa83a: HD330 (0x0100)
+        // 0xa68a: SD600, 0xa76a: ED600 (0x0204), 0xa83a: HD330 (0x0100),
+        // 0xa85a: HD680 (0x100)
     "-d sat"
   },
   { "USB: ADATA; Cypress",

--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -2992,7 +2992,8 @@ const drive_settings builtin_knowndrives[] = {
     "", "", ""
   },
   { "Seagate Mobile HDD", // tested with ST1000LM035-1RK172/ACM1,
-     // ST1000LM035-1RK172/ACM2, ST2000LM007-1R8174/SBK2
+     // ST1000LM035-1RK172/ACM2, ST1000LM035-1RK172/EB01 (0x1005:0xc004),
+     // ST2000LM007-1R8174/SBK2
     "ST(2000LM0(07|09|10)|1000LM03[578])-.*",
     "", "", ""
   },
@@ -5744,9 +5745,10 @@ const drive_settings builtin_knowndrives[] = {
     "" // unsupported
   },
   { "USB: ; Genesys Logic",
-    "0x05e3:0x(0718|073[15]|2013)", // 0x0718(0x0041): Requires '-T permissive',
+    "0x05e3:0x(07(18|3[15]|61)|2013)", // 0x0718(0x0041): Requires '-T permissive',
     "", // 0x0731: Genesys Logic GL3310, Chieftec USB 3.0 2.5" case, 0x0735(0x1003): ?,
-    "", // 0x2013(0x0100): Sharkoon QuickPort Duo Clone USB 3.1 Type-C
+    "", // 0x0761(0x2402): Other World Computing SATA Adapter PA023U3,
+        // 0x2013(0x0100): Sharkoon QuickPort Duo Clone USB 3.1 Type-C
     "-d sat"
   },
   // Micron
@@ -5802,6 +5804,12 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "",
     "-d sat"
+  },
+  { "USB: SanDisk Extreme; ASMedia ASM2362",
+    "0x0781:0x55ae", // SanDisk Extreme (Western Digital SN580E 1TB)
+    "", // 0x3008
+    "",
+    "-d sntasmedia"
   },
   // Freecom
   { "USB: ; Innostor IS631", // No Name USB3->SATA Enclosure
@@ -5936,6 +5944,12 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "-d sat,12"
   },
+  { "USB: Kingston; ",
+    "0x0951:0x1780", // XS1000
+    "", // 0x100
+    "",
+    "-d sat"
+  },
   // Apricorn
   { "USB: Apricorn; ",
     "0x0984:0x0(040|301|320)", // 0x0040: Apricorn SATA Wire
@@ -5983,6 +5997,12 @@ const drive_settings builtin_knowndrives[] = {
     "-d sat"
   },
   // Realtek
+  { "USB: ; Realtek RTL9201", // USB->SATA
+    "0x0bda:0x9201",
+    "", // 0xf200
+    "",
+    "-d sat"
+  },
   { "USB: ; Realtek RTL9210", // USB->PCIe (NVMe)
     "0x0bda:0x9210",
     "", // 0x2100
@@ -6105,6 +6125,13 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "-d sat"
   },
+  // Apacer
+  { "USB: Apacer; ",
+    "0x1005:0xc004", // Apacer AC633
+    "",
+    "",
+    "-d sat"
+  },
   // iRiver
   { "USB: iRiver iHP-120/140 MP3 Player; Cypress",
     "0x1006:0x3002",
@@ -6152,6 +6179,13 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "",
     "-d usbcypress"
+  },
+  // 0x1352 (?)
+  { "USB: ; ",
+    "0x1352:0xa006", // TerraMaster D2-320
+    "", // 0x0100
+    "",
+    "-d sat"
   },
   // Initio
   { "USB: ; Initio",
@@ -6205,7 +6239,7 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "-d sat"
   },
-  { "USB: ; JMicron JM562", // USB2/3+eSATA->2xSATA, USB2/3->3xSATA (RAID0/1)
+  { "USB: ; JMicron JMS562", // USB2/3+eSATA->2xSATA, USB2/3->3xSATA (RAID0/1)
     "0x152d:0x0562",
     "", // 0x0106, Fantec QB-X2US3R (ticket #966)
     "", // only ATA IDENTIFY works, SMART commands don't work
@@ -6350,9 +6384,9 @@ const drive_settings builtin_knowndrives[] = {
     "-d sat"
   },
   { "USB: ; JMicron",
-    "0x152d:0x(578e|b567)",
-    "", // 0x578e(0x1402): Intenso Memory Center
-    "", // 0xb567: Fantec AD-U3S
+    "0x152d:0x(578e|a5(78|80)|b567)",
+    "", // 0x578e(0x1402): Intenso Memory Center, 0xa578: Sabrent EC-DFLT,
+    "", // 0xa580(0x003): CENMATE 2 Bay RAID Enclosure, 0xb567: Fantec AD-U3S
     "-d sat"
   },
   { "USB: ; JMicron JMS561", // USB3->2xSATA
@@ -6570,10 +6604,24 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "-d sat"
   },
+  // 0x235c (?)
+  { "USB: ; ",
+    "0x235c:0xa006", // Terramaster D4-320
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
   // Norelsys
   { "USB: ; ", // USB 3.0
     "0x2537:0x106[68]", // 0x1066: Orico 2599US3, 0x1068: Fantec ER-35U3
     "", // 0x0100
+    "",
+    "-d sat"
+  },
+  // 0x2bdf (?)
+  { "USB: ; ",
+    "0x2bdf:0x0580", // HIKSEMI
+    "", // 0x1601
     "",
     "-d sat"
   },
@@ -6584,6 +6632,7 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "-d sat"
   },
+  // 0x2eb9 (?): See Realtek (0x0bda) above
   // KIOXIA (?)
   { "USB: ; ", // KIOXIA EXCERIA PLUS
     "0x30de:0x1000",
@@ -6591,11 +6640,10 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "-d sntjmicron"
   },
-  // 0x2eb9 (?): See Realtek (0x0bda) above
-  // Power Quotient International
-  { "USB: PQI H560; ",
-    "0x3538:0x0902",
-    "", // 0x0000
+  // 0x31db (?)
+  { "USB: ; ",
+    "0x31db:0x0716", // DockCase 10s PLP 2.5" Enclosure
+    "", // 0x0148
     "",
     "-d sat"
   },
@@ -6605,6 +6653,12 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "",
     "-d usbsunplus"
+  },
+  { "USB: PQI H560; ",
+    "0x3538:0x0902",
+    "", // 0x0000
+    "",
+    "-d sat"
   },
   // Sharkoon
   { "USB: Sharkoon QuickPort XT USB 3.0; ",
@@ -6621,7 +6675,7 @@ const drive_settings builtin_knowndrives[] = {
     "-d usbjmicron"
   },
   { "USB: Hitachi Touro; ",
-    "0x4971:0x101[45]", // 14=1TB, 15=2TB
+    "0x4971:0x101[345]", // 14=1TB, 15=2TB, 13=Touro Desk Pro 3TB
     "", // 0x0000
     "",
     "-d sat" // ATA output registers missing

--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -3880,8 +3880,9 @@ const drive_settings builtin_knowndrives[] = {
   { "Western Digital Ultrastar DC HC530", // tested with
       // WDC  WUH721414ALE604/LDAZW110, WDC  WUH721414ALE6L4/LDGNW07G
     "WDC  ?WUH721414ALE6[0L]4",
-    "", "", ""
-  //"-v 22,raw48,Helium_Level"
+    "", "",
+  //"-v 22,raw48,Helium_Level "
+    "-v 188,raw16 "
   },
   { "Western Digital Ultrastar DC HC550", // tested with WDC  WUH721818ALE6L4/PCGNW110,
       // WUH721818ALE6L4/PCGAW232, WDC  WUH721818ALN6L4/PCGNW088
@@ -4678,6 +4679,12 @@ const drive_settings builtin_knowndrives[] = {
     "", "",
     "-v 9,msec24hour32 -v 188,raw16 -v 240,msec24hour32"
   },
+  { "Seagate Enterprise Capacity 3.5 HDD v7 SED", // tested with ST12000NM0127/G005
+    "ST12000NM01[12]7",
+    "", "",
+    "-v 1,raw24/raw32 -v 7,raw24/raw32 "
+    "-v 195,raw24/raw32,Hardware_ECC_Recovered "
+  },
   { "Seagate Exos 5E8", // tested with ST8000AS0003-2HH188/0003
     "ST8000AS0003-.*",
     "", "",
@@ -4688,10 +4695,12 @@ const drive_settings builtin_knowndrives[] = {
   // ST4000NM006A, ST4000NM010A, ST4000NM012A, ST4000NM013A, ST6000NM002A,
   // ST6000NM021A, ST6000NM022A, ST6000NM025A, ST6000NM026A, ST8000NM000A,
   // ST8000NM002A, ST8000NM004A, ST8000NM008A, ST8000NM009A, ST8000NM016A
-  { "Seagate Exos 7E8", // tested with ST6000NM021A-2R7101/SN02, ST8000NM000A-2KE101/SN02
+  { "Seagate Exos 7E8", // tested with ST4000NM000A-2HZ100/TN03, ST6000NM021A-2R7101/SN02,
+      // ST8000NM000A-2KE101/SN02
     "ST[123468]000NM0(0[01234689]|1[0236]|2[1256])A-.*",
     "", "",
     "-v 18,raw48,Head_Health "
+    "-v 188,raw16 "
     "-v 240,msec24hour32"
   },
   { "Seagate Exos X12", // tested with ST12000NM0007-2A1101/SN02
@@ -4709,10 +4718,13 @@ const drive_settings builtin_knowndrives[] = {
     "-v 240,msec24hour32"
   },
   { "Seagate Exos X16", // tested with ST10000NM001G-2MW103/SN02
-      // ST14000NM001G-2KJ103/SN02, ST16000NM001G-2KK103/SN02, ST16000NM001G-2KK103/SN03
+      // ST14000NM001G-2KJ103/SN02, ST14000NM001G-2KJ1037/SN04, ST16000NM001G-2KK103/SN02,
+      // ST16000NM001G-2KK103/SN03
     "ST1[0246]000NM00[13]G-.*",
     "", "",
+    "-v 1,raw24/raw32 -v 7,raw24/raw32 "
     "-v 18,raw48,Head_Health "
+    "-v 188,raw16 "
     "-v 200,raw48,Pressure_Limit "
     "-v 240,msec24hour32"
   },
@@ -4772,10 +4784,11 @@ const drive_settings builtin_knowndrives[] = {
     "-v 240,msec24hour32"
   },
   { "Seagate IronWolf Pro", // tested with ST4000NE0025-2EW107/EN02,
-      // ST8000NE0004-1ZF11G/EN01, ST8000NE0021-2EN112/EN02, ST16000NE000-2RW103/EN02
-    "ST([24]000NE0025|4000NE001|6000NE0023|8000NE00(04|08|21)|(10|12|14)000NE000[478]|16000NE000)-.*",
+      // ST8000NE0004-1ZF11G/EN01, ST8000NE0021-2EN112/EN02, ST12000NT001-3LX101/EN01, ST16000NE000-2RW103/EN02
+    "ST([24]000NE0025|4000NE001|6000NE0023|8000NE00(04|08|21)|(10|12|14|22)000(NE|NT)(000[478]|001)|16000NE000)-.*",
     "", "",
     "-v 18,raw48,Head_Health " // ST16000NE000
+    "-v 188,raw16 "
     "-v 200,raw48,Pressure_Limit "
     "-v 240,msec24hour32"
   },

--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -200,8 +200,10 @@ const drive_settings builtin_knowndrives[] = {
     "-v 248,raw48,Perc_Rated_Life_Remain "
     "-v 249,raw48,Spares_Remaining_Perc "
   },
-  { "Swissbit X-7x Family SATA SSD",
-    "SFSA....(S|Q|M|U|V).AK.T(A|B|O).............",
+  { "Swissbit X-7x Family SATA SSD", // tested with
+      // SFSA060GM2AK1TO-C-6B-536-STD/SBR11007, SFSA020GU2AK1TO-I-6B-22P-STD/SBR15004,
+      // SFSA160GM2AK1TA-I-8C-11P-STD/SBR15103, SFSA320GM2AK2TA-I-8C-21P-STD/SBR15103
+    "SFSA....[MQSUV].AK.T[ABO].............",
     "", "",
   //"-v 1,raw48,Raw_Read_Error_Rate "
   //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
@@ -234,7 +236,8 @@ const drive_settings builtin_knowndrives[] = {
     "-v 244,raw48,Host_LBA_Read_Exp "
     "-v 248,raw48,SSD_Remaining_Life_Perc "
   },
-  { "Swissbit X-8x Family SATA SSD",
+  { "Swissbit X-8x Family SATA SSD", // tested with
+    // SFSA080GM1AO1TO-C-8C-11P-STD/AOR20008, SFSA020GM1AO1TO-I-6B-11P-STD/AOR20008
     "SFSA....M.AO.TO.............",
     "", "",
   //"-v 9,raw24(raw8),Power_On_Hours "

--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -3985,6 +3985,11 @@ const drive_settings builtin_knowndrives[] = {
     "TOSHIBA MQ03UBB(300|200|250)",
     "", "", ""
   },
+  { "Toshiba 2.5\" HDD MQ04UBB... (USB, SMR)", // tested with TOSHIBA MQ04UBB400/JS000U,
+      // TOSHIBA MQ04UBB400/JS0B0U (0x0480:0xa301) ('Device managed zones', no TRIM support)
+    "TOSHIBA MQ04UBB[24]00",
+    "", "", ""
+  },
   { "Toshiba 3.5\" HDD MK.002TSKB", // tested with TOSHIBA MK1002TSKB/MT1A
     "TOSHIBA MK(10|20)02TSKB",
     "", "", ""
@@ -4054,6 +4059,13 @@ const drive_settings builtin_knowndrives[] = {
   { "Toshiba MG10AFA... Enterprise Capacity HDD", // tested with TOSHIBA MG10AFA22TE/0102
     "TOSHIBA MG10AFA22T[AE]Y?",
     "", "",
+  //"-v 23,raw48,Helium_Condition_Lower "
+  //"-v 24,raw48,Helium_Condition_Upper "
+    "-v 27,raw48,MAMR_Health_Monitor"
+  },
+  { "Toshiba MG11 Cloud-scale Capacity HDD", // tested with TOSHIBA MG11ACA24TE/0102
+    "TOSHIBA MG11AC[AP](1[468]|2[024])TEY?", // ACP = self-encrypting device (SED)
+    "", "",                                  // TEY = sanitize instant erase (SIE)
   //"-v 23,raw48,Helium_Condition_Lower "
   //"-v 24,raw48,Helium_Condition_Upper "
     "-v 27,raw48,MAMR_Health_Monitor"

--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -6149,6 +6149,12 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "" // ... SATA (unsupported)
   },
+  { "USB: ; Realtek RTL9220", // USB->PCIe (NVMe) or SATA
+    "0x0bda:0x9220",
+    "",
+    "",
+    "-d sntrealtek" // ... SATA (requires `-d sat`)
+  },
   // Addonics
   { "USB: Addonics HDMU3; ", // (ticket #609)
     "0x0bf6:0x1001",

--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -648,7 +648,8 @@ const drive_settings builtin_knowndrives[] = {
     "Micron_5210_MTFDDAK(480|960|1T9|3T8|7T6)QDE|" // tested with Micron_5210_MTFDDAK7T6QDE/D2MU804
     "(Micron_5300(HC)?_)?MTFDDA[KV](240|480|960|1T9|3T8|7T6)TD[STU]|" // tested with Micron_5300_MTFDDAK1T9TDS/D3MU001
       // Micron_5300HC_MTFDDAK960TDS/D3MN010, MTFDDAK1T9TDT/D3MU001
-    "(Micron_5400_)?(EE|MT)FDDA[KV](240|480|960|1T9|3T8|7T6)TG[ABC]", // tested with Micron_5400_MTFDDAK1T9TGB/D4MU001,
+    "(Micron_5400_)?(EE|MT)FDDA[KV](240|480|960|1T9|3T8|7T6)TG[ABC](_SED)?", // tested with
+      // Micron_5400_MTFDDAK1T9TGB/D4MU001, Micron_5400_MTFDDAK960TGA_SED/D4CS001
     "", "",
   //"-v 1,raw48,Raw_Read_Error_Rate "
   //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
@@ -990,6 +991,7 @@ const drive_settings builtin_knowndrives[] = {
   // this is a copy of the Phison bases record for the OEM drives with a very
   // weak information in the model. Detection is based on Firmware.
   { "Phison Driven OEM SSDs", // see MKP_521_Phison_SMART_attribute.pdf
+    "Gigastone SSD|" // tested with GSTB512G (Gigastone SSD/SHFM20.2)
     "GOODRAM|" // tested with GOODRAM CX200 (GOODRAM/SAFM12.2)
     "Hoodisk SSD|" // tested with Hoodisk SSD/SBFM01.3, Hoodisk SSD/SBFMJ1.3
     "INTENSO|" // tested with Intenso SSD SATA III Top (INTENSO/S9FM02.6, .../SAFM01.6)
@@ -1001,7 +1003,7 @@ const drive_settings builtin_knowndrives[] = {
       // SPCC Solid State Disk/SBFM61.2, SPCC Solid State Disk/SBFMT1.3
     "SSDPR-CX400-(128|256|512|1024|2028)-G2", // Goodram CX400 G2, tested with
       // SSDPR-CX400-512-G2/SBFMLA.5 (SSDPR-CX400-128-G2/SN07373 differs, see ticket #1689)
-    "S[89AB]F[DM][0-9JLTY][0-9A]\\.[0-9]",
+    "S[89ABH]F[DM][0-9JLTY][0-9A]\\.[0-9]",
     "",
   //"-v 1,raw48,Raw_Read_Error_Rate "
     "-v 2,raw48,Not_In_Use "
@@ -2340,7 +2342,7 @@ const drive_settings builtin_knowndrives[] = {
       // TS512GSSD370S/N1114H, TS32GSSD420I/N1114H, TS32GSSD420K/P1225CE
     "TS(16|32|64|128|512|256)GMTS4[03]0S?|" // TS256GMTS400, TS256GMTS430S/S0423A
     "TS(120|240)GMTS420S?|" // Transcend MTS420, tested with TS120GMTS420S/R0510A0
-    "TS(128G|256G|512G|1T)SSD230S|" // TS128GSSD230S/P1025F8
+    "TS(128G|256G|512G|1T|2T|4T)SSD230S|" // TS128GSSD230S/P1025F8, TS2TSSD230S/22Z4W14J
     "TS(120|240|480|960)GSSD220S|" // TS480GSSD220S/P0520AA
     "TS((64|128|256|512)G|[12]T)SSD452K|"// Transcend 452K, tested with TS128GSSD452K/02J0S86A
     "TS(16G|32G|64G|128G|256G|512G|1T)MTS800S?|" // MTS800, tested with TS1TMTS800/O1225H1
@@ -2427,7 +2429,8 @@ const drive_settings builtin_knowndrives[] = {
     "INTENSO( SSD)?|" // tested with INTENSO/S1211A0 (Portable SSD 256GB premium edition),
       // INTENSO/V0609A0, INTENSO SSD/V0823A0, INTENSO/V0718B0, INTENSO SSD/W0413A0, INTENSO SSD/W0714A0,
     "Intenso  ?SSD( S(ata|ATA) ?III)?|" // tested with Intenso SSD/Q1107A0, Intenso  SSD Sata III/P0510E,
-      // Intenso SSD Sata III/R0817B0, Intenso SSD Sata III/V0303B0, Intenso SSD SATAIII/W0825A0
+      // Intenso SSD Sata III/R0817B0, Intenso SSD Sata III/S0222A0, Intenso SSD Sata III/V0303B0,
+      // Intenso SSD SATAIII/W0825A0,
     "KingFast|" // tested with KingFast/P0725A (F6M), KingFast/S0424A0 (120GB), KingFast/S1128B0 (512GB)
     "KSM512|" // KingSpec, tested with KSM512/S0509A0
     "LDLC|" // tested with LDLC/KFS03005
@@ -2440,12 +2443,14 @@ const drive_settings builtin_knowndrives[] = {
       // KingDian S280, tested with SATA3 240GB SSD/T0519A0
     "SPCC M\\.2 SSD|" // Silicon Power A/M55, tested with SPCC M.2 SSD/Q0627A0, SPCC M.2 SSD/U0506A0,
       // SPCC M.2 SSD/U1209A0
+    "SSD 120GB|" // Intenso M.2 SSD High, tested with SSD 120GB/R0529A
     "T-FORCE (128|256|512)GB|" // tested with T-FORCE 512GB/T0910A0
-    "Verbatim Vi550 S3|" // may also exist with different controller (tickets #1626 <> #1629),
-      // tested with Verbatim Vi550 S3/U1124A0 (128GB)
+    "Verbatim Vi550 S3|" // tested with Verbatim Vi550 S3/U1124A0 (128GB),
+       // may also exist with different controllers (tickets #1626, #1629, #1774, #1930, GH issues/185),
     "Vi550 S3", // another variant (ticket #1899), tested with Vi550 S3/HP3418C5
-    "HP(3418C5|S2227I)|KFS03005|P0510E|P0725A|Q(0627|1107)A0|R0817B0|S(0424|0509|0618|1211|1230)A0|"
-    "S112[78]B0|T0(311|519|910)A0|U(0202|0401|0506|1124|1209)A0|V0((609|823)A|(303|718)B)0|V1027A0|"
+    "HP(3418C5|S2227I)|KFS03005|P0510E|P0725A|Q(0627|1107)A0|R(0529A|0817B0)|"
+    "S(0222|0424|0509|0618|1211|1230)A0|S112[78]B0|T0(311|519|910)A0|"
+    "U(0202|0401|0506|1124|1209)A0|V0((609|823)A|(303|718)B)0|V1027A0|"
     "W(0413|0714|0825)A0",
     "",
     "-v 148,raw48,Total_SLC_Erase_Ct "
@@ -2560,10 +2565,11 @@ const drive_settings builtin_knowndrives[] = {
   //"-v 194,tempminmax,Temperature_Celsius"
   },
   { "SSSTC ERX GD/CD Series SSDs", // Marvel DEAN 2.1
-    "(SSSTC|SATA) ER[2-9]-[CG]D(240|480|960|1920|3840)A?|" // tested with SSSTC ER2-GD480/E4N23021,
-      // SSSTC ER2-CD1920A/E5MN401, SSSTC ER3-GD240/F2MRD0F, SSSTC ER3-CD960A/F3MRD0Y
-    "AF[2-9]MA31DT[ED]LT(240|480|960|1920)A?", // tested with AF2MA31DTDLT240A/F2M96T0,
-      // AF3MA31DTELT240A/F2M9601
+    "(SSSTC|SATA) ER[2-9]-[CG]D(240|480|960|1920|3840|7680|15360)A?|" // tested with
+      // SSSTC ER3-GD240/F2MRD0F, SSSTC ER2-GD480/E4N23021, SSSTC ER3-CD960A/F3MRD0Y,
+      // SSSTC ER2-CD1920A/E5MN401, SSSTC ER4-CD7680A/G62RD14
+    "AF[2-9]MA31DT[ED]LT(240|480|960|1920|3840|7680|15360)A?", // tested with
+      // AF2MA31DTDLT240A/F2M96T0, AF3MA31DTELT240A/F2M9601
     "","",
   //"-v 1,raw48,Raw_Read_Error_Rate "
   //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
@@ -4696,8 +4702,9 @@ const drive_settings builtin_knowndrives[] = {
   // ST6000NM021A, ST6000NM022A, ST6000NM025A, ST6000NM026A, ST8000NM000A,
   // ST8000NM002A, ST8000NM004A, ST8000NM008A, ST8000NM009A, ST8000NM016A
   { "Seagate Exos 7E8", // tested with ST4000NM000A-2HZ100/TN03, ST6000NM021A-2R7101/SN02,
-      // ST8000NM000A-2KE101/SN02
-    "ST[123468]000NM0(0[01234689]|1[0236]|2[1256])A-.*",
+      // ST8000NM000A-2KE101/SN02, OOS6000G/OOS1
+    "ST[123468]000NM0(0[01234689]|1[0236]|2[1256])A-.*|"
+    "OOS6000G", // 6TB refurbished and rebranded
     "", "",
     "-v 18,raw48,Head_Health "
     "-v 188,raw16 "
@@ -4739,8 +4746,10 @@ const drive_settings builtin_knowndrives[] = {
     "-v 200,raw48,Pressure_Limit "
     "-v 240,msec24hour32"
   },
-  { "Seagate Exos X20", // tested with ST20000NM007D-3DJ103/SN01, .../SN03
-    "ST(18|20)000NM00[0347]D-.*",
+  { "Seagate Exos X20", // tested with ST20000NM007D-3DJ103/SN01, .../SN03,
+      // OOS20000G/OOS1
+    "ST(18|20)000NM00[0347]D-.*|"
+    "OOS20000G", // 20TB refurbished and rebranded
     "", "",
     "-v 1,raw24/raw32 -v 7,raw24/raw32 "
     "-v 18,raw48,Head_Health "

--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -4643,6 +4643,36 @@ const drive_settings builtin_knowndrives[] = {
     "-v 200,raw48,Pressure_Limit "
     "-v 240,msec24hour32"
   },
+  { "Seagate Exos X18", // tested with ST12000NM000J-2TY103/SN02,
+      // ST16000NM000J-2TW103/SC02, ST18000NM000J-2TV103/SN01, .../SN02,
+      // ST18000NM002J-2TV133/PAL7 (Dell)
+    "ST1(0000NM0(18|20)G|[2468]000NM00[012]J)-.*",
+    "", "",
+    "-v 1,raw24/raw32 -v 7,raw24/raw32 "
+    "-v 18,raw48,Head_Health "
+    "-v 188,raw16 "
+    "-v 200,raw48,Pressure_Limit "
+    "-v 240,msec24hour32"
+  },
+  { "Seagate Exos X20", // tested with ST20000NM007D-3DJ103/SN01, .../SN03
+    "ST(18|20)000NM00[0347]D-.*",
+    "", "",
+    "-v 1,raw24/raw32 -v 7,raw24/raw32 "
+    "-v 18,raw48,Head_Health "
+    "-v 188,raw16 "
+    "-v 200,raw48,Pressure_Limit "
+    "-v 240,msec24hour32"
+  },
+  { "Seagate Exos X24", // tested with ST24000NM002H-3KS133/SE03,
+      // ST24000NM000C-3WD103/SN02 (30TB HAMR recertified to 24TB CMR ?)
+    "ST((12|16|20|24)000NM002H|24000NM000C)-.*",
+    "", "",
+    "-v 1,raw24/raw32 -v 7,raw24/raw32 "
+    "-v 18,raw48,Head_Health "
+    "-v 188,raw16 "
+    "-v 200,raw48,Pressure_Limit "
+    "-v 240,msec24hour32"
+  },
   // new models: ST8000VN0002, ST6000VN0021, ST4000VN000
   //             ST8000VN0012, ST6000VN0031, ST4000VN003
   // tested with ST8000VN0002-1Z8112/ZA13YGNF

--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -5476,30 +5476,19 @@ const drive_settings builtin_knowndrives[] = {
     "" // unsupported
   },
   // Buffalo / Melco
-  { "USB: Buffalo JustStore Portable HD-PVU2; ",
-    "0x0411:0x0181",
-    "",
-    "",
-    "-d sat"
-  },
-  { "USB: Buffalo Drivestation Duo; ",
-    "0x0411:0x01ce",
-    "",
-    "",
-    "-d sat"
-  },
-  { "USB: Buffalo DriveStation HD-LBU2 ; Medialogic MLDU11",
-    "0x0411:0x01ea",
-    "",
-    "",
-    "-d sat"
-  },
   { "USB: Buffalo; ",
-    "0x0411:0x0(157|1[df]9|1e7|240|251|27e)", // 0x0157: HD-PEU2, 0x01d9: HD-PCTU2 (0x0108), 0x01e7: HD-PNTU3,
+    "0x0411:0x0(157|181|1ce|1[df]9|1e[7a]|240|251|27e)", // 0x0157: HD-PEU2, 0x0181: HD-PVU2,
+      // 0x01ce: Duo, 0x01d9: HD-PCTU2 (0x0108), 0x01e7: HD-PNTU3, 0x01ea: HD-LBU2,
       // 0x01f9: HD-PZU3 (0x0100), 0x0240: HD-PCFU3, 0x0251: HD-PNFU3, 0x027e: HD-LC3
     "",
     "",
     "-d sat"
+  },
+  { "USB: Buffalo SSD-PSTA/N; ASMedia",
+    "0x0411:0x039d",
+    "",
+    "",
+    "-d sntasmedia"
   },
   // LG Electronics
   { "USB: LG Mini HXD5; JMicron",
@@ -5915,11 +5904,11 @@ const drive_settings builtin_knowndrives[] = {
     "-d sat"
   },
   // Jess-Link
-  { "USB: Packard Bell Carbon; ",
+  { "USB: Packard Bell Carbon; SunPlus",
     "0x0766:0x0017",
     "", // 0x0108
     "",
-    "" // unsupported
+    "-d usbsunplus"
   },
   // Logitec
   { "USB: Logitec LGB-4BNHUC; ",

--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -902,6 +902,7 @@ const drive_settings builtin_knowndrives[] = {
     "BP4 mSATA SSD|" // MyDigital BP4, tested with BP4 mSATA SSD/S8FM06.9
     "Corsair Force LE(200)? SSD|" // tested with Corsair Force LE SSD/SAFC11.0,
       // Corsair Force LE200 SSD/SBFM10, .../SBFM60.9
+    "DGSR2(128|256|512)GP13T|"  // tested with DGSR2512GP13T/SBFM61.5
     "GIGABYTE GP-GSTFS31((120|240|256|480)G|100T)NTD|" // tested with GIGABYTE GP-GSTFS31120GNTD/SBFM61.3
     "GOODRAM IRIDIUM PRO|" // tested with GOODRAM IRIDIUM PRO/SAFM01.5
     "IRP?-SSDPR-S25[AC]-(120|240|256|480|512|960|0[12]T)|" // Goodram IRIDM (PRO), tested with
@@ -937,9 +938,11 @@ const drive_settings builtin_knowndrives[] = {
       // PNY CS900 240GB SSD/CS900613, PNY CS900 500GB SSD/CS900Y13, PNY CS1311 120GB SSD/CS131122,
       // PNY CS2211 240GB SSD/CS221016 (CS900 1TB has different attribute set)
     "PNY ELITE PSSD|" // tested with PNY ELITE PSSD/CS105P13 (240G)
+    "S11-(128|256|512)G-PHISON-SSD-B27|" // tested with: S11-512G-PHISON-SSD-B27/SBFMJ1.3
     "SSD Smartbuy (60|64|120|128|240|256|480|512|960|1024|2000)GB|" // PS3111-S11, tested with
       // SSD Smartbuy 240GB/SBFM91.1, SSD Smartbuy 64GB/SBFM21.1
-    "SSD PHISON 256GB PS3110-S10C|" // tested with SSD PHISON 256GB PS3110-S10C/SAFM12.2
+    "SSD PHISON (128|256)GB PS3110-S10C|" // tested with SSD PHISON 128GB PS3110-S10C/SAFM12.2,
+      // SSD PHISON 256GB PS3110-S10C/SAFM12.2
     "SSDPR-CX400-(128|256|512|1024)|" // Goodram CX400, tested with SSDPR-CX400-512/SBFM61.3
     "TEAM L3 EVO SSD (120|240|480|960)GB|" // TEAM L3 EVO SSD 120GB/SBFM11.0
     "SSM28(128|256|512)GPTCB3B-S11[24]61[123]|" // tested with SSM28256GPTCB3B-S112612/SBFM61.2
@@ -994,9 +997,11 @@ const drive_settings builtin_knowndrives[] = {
     "Kingmax SATA SSD (120|240|480|960)GB|" // tested with Kingmax SATA SSD 240GB/SBFMY1.3
     "SATA SSD|" // tested with Supermicro SSD-DM032-PHI (SATA SSD/S9FM02.1),
       // PC Engines msata16d (SATA SSD/S9FM02.3), FoxLine flssd240x4s(SATA SSD/SBFM10.5)
-    "SPCC Solid State Disk", // Silicon Power, tested with SPCC Solid State Disk/SBFD00.3,
+    "SPCC Solid State Disk|" // Silicon Power, tested with SPCC Solid State Disk/SBFD00.3,
       // SPCC Solid State Disk/SBFM61.2, SPCC Solid State Disk/SBFMT1.3
-    "S[89AB]F[DM][0-9JTY][0-9]\\.[0-9]",
+    "SSDPR-CX400-(128|256|512|1024|2028)-G2", // Goodram CX400 G2, tested with
+      // SSDPR-CX400-512-G2/SBFMLA.5 (SSDPR-CX400-128-G2/SN07373 differs, see ticket #1689)
+    "S[89AB]F[DM][0-9JLTY][0-9A]\\.[0-9]",
     "",
   //"-v 1,raw48,Raw_Read_Error_Rate "
     "-v 2,raw48,Not_In_Use "

--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -584,8 +584,8 @@ const drive_settings builtin_knowndrives[] = {
     "(Micron_5200_)?MTFDDAK(240|480|960|1T9|3T8|7T6)TD(C|D|N)|" // tested with Micron_5200_MTFDDAK240TDN/D1MU005,
       // Micron_5200_MTFDDAK3T8TDD/D1MU505
     "Micron_5210_MTFDDAK(480|960|1T9|3T8|7T6)QDE|" // tested with Micron_5210_MTFDDAK7T6QDE/D2MU804
-    "Micron_5300(HC)?_MTFDDA[KV](240|480|960|1T9|3T8|7T6)TD[STU]|" // tested with Micron_5300_MTFDDAK1T9TDS/D3MU001
-      // Micron_5300HC_MTFDDAK960TDS/D3MN010
+    "(Micron_5300(HC)?_)?MTFDDA[KV](240|480|960|1T9|3T8|7T6)TD[STU]|" // tested with Micron_5300_MTFDDAK1T9TDS/D3MU001
+      // Micron_5300HC_MTFDDAK960TDS/D3MN010, MTFDDAK1T9TDT/D3MU001
     "(Micron_5400_)?(EE|MT)FDDA[KV](240|480|960|1T9|3T8|7T6)TG[ABC]", // tested with Micron_5400_MTFDDAK1T9TGB/D4MU001,
     "", "",
   //"-v 1,raw48,Raw_Read_Error_Rate "
@@ -4855,7 +4855,9 @@ const drive_settings builtin_knowndrives[] = {
     "WDC WDBNCE(250|500|00[124])0PNC(-.*)?|" // Blue 3D
     "WDC  ?WDS((120|240|250|480|500)G|[124]00T)(1B|2B|1G|2G|1R)0[AB](-.*)?|"
       // *B* = Blue, *G* = Green, *2B* = Blue 3D NAND, *1R* = Red SA500
-    "WD Blue SA510 2.5 1000GB", // tested with WD Blue SA510 2.5 1000GB/52008100
+    "WD Blue SA510 2.5 1000GB|" // tested with WD Blue SA510 2.5 1000GB/52008100
+    "SanDisk Portable SSD", // tested with SanDisk Portable SSD/UM5004RL
+                            // (Sandisk SDSSDE30-2T00, 0x0781:0x55b0)
     "", "",
   //"-v 5,raw16(raw16),Reallocated_Sector_Ct " // Reassigned Block Count
   //"-v 9,raw24(raw8),Power_On_Hours "
@@ -5799,9 +5801,9 @@ const drive_settings builtin_knowndrives[] = {
     "-d sat"
   },
   // SanDisk
-  { "USB: SanDisk SDCZ80 Flash Drive; Fujitsu", // ATA ID: SanDisk pSSD
-    "0x0781:0x558[08]",
-    "",
+  { "USB: SanDisk; ",
+    "0x0781:0x55(8[08]|b0)", // 0x5580: SanDisk SDCZ80 (SanDisk pSSD)
+    "", // 0x55b0: Sandisk SDSSDE30-2T00 (SanDisk Portable SSD)
     "",
     "-d sat"
   },

--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -200,6 +200,65 @@ const drive_settings builtin_knowndrives[] = {
     "-v 248,raw48,Perc_Rated_Life_Remain "
     "-v 249,raw48,Spares_Remaining_Perc "
   },
+  { "Swissbit X-7x Family SATA SSD",
+    "SFSA....(S|Q|M|U|V).AK.T(A|B|O).............",
+    "", "",
+  //"-v 1,raw48,Raw_Read_Error_Rate "
+  //"-v 5,raw16(raw16),Reallocated_Sector_Ct "
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 16,raw48,Avg_Erase_Count_pSLC "
+    "-v 17,raw48,Rated_Erase_Count_pSLC "
+    "-v 160,raw48,UECC_Sector_Count "
+    "-v 161,raw48,Spare_Block_Count "
+    "-v 163,raw48,Initial_Bad_Block_Count "
+    "-v 164,raw48,Total_Erase_Count "
+    "-v 165,raw48,Maximum_Erase_Count "
+    "-v 166,raw48,Minimum_Erase_Count "
+    "-v 167,raw48,Average_Erase_Count "
+    "-v 168,raw48,Rated_Erase_Count "
+    "-v 169,raw48,Power_On_UECC_Err_Cnt "
+    "-v 193,raw48,Dynamic_Remaps "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 195,raw48,Hardware_ECC_Recovered "
+  //"-v 196,raw16(raw16),Reallocated_Event_Count "
+  //"-v 198,raw48,Offline_Uncorrectable "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 215,raw48,Number_of_TRIM_Commands  "
+    "-v 231,raw48,Life_Remaining_Percent "
+    "-v 235,raw48,Flash_LBAs_Written "
+    "-v 237,raw48,Flash_LBAs_Written_Exp "
+  //"-v 241,raw48,Total_LBAs_Written "
+  //"-v 242,raw48,Total_LBAs_Read "
+    "-v 243,raw48,Host_LBA_Write_Exp "
+    "-v 244,raw48,Host_LBA_Read_Exp "
+    "-v 248,raw48,SSD_Remaining_Life_Perc "
+  },
+  { "Swissbit X-8x Family SATA SSD",
+    "SFSA....M.AO.TO.............",
+    "", "",
+  //"-v 9,raw24(raw8),Power_On_Hours "
+  //"-v 12,raw48,Power_Cycle_Count "
+    "-v 165,raw48,Maximum_Erase_Count "
+    "-v 167,raw48,Average_Erase_Count "
+    "-v 168,raw48,Rated_Erase_Count "
+    "-v 169,raw48,Power_On_Data_Repairs "
+  //"-v 184,raw48,End-to-End_Error "
+    "-v 185,raw48,E2E_ErrCnt_SATA-Flash "
+  //"-v 194,tempminmax,Temperature_Celsius "
+  //"-v 195,raw48,Hardware_ECC_Recovered "
+    "-v 196,raw48,Total_Spare_Block_Cnt "
+  //"-v 198,raw48,Offline_Uncorrectable "
+  //"-v 199,raw48,UDMA_CRC_Error_Count "
+    "-v 200,raw48,SATA_COM_Reset "
+    "-v 213,raw48,Spare_Block_Cnt_Worst "
+    "-v 215,raw48,Trim_Status "
+    "-v 229,raw48,Total_Flash_Blk_Erases "
+    "-v 232,raw48,Total_Read_Cnt "
+    "-v 241,raw48,Total_Host_LBA_Written "
+    "-v 242,raw48,Total_Host_LBA_Read "
+    "-v 248,raw48,Remaining_Life "
+  },
   { "Apacer SDM4 Series SSD Module",
     "(2|4|8|16|32|64)GB SATA Flash Drive", // tested with APSDM002G15AN-CT/SFDDA01C and SFI2101D
     "SF(DDA01C|I2101D)",

--- a/smartmontools/drivedb.h
+++ b/smartmontools/drivedb.h
@@ -5382,6 +5382,12 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "-d usbsunplus"
   },
+  { "USB: HP x911w; ",
+    "0x03f0:0x0c5c",
+    "",
+    "",
+     "-d sat"
+  },
   { "USB: HP Desktop HD BD07; ", // 2TB
     "0x03f0:0xbd07",
     "",
@@ -5576,12 +5582,19 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "-d sat"
   },
+  { "USB: Samsung Portable SSD T9; ASMedia ASM2362",
+    "0x04e8:0x61fd",
+    "", // 0x0100
+    "",
+    "-d sntasmedia"
+  },
   { "USB: Samsung; ",
     "0x04e8:0x8003", // USB3 Adapter from SSD EVO 850 Starter Kit
     "", // 0x0100
     "",
     "-d sat"
   },
+  // Sony
   { "USB: Sony HD-E1; ",
     "0x054c:0x05bf", //  Sony HD-E1B - 1TB USB3.0
     "", // 0x6610
@@ -6021,6 +6034,12 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "-d sat"
   },
+  { "USB: ; ASMedia ASM236x",
+    "0x0b05:0x1932", // Asus ROG Strix Arion enclosure
+    "", // 0x0100
+    "",
+    "-d sntasmedia"
+  },
   // Seagate
   { "USB: Seagate External Drive; Cypress",
     "0x0bc2:0x0503",
@@ -6196,6 +6215,12 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "-d usbcypress"
   },
+  { "USB: Western Digital; ASMedia ASM236x",
+    "0x1058:0x266e", // WD Elements SE SSD
+    "",
+    "",
+    "-d sntasmedia"
+  },
   { "USB: Western Digital; ",
     "0x1058:0x....",
     "",
@@ -6255,6 +6280,13 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "",
     "-d sat"
+  },
+  // Phison
+  { "USB: ; ",
+    "0x13fe:0x6500", // TeamGroup C212 USB flash drive
+    "", // 0x0110
+    "",
+    "-d sntasmedia" // limited info only
   },
   // Super Top
   { "USB: Super Top generic enclosure; ",
@@ -6656,7 +6688,7 @@ const drive_settings builtin_knowndrives[] = {
   },
   // 0x235c (?)
   { "USB: ; ",
-    "0x235c:0xa006", // Terramaster D4-320
+    "0x235c:0xa006", // Terramaster D4-320 (see also 0x5432:0x235c)
     "", // 0x0100
     "",
     "-d sat"
@@ -6748,12 +6780,26 @@ const drive_settings builtin_knowndrives[] = {
     "",
     "-d usbjmicron,x"
   },
+  // 0x5432 (?)
+  { "USB: ; ",
+    "0x5432:0x235c", // TerraMaster D4-320 (see also 0x235c:0xa006)
+    "", // 0x0100
+    "",
+    "-d sat"
+  },
   // OnSpec
   { "USB: ; OnSpec", // USB->PATA
     "0x55aa:0x2b00",
     "", // 0x0100
     "",
     "" // unsupported
+  },
+  // 0x5910 (?)
+  { "USB: ; ",
+    "0x5910:0x13fd", // Sabrent EC-SSHD
+    "", // 0x0153
+    "",
+    "-d sat"
   },
   // 0x6795 (?)
   { "USB: Sharkoon 2-Bay RAID Box; ", // USB 3.0

--- a/smartmontools/farmprint.cpp
+++ b/smartmontools/farmprint.cpp
@@ -173,6 +173,7 @@ void ataPrintFarmLog(const ataFarmLog& farmLog) {
   farm_format_id_string(firmwareRev, farm_byte_swap(farmLog.driveInformation.firmwareRev2), farm_byte_swap(farmLog.driveInformation.firmwareRev));
 
   char modelNumber[sizeof(farmLog.driveInformation.modelNumber) + 1];
+  modelNumber[0] = '\0';
   for (uint8_t i = 0; i < sizeof(farmLog.driveInformation.modelNumber) / sizeof(farmLog.driveInformation.modelNumber[0]); i++) {
     farm_format_id_string(&modelNumber[strlen(modelNumber)], farm_byte_swap(farmLog.driveInformation.modelNumber[i]));
   }
@@ -180,7 +181,7 @@ void ataPrintFarmLog(const ataFarmLog& farmLog) {
   const char* recordingType = farm_get_recording_type(farmLog.driveInformation.driveRecordingType);
 
   char dateOfAssembly[sizeof(farmLog.driveInformation.dateOfAssembly)];
-  farm_format_id_string(dateOfAssembly, farm_byte_swap(farmLog.driveInformation.dateOfAssembly));
+  memcpy(dateOfAssembly, &farmLog.driveInformation.dateOfAssembly, sizeof(farmLog.driveInformation.dateOfAssembly));
 
   // Print plain-text
   jout("Seagate Field Access Reliability Metrics log (FARM) (GP Log 0xa6)\n");

--- a/smartmontools/farmprint.cpp
+++ b/smartmontools/farmprint.cpp
@@ -334,7 +334,7 @@ void ataPrintFarmLog(const ataFarmLog& farmLog) {
   farm_print_by_head_to_text("RVGA Skip Write Detect by Head", farmLog.reliability.RVGASkipWriteDetect, farmLog.driveInformation.heads);
   farm_print_by_head_to_text("FVGA Skip Write Detect by Head", farmLog.reliability.FVGASkipWriteDetect, farmLog.driveInformation.heads);
   farm_print_by_head_to_text("Skip Write Detect Threshold Exceeded by Head", farmLog.reliability.skipWriteDetectThresExceeded, farmLog.driveInformation.heads);
-  farm_print_by_head_to_text("Write Power On (hrs) by Head", farmLog.reliability.writeWorkloadPowerOnTime, farmLog.driveInformation.heads);
+  farm_print_by_head_to_text("Write Power On (sec) by Head", farmLog.reliability.writeWorkloadPowerOnTime, farmLog.driveInformation.heads);
   farm_print_by_head_to_text("MR Head Resistance from Head", (int64_t*)farmLog.reliability.mrHeadResistance, farmLog.driveInformation.heads);
   farm_print_by_head_to_text("Second MR Head Resistance by Head", farmLog.reliability.secondMRHeadResistance, farmLog.driveInformation.heads);
   farm_print_by_head_to_text("Number of Reallocated Sectors by Head", farmLog.reliability.reallocatedSectors, farmLog.driveInformation.heads);
@@ -647,7 +647,7 @@ void scsiPrintFarmLog(const scsiFarmLog& farmLog) {
   farm_print_by_head_to_text("MR Head Resistance", (int64_t*)farmLog.mrHeadResistance.headValue, farmLog.driveInformation.heads);
   farm_print_by_head_to_text("Number of Reallocated Sectors", (int64_t*)farmLog.totalReallocations.headValue, farmLog.driveInformation.heads);
   farm_print_by_head_to_text("Number of Reallocation Candidate Sectors", (int64_t*)farmLog.totalReallocationCanidates.headValue, farmLog.driveInformation.heads);
-  farm_print_by_head_to_text("Write Power On (hrs)", (int64_t*)farmLog.writeWorkloadPowerOnTime.headValue, farmLog.driveInformation.heads);
+  farm_print_by_head_to_text("Write Power On (sec)", (int64_t*)farmLog.writeWorkloadPowerOnTime.headValue, farmLog.driveInformation.heads);
   farm_print_by_head_to_text("Cum Lifetime Unrecoverable Read Repeating", (int64_t*)farmLog.cumulativeUnrecoverableReadRepeat.headValue, farmLog.driveInformation.heads);
   farm_print_by_head_to_text("Cum Lifetime Unrecoverable Read Unique", (int64_t*)farmLog.cumulativeUnrecoverableReadUnique.headValue, farmLog.driveInformation.heads);
   farm_print_by_head_to_text("Second MR Head Resistance", (int64_t*)farmLog.secondMRHeadResistance.headValue, farmLog.driveInformation.heads);
@@ -816,7 +816,7 @@ void scsiPrintFarmLog(const scsiFarmLog& farmLog) {
   farm_print_by_head_to_json(jrefh, buffer, "mr_head_resistance", (int64_t*)farmLog.mrHeadResistance.headValue, farmLog.driveInformation.heads);
   farm_print_by_head_to_json(jrefh, buffer, "number_of_reallocated_sectors", (int64_t*)farmLog.totalReallocations.headValue, farmLog.driveInformation.heads);
   farm_print_by_head_to_json(jrefh, buffer, "number_of_reallocation_candidate_sectors", (int64_t*)farmLog.totalReallocationCanidates.headValue, farmLog.driveInformation.heads);
-  farm_print_by_head_to_json(jrefh, buffer, "write_power_on_(hrs)", (int64_t*)farmLog.writeWorkloadPowerOnTime.headValue, farmLog.driveInformation.heads);
+  farm_print_by_head_to_json(jrefh, buffer, "write_power_on_(sec)", (int64_t*)farmLog.writeWorkloadPowerOnTime.headValue, farmLog.driveInformation.heads);
   farm_print_by_head_to_json(jrefh, buffer, "cum_lifetime_unrecoverable_read_repeating", (int64_t*)farmLog.cumulativeUnrecoverableReadRepeat.headValue, farmLog.driveInformation.heads);
   farm_print_by_head_to_json(jrefh, buffer, "cum_lifetime_unrecoverable_read_unique", (int64_t*)farmLog.cumulativeUnrecoverableReadUnique.headValue, farmLog.driveInformation.heads);
   farm_print_by_head_to_json(jrefh, buffer, "second_mr_head_resistance", (int64_t*)farmLog.secondMRHeadResistance.headValue, farmLog.driveInformation.heads);

--- a/smartmontools/farmprint.cpp
+++ b/smartmontools/farmprint.cpp
@@ -197,8 +197,10 @@ void ataPrintFarmLog(const ataFarmLog& farmLog) {
 
   // Page 1: Drive Information
   jout("\tFARM Log Page 1: Drive Information\n");
-  jout("\t\tSerial Number: %s\n", serialNumber);
-  jout("\t\tWorld Wide Name: %s\n", worldWideName);
+  if (!dont_print_serial_number) { // TODO: Invalidate the fields in the ATA debug output
+    jout("\t\tSerial Number: %s\n", serialNumber);
+    jout("\t\tWorld Wide Name: %s\n", worldWideName);
+  }
   jout("\t\tDevice Interface: %s\n", deviceInterface);
   jout("\t\tDevice Capacity in Sectors: %" PRIu64 "\n", farmLog.driveInformation.deviceCapacity);
   jout("\t\tPhysical Sector Size: %" PRIu64 "\n", farmLog.driveInformation.psecSize);
@@ -356,8 +358,10 @@ void ataPrintFarmLog(const ataFarmLog& farmLog) {
 
   // Page 1: Drive Information
   json::ref jref1 = jref["page_1_drive_information"];
-  jref1["serial_number"] = serialNumber;
-  jref1["world_wide_name"] = worldWideName;
+  if (!dont_print_serial_number) {
+    jref1["serial_number"] = serialNumber;
+    jref1["world_wide_name"] = worldWideName;
+  }
   jref1["device_interface"] = deviceInterface;
   jref1["device_capacity_in_sectors"] = farmLog.driveInformation.deviceCapacity;
   jref1["physical_sector_size"] = farmLog.driveInformation.psecSize;
@@ -553,8 +557,10 @@ void scsiPrintFarmLog(const scsiFarmLog& farmLog) {
 
   // Parameter 1: Drive Information
   jout("\tFARM Log Parameter 1: Drive Information\n");
-  jout("\t\tSerial Number: %s\n", serialNumber);
-  jout("\t\tWorld Wide Name: %s\n", worldWideName);
+  if (!dont_print_serial_number) { // TODO: Invalidate the fields in the SCSI debug output
+    jout("\t\tSerial Number: %s\n", serialNumber);
+    jout("\t\tWorld Wide Name: %s\n", worldWideName);
+  }
   jout("\t\tFirmware Rev: %s\n", firmwareRev);
   jout("\t\tDevice Interface: %s\n", deviceInterface);
   jout("\t\tDevice Capacity in Sectors: %" PRIu64 "\n", farmLog.driveInformation.deviceCapacity);
@@ -719,8 +725,10 @@ void scsiPrintFarmLog(const scsiFarmLog& farmLog) {
 
   // Parameter 1: Drive Information
   json::ref jref1 = jref["drive_information"];
-  jref1["serial_number"] = serialNumber;
-  jref1["world_wide_name"] = worldWideName;
+  if (!dont_print_serial_number) {
+    jref1["serial_number"] = serialNumber;
+    jref1["world_wide_name"] = worldWideName;
+  }
   jref1["firmware_rev"] = firmwareRev;
   jref1["device_interface"] = deviceInterface;
   jref1["device_capacity_in_sectors"] = farmLog.driveInformation.deviceCapacity;

--- a/smartmontools/nvmecmds.cpp
+++ b/smartmontools/nvmecmds.cpp
@@ -3,7 +3,7 @@
  *
  * Home page of code is: https://www.smartmontools.org
  *
- * Copyright (C) 2016-23 Christian Franke
+ * Copyright (C) 2016-24 Christian Franke
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
@@ -370,9 +370,9 @@ static const char * nvme_status_to_flagged_str(uint16_t status)
         case 0x0a: return "-Invalid Format";
         case 0x0b: return "Firmware Activation Requires Conventional Reset";
         case 0x0c: return "-Invalid Queue Deletion";
-        case 0x0d: return "Feature Identifier Not Saveable";
-        case 0x0e: return "Feature Not Changeable";
-        case 0x0f: return "Feature Not Namespace Specific";
+        case 0x0d: return "-Feature Identifier Not Saveable";
+        case 0x0e: return "-Feature Not Changeable";
+        case 0x0f: return "-Feature Not Namespace Specific";
         case 0x10: return "Firmware Activation Requires NVM Subsystem Reset";
         case 0x11: return "Firmware Activation Requires Controller Level Reset";
         case 0x12: return "Firmware Activation Requires Maximum Time Violation";

--- a/smartmontools/nvmecmds.cpp
+++ b/smartmontools/nvmecmds.cpp
@@ -231,7 +231,7 @@ unsigned nvme_read_log_page(nvme_device * device, unsigned nsid, unsigned char l
 unsigned nvme_read_error_log(nvme_device * device, nvme_error_log_page * error_log,
   unsigned num_entries, bool lpo_sup)
 {
-  unsigned n = nvme_read_log_page(device, 0xffffffff, 0x01, error_log,
+  unsigned n = nvme_read_log_page(device, nvme_broadcast_nsid, 0x01, error_log,
                                   num_entries * sizeof(*error_log), lpo_sup);
 
   unsigned read_entries = n / sizeof(*error_log);
@@ -253,7 +253,8 @@ unsigned nvme_read_error_log(nvme_device * device, nvme_error_log_page * error_l
 // Read NVMe SMART/Health Information log.
 bool nvme_read_smart_log(nvme_device * device, nvme_smart_log & smart_log)
 {
-  if (!nvme_read_log_page_1(device, 0xffffffff, 0x02, &smart_log, sizeof(smart_log)))
+  if (!nvme_read_log_page_1(device, nvme_broadcast_nsid, 0x02, &smart_log,
+                            sizeof(smart_log)))
     return false;
 
   if (isbigendian()) {

--- a/smartmontools/nvmecmds.cpp
+++ b/smartmontools/nvmecmds.cpp
@@ -251,10 +251,9 @@ unsigned nvme_read_error_log(nvme_device * device, nvme_error_log_page * error_l
 }
 
 // Read NVMe SMART/Health Information log.
-bool nvme_read_smart_log(nvme_device * device, nvme_smart_log & smart_log)
+bool nvme_read_smart_log(nvme_device * device, uint32_t nsid, nvme_smart_log & smart_log)
 {
-  if (!nvme_read_log_page_1(device, nvme_broadcast_nsid, 0x02, &smart_log,
-                            sizeof(smart_log)))
+  if (!nvme_read_log_page_1(device, nsid, 0x02, &smart_log, sizeof(smart_log)))
     return false;
 
   if (isbigendian()) {

--- a/smartmontools/nvmecmds.h
+++ b/smartmontools/nvmecmds.h
@@ -253,6 +253,9 @@ STATIC_ASSERT(sizeof(nvme_self_test_log) == 564);
 
 class nvme_device;
 
+// Broadcast namespace ID.
+constexpr uint32_t nvme_broadcast_nsid = 0xffffffffU;
+
 // Print NVMe debug messages?
 extern unsigned char nvme_debugmode;
 

--- a/smartmontools/nvmecmds.h
+++ b/smartmontools/nvmecmds.h
@@ -274,7 +274,8 @@ unsigned nvme_read_error_log(nvme_device * device, smartmontools::nvme_error_log
   unsigned num_entries, bool lpo_sup);
 
 // Read NVMe SMART/Health Information log.
-bool nvme_read_smart_log(nvme_device * device, smartmontools::nvme_smart_log & smart_log);
+bool nvme_read_smart_log(nvme_device * device, uint32_t nsid,
+  smartmontools::nvme_smart_log & smart_log);
 
 // Read NVMe Self-test Log.
 bool nvme_read_self_test_log(nvme_device * device, uint32_t nsid,

--- a/smartmontools/nvmeprint.cpp
+++ b/smartmontools/nvmeprint.cpp
@@ -3,7 +3,7 @@
  *
  * Home page of code is: https://www.smartmontools.org
  *
- * Copyright (C) 2016-24 Christian Franke
+ * Copyright (C) 2016-25 Christian Franke
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
@@ -389,8 +389,13 @@ static void print_smart_log(const nvme_smart_log & smart_log,
   jref["available_spare"] = smart_log.avail_spare;
   jout("Available Spare Threshold:          %u%%\n", smart_log.spare_thresh);
   jref["available_spare_threshold"] = smart_log.spare_thresh;
+  jglb["spare_available"] += {
+    {"current_percent", smart_log.avail_spare},
+    {"threshold_percent", smart_log.spare_thresh}
+  };
   jout("Percentage Used:                    %u%%\n", smart_log.percent_used);
   jref["percentage_used"] = smart_log.percent_used;
+  jglb["endurance_used"]["current_percent"] = smart_log.percent_used;
   jout("Data Units Read:                    %s\n", le128_to_str(buf, smart_log.data_units_read, 1000*512));
   jref["data_units_read"].set_unsafe_le128(smart_log.data_units_read);
   jout("Data Units Written:                 %s\n", le128_to_str(buf, smart_log.data_units_written, 1000*512));

--- a/smartmontools/nvmeprint.cpp
+++ b/smartmontools/nvmeprint.cpp
@@ -523,7 +523,7 @@ static void print_error_log(const nvme_error_log_page * error_log,
       snprintf(lb, sizeof(lb), "%" PRIu64, e.lba);
       jrefi["lba"]["value"].set_unsafe_uint64(e.lba);
     }
-    if (e.nsid != 0xffffffffU) {
+    if (e.nsid != nvme_broadcast_nsid) {
       snprintf(ns, sizeof(ns), "%u", e.nsid);
       jrefi["nsid"] = e.nsid;
     }
@@ -548,7 +548,7 @@ static void print_self_test_log(const nvme_self_test_log & self_test_log, unsign
   // Figure 203 of NVM Express Base Specification Revision 1.4c, March 9, 2021
   json::ref jref = jglb["nvme_self_test_log"];
   jout("Self-test Log (NVMe Log 0x06, NSID 0x%x)\n", nsid);
-  jref["nsid"] = (nsid != 0xffffffff ? (int64_t)nsid : -1);
+  jref["nsid"] = (nsid != nvme_broadcast_nsid ? (int64_t)nsid : -1);
 
   const char * s; char buf[32];
   switch (self_test_log.current_operation & 0xf) {
@@ -618,12 +618,12 @@ static void print_self_test_log(const nvme_self_test_log & self_test_log, unsign
       jrefi["segment"] = r.segment;
     }
     if (r.valid & 0x01) {
-      if (r.nsid == 0xffffffff)
+      if (r.nsid == nvme_broadcast_nsid)
         ns[0] = '*', ns[1] = 0;
       else
         snprintf(ns, sizeof(ns), "%u", r.nsid);
       // Broadcast = -1
-      jrefi["nsid"] = (r.nsid != 0xffffffff ? (int64_t)r.nsid : -1);
+      jrefi["nsid"] = (r.nsid != nvme_broadcast_nsid ? (int64_t)r.nsid : -1);
     }
     if (r.valid & 0x02) {
       uint64_t lba = sg_get_unaligned_le64(r.lba);
@@ -676,7 +676,7 @@ int nvmePrintMain(nvme_device * device, const nvme_print_options & options)
     nvme_id_ns id_ns; memset(&id_ns, 0, sizeof(id_ns));
 
     unsigned nsid = device->get_nsid();
-    if (nsid == 0xffffffffU) {
+    if (nsid == nvme_broadcast_nsid) {
       // Broadcast namespace
       if (id_ctrl.nn == 1) {
         // No namespace management, get size from single namespace
@@ -760,7 +760,7 @@ int nvmePrintMain(nvme_device * device, const nvme_print_options & options)
       pout("Self-tests not supported\n\n");
     else {
       nvme_self_test_log self_test_log;
-      unsigned self_test_log_nsid = 0xffffffff;
+      unsigned self_test_log_nsid = nvme_broadcast_nsid;
       if (!nvme_read_self_test_log(device, self_test_log_nsid, self_test_log)) {
         jerr("Read Self-test Log failed: %s\n\n", device->get_errmsg());
         return retval | FAILSMART;
@@ -785,7 +785,7 @@ int nvmePrintMain(nvme_device * device, const nvme_print_options & options)
     case 1:
     case 2:
     case 3:
-      nsid = 0xffffffff;
+      nsid = nvme_broadcast_nsid;
       break;
     default:
       nsid = device->get_nsid();

--- a/smartmontools/nvmeprint.cpp
+++ b/smartmontools/nvmeprint.cpp
@@ -487,6 +487,7 @@ static void print_smart_log(const nvme_smart_log & smart_log,
   json::ref jref = jglb["nvme_smart_health_information_log"];
   char buf[64];
   jout("SMART/Health Information (NVMe Log 0x02, NSID 0x%x)\n", nsid);
+  jref["nsid"] = (nsid != nvme_broadcast_nsid ? (int64_t)nsid : -1);
   jout("Critical Warning:                   0x%02x\n", smart_log.critical_warning);
   jref["critical_warning"] = smart_log.critical_warning;
 

--- a/smartmontools/nvmeprint.cpp
+++ b/smartmontools/nvmeprint.cpp
@@ -164,7 +164,7 @@ static void print_drive_info(const nvme_id_ctrl & id_ctrl, const nvme_id_ns & id
     const char * align = &("  "[nsid < 10 ? 0 : (nsid < 100 ? 1 : 2)]);
     int fmt_lba_bits = id_ns.lbaf[id_ns.flbas & 0xf].ds;
 
-    json::ref jrns = jglb["nvme_namespaces"][0];
+    json::ref jrns = jglb["nvme_namespaces"][0]; // Same as in print_drive_capabilities()
     jrns["id"] = nsid;
 
     // Size and Capacity are equal if thin provisioning is not supported
@@ -223,21 +223,41 @@ static const char * format_power(char (& str)[16], unsigned power, unsigned scal
   return str;
 }
 
+static void format_power(const json::ref & jref, const char * name,
+  unsigned power, unsigned scale)
+{
+  unsigned sc = scale & 0x3;
+  if (!sc)
+    return; // not reported
+  jref[name] += { { "value", power }, { "scale", sc } };
+  if (sc <= 2)
+    jref[name]["units_per_watt"] = (sc == 2 ? 100 : 10000);
+}
+
 static void print_drive_capabilities(const nvme_id_ctrl & id_ctrl, const nvme_id_ns & id_ns,
   unsigned nsid, bool show_all)
 {
   // Figure 112 of NVM Express Base Specification Revision 1.3d, March 20, 2019
   // Figure 251 of NVM Express Base Specification Revision 1.4c, March 9, 2021
   // Figure 275 of NVM Express Base Specification Revision 2.0c, October 4, 2022
-  pout("Firmware Updates (0x%02x):            %d Slot%s%s%s%s%s\n", id_ctrl.frmw,
+  jout("Firmware Updates (0x%02x):            %d Slot%s%s%s%s%s\n", id_ctrl.frmw,
        ((id_ctrl.frmw >> 1) & 0x7), (((id_ctrl.frmw >> 1) & 0x7) != 1 ? "s" : ""),
        ((id_ctrl.frmw & 0x01) ? ", Slot 1 R/O" : ""),
        ((id_ctrl.frmw & 0x10) ? ", no Reset required" : ""),
        ((id_ctrl.frmw & 0x20) ? ", multiple detected" : ""), // NVMe 2.0
        ((id_ctrl.frmw & ~0x3f) ? ", *Other*" : ""));
 
+  jglb["nvme_firmware_update_capabilities"] += {
+    { "value", id_ctrl.frmw },
+    { "slots", (id_ctrl.frmw >> 1) & 0x7 },
+    { "first_slot_is_read_only", !!(id_ctrl.frmw & 0x01) },
+    { "activiation_without_reset", !!(id_ctrl.frmw & 0x10) },
+    { "multiple_update_detection", !!(id_ctrl.frmw & 0x20) },
+    { "other", id_ctrl.frmw & ~0x3f }
+  };
+
   if (show_all || id_ctrl.oacs)
-    pout("Optional Admin Commands (0x%04x):  %s%s%s%s%s%s%s%s%s%s%s%s%s\n", id_ctrl.oacs,
+    jout("Optional Admin Commands (0x%04x):  %s%s%s%s%s%s%s%s%s%s%s%s%s\n", id_ctrl.oacs,
          (!id_ctrl.oacs ? " -" : ""),
          ((id_ctrl.oacs & 0x0001) ? " Security" : ""),
          ((id_ctrl.oacs & 0x0002) ? " Format" : ""),
@@ -252,8 +272,24 @@ static void print_drive_capabilities(const nvme_id_ctrl & id_ctrl, const nvme_id
          ((id_ctrl.oacs & 0x0400) ? " Lockdown" : ""), // NVMe 2.0
          ((id_ctrl.oacs & ~0x07ff) ? " *Other*" : ""));
 
+  jglb["nvme_optional_admin_commands"] += {
+    { "value", id_ctrl.oacs },
+    { "security_send_receive", !!(id_ctrl.oacs & 0x0001) },
+    { "format_nvm", !!(id_ctrl.oacs & 0x0002) },
+    { "firmware_download", !!(id_ctrl.oacs & 0x0004) },
+    { "namespace_management", !!(id_ctrl.oacs & 0x0008) }, // NVMe 1.2
+    { "self_test", !!(id_ctrl.oacs & 0x0010) }, // NVMe 1.3 ...
+    { "directives", !!(id_ctrl.oacs & 0x0020) },
+    { "mi_send_receive", !!(id_ctrl.oacs & 0x0040) },
+    { "virtualization_management", !!(id_ctrl.oacs & 0x0080) },
+    { "doorbell_buffer_config", !!(id_ctrl.oacs & 0x0100) },
+    { "get_lba_status", !!(id_ctrl.oacs & 0x0200) }, // NVMe 1.4
+    { "command_and_feature_lockdown", !!(id_ctrl.oacs & 0x0400) }, // NVMe 2.0
+    { "other", id_ctrl.oacs & ~0x07ff }
+  };
+
   if (show_all || id_ctrl.oncs)
-    pout("Optional NVM Commands (0x%04x):    %s%s%s%s%s%s%s%s%s%s%s\n", id_ctrl.oncs,
+    jout("Optional NVM Commands (0x%04x):    %s%s%s%s%s%s%s%s%s%s%s\n", id_ctrl.oncs,
          (!id_ctrl.oncs ? " -" : ""),
          ((id_ctrl.oncs & 0x0001) ? " Comp" : ""),
          ((id_ctrl.oncs & 0x0002) ? " Wr_Unc" : ""),
@@ -266,8 +302,22 @@ static void print_drive_capabilities(const nvme_id_ctrl & id_ctrl, const nvme_id
          ((id_ctrl.oncs & 0x0100) ? " Copy" : ""), // NVMe 2.0
          ((id_ctrl.oncs & ~0x01ff) ? " *Other*" : ""));
 
+  jglb["nvme_optional_nvm_commands"] += {
+    { "value", id_ctrl.oncs },
+    { "compare", !!(id_ctrl.oncs & 0x0001) },
+    { "write_uncorrectable", !!(id_ctrl.oncs & 0x0002) },
+    { "dataset_management", !!(id_ctrl.oncs & 0x0004) },
+    { "write_zeroes", !!(id_ctrl.oncs & 0x0008) }, // NVMe 1.1 ...
+    { "save_select_feature_nonzero", !!(id_ctrl.oncs & 0x0010) },
+    { "reservations", !!(id_ctrl.oncs & 0x0020) },
+    { "timestamp", !!(id_ctrl.oncs & 0x0040) }, // NVMe 1.3
+    { "verify", !!(id_ctrl.oncs & 0x0080) }, // NVMe 1.4
+    { "copy", !!(id_ctrl.oncs & 0x0100) }, // NVMe 2.0
+    { "other", id_ctrl.oncs & ~0x01ff }
+  };
+
   if (show_all || id_ctrl.lpa)
-    pout("Log Page Attributes (0x%02x):        %s%s%s%s%s%s%s%s%s\n", id_ctrl.lpa,
+    jout("Log Page Attributes (0x%02x):        %s%s%s%s%s%s%s%s%s\n", id_ctrl.lpa,
          (!id_ctrl.lpa ? " -" : ""),
          ((id_ctrl.lpa & 0x01) ? " S/H_per_NS" : ""),
          ((id_ctrl.lpa & 0x02) ? " Cmd_Eff_Lg" : ""), // NVMe 1.2
@@ -278,24 +328,47 @@ static void print_drive_capabilities(const nvme_id_ctrl & id_ctrl, const nvme_id
          ((id_ctrl.lpa & 0x40) ? " Telmtry_Ar_4" : ""),
          ((id_ctrl.lpa & ~0x7f) ? " *Other*" : ""));
 
-  if (id_ctrl.mdts)
-    pout("Maximum Data Transfer Size:         %u Pages\n", (1U << id_ctrl.mdts));
+  jglb["nvme_log_page_attributes"] += {
+    { "value", id_ctrl.lpa },
+    { "smart_health_per_namespace", !!(id_ctrl.lpa & 0x01) },
+    { "commands_effects_log", !!(id_ctrl.lpa & 0x02) }, // NVMe 1.2
+    { "extended_get_log_page_cmd", !!(id_ctrl.lpa & 0x04) }, // NVMe 1.2.1
+    { "telemetry_log", !!(id_ctrl.lpa & 0x08) }, // NVMe 1.3
+    { "persistent_event_log", !!(id_ctrl.lpa & 0x10) }, // NVMe 1.4
+    { "supported_log_pages_log", !!(id_ctrl.lpa & 0x20) }, // NVMe 2.0 ...
+    { "telemetry_data_area_4", !!(id_ctrl.lpa & 0x40) },
+    { "other", id_ctrl.lpa & ~0x7f }
+  };
+
+  if (id_ctrl.mdts) {
+    jout("Maximum Data Transfer Size:         %u Pages\n", (1U << id_ctrl.mdts));
+    jglb["nvme_maximum_data_transfer_pages"] = (1U << id_ctrl.mdts);
+  }
   else if (show_all)
     pout("Maximum Data Transfer Size:         -\n");
 
   // Temperature thresholds are optional
   char buf[64];
   if (show_all || id_ctrl.wctemp)
-    pout("Warning  Comp. Temp. Threshold:     %s\n", kelvin_to_str(buf, id_ctrl.wctemp));
+    jout("Warning  Comp. Temp. Threshold:     %s\n", kelvin_to_str(buf, id_ctrl.wctemp));
   if (show_all || id_ctrl.cctemp)
-    pout("Critical Comp. Temp. Threshold:     %s\n", kelvin_to_str(buf, id_ctrl.cctemp));
+    jout("Critical Comp. Temp. Threshold:     %s\n", kelvin_to_str(buf, id_ctrl.cctemp));
+
+  if (id_ctrl.wctemp) {
+    jglb["nvme_composite_temperature_threshold"]["warning"] = id_ctrl.wctemp - 273;
+    jglb["temperature"]["op_limit_max"] = id_ctrl.wctemp - 273;
+  }
+  if (id_ctrl.cctemp) {
+    jglb["nvme_composite_temperature_threshold"]["critical"] = id_ctrl.cctemp - 273;
+    jglb["temperature"]["critical_limit_max"] = id_ctrl.cctemp - 273;
+  }
 
   // Figure 110 of NVM Express Base Specification Revision 1.3d, March 20, 2019
   // Figure 249 of NVM Express Base Specification Revision 1.4c, March 9, 2021
   // Figure 97 of NVM Express NVM Command Set Specification, Revision 1.0c, October 3, 2022
   if (nsid && (show_all || id_ns.nsfeat)) {
     const char * align = &("  "[nsid < 10 ? 0 : (nsid < 100 ? 1 : 2)]);
-    pout("Namespace %u Features (0x%02x):     %s%s%s%s%s%s%s%s\n", nsid, id_ns.nsfeat, align,
+    jout("Namespace %u Features (0x%02x):     %s%s%s%s%s%s%s%s\n", nsid, id_ns.nsfeat, align,
          (!id_ns.nsfeat ? " -" : ""),
          ((id_ns.nsfeat & 0x01) ? " Thin_Prov" : ""),
          ((id_ns.nsfeat & 0x02) ? " NA_Fields" : ""), // NVMe 1.2 ...
@@ -305,13 +378,28 @@ static void print_drive_capabilities(const nvme_id_ctrl & id_ctrl, const nvme_id
          ((id_ns.nsfeat & ~0x1f) ? " *Other*" : ""));
   }
 
+  json::ref jrns = jglb["nvme_namespaces"][0]; // Same as in print_drive_info()
+  if (nsid) {
+    jrns["id"] = nsid;
+    jrns["features"] += {
+      { "value", id_ns.nsfeat },
+      { "thin_provisioning", !!(id_ns.nsfeat & 0x01) },
+      { "na_fields", !!(id_ns.nsfeat & 0x02) }, // NVMe 1.2 ...
+      { "dealloc_or_unwritten_block_error", !!(id_ns.nsfeat & 0x04) },
+      { "uid_reuse", !!(id_ns.nsfeat & 0x08) }, // NVMe 1.3
+      { "np_fields", !!(id_ns.nsfeat & 0x10) }, // NVMe 1.4
+      { "other", id_ns.nsfeat & ~0x1f }
+    };
+  }
+
   // Print Power States
-  pout("\nSupported Power States\n");
-  pout("St Op     Max   Active     Idle   RL RT WL WT  Ent_Lat  Ex_Lat\n");
+  jout("\nSupported Power States\n");
+  jout("St Op     Max   Active     Idle   RL RT WL WT  Ent_Lat  Ex_Lat\n");
+
   for (int i = 0; i <= id_ctrl.npss /* 1-based */ && i < 32; i++) {
     char p1[16], p2[16], p3[16];
     const nvme_id_power_state & ps = id_ctrl.psd[i];
-    pout("%2d %c %9s %8s %8s %3d %2d %2d %2d %8u %7u\n", i,
+    jout("%2d %c %9s %8s %8s %3d %2d %2d %2d %8u %7u\n", i,
          ((ps.flags & 0x02) ? '-' : '+'),
          format_power(p1, ps.max_power, ((ps.flags & 0x01) ? 1 : 2)),
          format_power(p2, ps.active_power, ps.active_work_scale),
@@ -319,16 +407,40 @@ static void print_drive_capabilities(const nvme_id_ctrl & id_ctrl, const nvme_id
          ps.read_lat & 0x1f, ps.read_tput & 0x1f,
          ps.write_lat & 0x1f, ps.write_tput & 0x1f,
          ps.entry_lat, ps.exit_lat);
+
+    json::ref jrefi = jglb["nvme_power_states"][i];
+    jrefi += {
+      { "non_operational_state", !!(ps.flags & 0x02) },
+      { "relative_read_latency", ps.read_lat & 0x1f },
+      { "relative_read_throughput", ps.read_tput & 0x1f },
+      { "relative_write_latency", ps.write_lat & 0x1f },
+      { "relative_write_throughput", ps.write_tput & 0x1f },
+      { "entry_latency_us", ps.entry_lat },
+      { "exit_latency_us", ps.exit_lat }
+    };
+    format_power(jrefi, "max_power", ps.max_power, ((ps.flags & 0x01) ? 1 : 2));
+    format_power(jrefi, "active_power", ps.active_power, ps.active_work_scale);
+    format_power(jrefi, "idle_power", ps.idle_power, ps.idle_scale);
   }
 
   // Print LBA sizes
   if (nsid && id_ns.lbaf[0].ds) {
-    pout("\nSupported LBA Sizes (NSID 0x%x)\n", nsid);
-    pout("Id Fmt  Data  Metadt  Rel_Perf\n");
+    jout("\nSupported LBA Sizes (NSID 0x%x)\n", nsid);
+    jout("Id Fmt  Data  Metadt  Rel_Perf\n");
+    jrns["id"] = nsid;
     for (int i = 0; i <= id_ns.nlbaf /* 1-based */ && i < 16; i++) {
       const nvme_lbaf & lba = id_ns.lbaf[i];
-      pout("%2d %c %7u %7d %9d\n", i, (i == id_ns.flbas ? '+' : '-'),
+      if (!lba.ds)
+        continue; // not supported or not currently available
+      bool formatted = (i == id_ns.flbas);
+      jout("%2d %c %7u %7d %9d\n", i, (formatted ? '+' : '-'),
            (1U << lba.ds), lba.ms, lba.rp);
+      jrns["lba_formats"][i] += {
+        { "formatted", formatted },
+        { "data_bytes", 1U << lba.ds },
+        { "metadata_bytes", lba.ms },
+        { "relative_performance", lba.rp }
+      };
     }
   }
 }

--- a/smartmontools/openbsd_nvme_ioctl.h
+++ b/smartmontools/openbsd_nvme_ioctl.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024 Kenneth R Westerback <krw@openbsd.org>
+ *
+ * Permission to use, copy, modify, and distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#define	NVME_PASSTHROUGH_CMD		_IOWR('n', 0, struct nvme_pt_cmd)
+
+struct nvme_pt_status {
+	int			ps_dv_unit;
+	int			ps_nsid;
+	int			ps_flags;
+#define NVME_CQE_SCT(_f)	((_f) & (0x07 << 9))
+#define  NVME_CQE_SCT_GENERIC		(0x00 << 9)
+#define NVME_CQE_SC(_f)		((_f) & (0xff << 1))
+#define  NVME_CQE_SC_SUCCESS		(0x00 << 1)
+	uint32_t		ps_csts;
+	uint32_t		ps_cc;
+};
+
+#define	BIO_MSG_COUNT	5
+#define	BIO_MSG_LEN	128
+
+struct bio_msg {
+	int		bm_type;
+	char		bm_msg[BIO_MSG_LEN];
+};
+
+struct bio_status {
+	char		bs_controller[16];
+	int		bs_status;
+	int		bs_msg_count;
+	struct bio_msg	bs_msgs[BIO_MSG_COUNT];
+};
+
+struct bio {
+	void			*bio_cookie;
+	struct bio_status	bio_status;
+};
+
+struct nvme_pt_cmd {
+	/* Commands may arrive via /dev/bio. */
+	struct bio		pt_bio;
+
+	/* The sqe fields that the caller may specify. */
+	uint8_t			pt_opcode;
+	uint32_t		pt_nsid;
+	uint32_t		pt_cdw10;
+	uint32_t		pt_cdw11;
+	uint32_t		pt_cdw12;
+	uint32_t		pt_cdw13;
+	uint32_t		pt_cdw14;
+	uint32_t		pt_cdw15;
+
+	caddr_t			pt_status;
+	uint32_t		pt_statuslen;
+
+	caddr_t			pt_databuf;	/* User space address. */
+	uint32_t		pt_databuflen;	/* Length of buffer. */
+};
+
+#define	nvme_completion_is_error(_flags)				\
+	((NVME_CQE_SC(_flags) != NVME_CQE_SC_SUCCESS)   		\
+	    || (NVME_CQE_SCT(_flags) != NVME_CQE_SCT_GENERIC))
+

--- a/smartmontools/os_linux.cpp
+++ b/smartmontools/os_linux.cpp
@@ -2653,17 +2653,9 @@ smart_device * linux_scsi_device::autodetect_open()
       return this;
     }
 
-    // Marvell ?
-    if (len >= 42 && !memcmp(req_buff + 36, "MVSATA", 6)) {
-      //pout("Device %s: using '-d marvell' for ATA disk with Marvell driver\n", get_dev_name());
-      close();
-      smart_device_auto_ptr newdev(
-        new linux_marvell_device(smi(), get_dev_name(), get_req_type())
-      );
-      newdev->open(); // TODO: Can possibly pass open fd
-      delete this;
-      return newdev.release();
-    }
+    // TODO: Remove after smartmontools 7.5
+    if (len >= 42 && !memcmp(req_buff + 36, "MVSATA", 6))
+      pout("Warning: device type 'marvell' is deprecated and no longer autodetected\n");
   }
 
   // SAT or USB ?
@@ -3527,7 +3519,7 @@ smart_device * linux_smart_interface::autodetect_smart_device(const char * name)
 smart_device * linux_smart_interface::get_custom_smart_device(const char * name, const char * type)
 {
   // Marvell ?
-  // TODO: Remove after smartmontools 7.4
+  // TODO: Remove after smartmontools 7.5
   if (!strcmp(type, "marvell"))
     return set_err_np(EINVAL,
       "The device type 'marvell' is deprecated and will be removed in a\n"

--- a/smartmontools/os_openbsd.cpp
+++ b/smartmontools/os_openbsd.cpp
@@ -14,6 +14,7 @@
 
 #include "atacmds.h"
 #include "scsicmds.h"
+#include "nvmecmds.h"
 #include "utility.h"
 #include "os_openbsd.h"
 
@@ -27,11 +28,31 @@ const char * os_openbsd_cpp_cvsid = "$Id$"
 
 #define ARGUSED(x) ((void)(x))
 
+// based on OpenBSD "/usr/include/dev/ic/nvmeio.h" && "/usr/include/dev/biovar.h"
+#include "openbsd_nvme_ioctl.h"       // NVME_PASSTHROUGH_CMD, nvme_completion_is_error
+
 /////////////////////////////////////////////////////////////////////////////
 
 namespace os_openbsd { // No need to publish anything, name provided for Doxygen
 
 static const char *net_dev_prefix = "/dev/";
+
+bool sd_is_nvme(const char *dev)
+{
+      struct nvme_pt_cmd pt;
+      memset(&pt, 0, sizeof(pt));
+      pt.pt_opcode = smartmontools::nvme_admin_identify;
+
+      int fd = ::open(dev, O_RDWR);
+      if (fd == -1)
+        return false;
+
+      int status = ioctl(fd, NVME_PASSTHROUGH_CMD, &pt);
+      close(fd);
+
+      return status != -1 || errno != ENOTTY;
+}
+
 static const char *net_dev_ata_disk = "wd";
 static const char *net_dev_scsi_disk = "sd";
 static const char *net_dev_scsi_tape = "st";
@@ -209,6 +230,80 @@ bool openbsd_ata_device::ata_pass_through(const ata_cmd_in & in, ata_cmd_out & o
 }
 
 /////////////////////////////////////////////////////////////////////////////
+/// NVMe support
+
+class openbsd_nvme_device
+: public /*implements*/ nvme_device,
+  public /*extends*/ openbsd_smart_device
+{
+public:
+  openbsd_nvme_device(smart_interface * intf, const char * dev_name,
+    const char * req_type, unsigned nsid);
+
+  virtual bool open() override;
+
+  virtual bool nvme_pass_through(const nvme_cmd_in & in, nvme_cmd_out & out) override;
+};
+
+openbsd_nvme_device::openbsd_nvme_device(smart_interface * intf, const char * dev_name,
+  const char * req_type, unsigned nsid)
+: smart_device(intf, dev_name, "nvme", req_type),
+  nvme_device(nsid),
+  openbsd_smart_device()
+{
+}
+
+bool openbsd_nvme_device::open()
+{
+  const char *dev = get_dev_name();
+  int fd;
+
+  if ((fd = ::open(dev, O_RDWR)) == -1) {
+    set_err(errno, "can't open sd device");
+    return false;
+  }
+
+  set_fd(fd);
+
+  return true;
+}
+
+bool openbsd_nvme_device::nvme_pass_through(const nvme_cmd_in & in, nvme_cmd_out & out)
+{
+  struct nvme_pt_cmd pt;
+  struct nvme_pt_status ps;
+
+  memset(&ps, 0, sizeof(ps));
+  memset(&pt.pt_bio, 0, sizeof(pt.pt_bio));
+
+  pt.pt_opcode = in.opcode;
+  pt.pt_nsid = in.nsid;
+  pt.pt_databuf = (caddr_t)in.buffer;
+  pt.pt_databuflen = in.size;
+  pt.pt_cdw10 = in.cdw10;
+  pt.pt_cdw11 = in.cdw11;
+  pt.pt_cdw12 = in.cdw12;
+  pt.pt_cdw13 = in.cdw13;
+  pt.pt_cdw14 = in.cdw14;
+  pt.pt_cdw15 = in.cdw15;
+  pt.pt_status = (char *)&ps;
+  pt.pt_statuslen = sizeof(ps);
+
+  int status = ioctl(get_fd(), NVME_PASSTHROUGH_CMD, &pt);
+
+  if (status == -1)
+    return set_err(errno, "NVME_PASSTHROUGH_CMD: %s", strerror(errno));
+
+  out.result = 0; // cqe.cdw0 (Command specific result) is not provided
+
+  if (nvme_completion_is_error(ps.ps_flags))
+    return set_nvme_err(out, nvme_completion_is_error(ps.ps_flags));
+
+  return true;
+}
+
+
+/////////////////////////////////////////////////////////////////////////////
 /// Standard SCSI support
 
 class openbsd_scsi_device
@@ -381,6 +476,9 @@ protected:
 
   virtual scsi_device * get_scsi_device(const char * name, const char * type) override;
 
+  virtual nvme_device * get_nvme_device(const char * name, const char * type,
+    unsigned nsid) override;
+
   virtual smart_device * autodetect_smart_device(const char * name) override;
 
   virtual smart_device * get_custom_smart_device(const char * name, const char * type) override;
@@ -432,6 +530,11 @@ ata_device * openbsd_smart_interface::get_ata_device(const char * name, const ch
 scsi_device * openbsd_smart_interface::get_scsi_device(const char * name, const char * type)
 {
   return new openbsd_scsi_device(this, name, type);
+}
+
+nvme_device * openbsd_smart_interface::get_nvme_device(const char * name, const char * type, unsigned nsid)
+{
+  return new openbsd_nvme_device(this, name, type, nsid);
 }
 
 int openbsd_smart_interface::get_dev_names(char ***names, const char *prefix)
@@ -504,6 +607,7 @@ bool openbsd_smart_interface::scan_smart_devices(smart_device_list & devlist,
 
     bool scan_ata = !*type || !strcmp(type, "ata");
     bool scan_scsi = !*type || !strcmp(type, "scsi") || !strcmp(type, "sat");
+    bool scan_nvme = !*type || !strcmp(type, "nvme");
 
     // Make namelists
     char * * atanames = 0; int numata = 0;
@@ -517,7 +621,7 @@ bool openbsd_smart_interface::scan_smart_devices(smart_device_list & devlist,
 
     char * * scsinames = 0; int numscsi = 0;
     char * * scsitapenames = 0; int numscsitape = 0;
-    if (scan_scsi) {
+    if (scan_scsi || scan_nvme) {
       numscsi = get_dev_names(&scsinames, net_dev_scsi_disk);
       if (numscsi < 0) {
         set_err(ENOMEM);
@@ -541,9 +645,17 @@ bool openbsd_smart_interface::scan_smart_devices(smart_device_list & devlist,
     if(numata) free(atanames);
 
     for (i = 0; i < numscsi; i++) {
-      scsi_device * scsidev = new openbsd_scsi_device(this, scsinames[i], type, true /*scanning*/);
-      if (scsidev)
-        devlist.push_back(scsidev);
+      if (sd_is_nvme(scsinames[i])) {
+        if (scan_nvme) {
+          nvme_device * nvmedev = new openbsd_nvme_device(this, scsinames[i], type, true /*scanning*/);
+          if (nvmedev)
+            devlist.push_back(nvmedev);
+        }
+      } else if (scan_scsi) {
+        scsi_device * scsidev = new openbsd_scsi_device(this, scsinames[i], type, true /*scanning*/);
+        if (scsidev)
+          devlist.push_back(scsidev);
+      }
       free(scsinames[i]);
     }
     if(numscsi) free(scsinames);
@@ -588,8 +700,11 @@ smart_device * openbsd_smart_interface::autodetect_smart_device(const char * nam
       // XXX get USB vendor ID, product ID and version from sd(4)/umass(4).
       // XXX check sat device via get_usb_dev_type_by_id().
 
-      // No USB bridge found, assume regular SCSI or SAT device
-      return get_scsi_device(name, "");
+      // No USB bridge found, decide if it's NVME or regular SCSI or SAT device
+      if (sd_is_nvme(name))
+        return get_nvme_device(name, "nvme", 0);
+      else
+        return get_scsi_device(name, "");
     }
     if (!strncmp(net_dev_scsi_tape, test_name, strlen(net_dev_scsi_tape)))
       return get_scsi_device(name, "scsi");

--- a/smartmontools/os_win32.cpp
+++ b/smartmontools/os_win32.cpp
@@ -4183,11 +4183,14 @@ std::string win_smart_interface::get_os_version_str()
           case 19041:   w = "2019-2004"; break;
           case 19042:   w = "2019-20H2"; break;
           case 20348:   w = "2022-21H2"; break;
+          case 26100:   w = "2025-24H2"; break;
           default:      w = (vi.dwBuildNumber < 17763
                           ? "2016"
                           :  vi.dwBuildNumber < 20348
                           ? "2019"
-                          : "2022");
+                          :  vi.dwBuildNumber < 26100
+                          ? "2022"
+                          : "2025");
                         build = vi.dwBuildNumber; break;
         } break;
     }

--- a/smartmontools/os_win32/smartd_mailer.conf.sample.ps1
+++ b/smartmontools/os_win32/smartd_mailer.conf.sample.ps1
@@ -29,3 +29,24 @@ $smtpServer = "smtp.domain.local"
 #  0123456789abcdef...
 #  ...
 #"
+
+# # -------------------------------------------------------------------------
+# # Sample encryption/decryption for $password <-> $passwordEnc
+# # (Requires same system and user account as smartd service)
+#
+# $password = "PASSWORD"
+# Clear-History # Recommended if run interactively
+# $t = ConvertTo-SecureString -AsPlainText -Force $password
+# $t = ConvertFrom-SecureString $t
+# $t = ($t -split '(.{78})' | Where-Object {$_}) -replace '^','  ' -join "`n"
+# $passwordEnc = "`n" + $t + "`n"
+# echo "`$passwordEnc = `"$passwordEnc`""
+#
+# $t = $passwordEnc -replace '[\r\n\t ]',''
+# $t = ConvertTo-SecureString $t
+# $t = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($t)
+# $password = [System.Runtime.InteropServices.Marshal]::PtrToStringAuto($t)
+# $t = $undef
+# echo "`$password = `"$password`""
+#
+# # -------------------------------------------------------------------------

--- a/smartmontools/os_win32/update-smart-drivedb.ps1.in
+++ b/smartmontools/os_win32/update-smart-drivedb.ps1.in
@@ -3,7 +3,7 @@
 #
 # Home page of code is: https://www.smartmontools.org
 #
-# Copyright (C) 2022-23 Christian Franke
+# Copyright (C) 2022-25 Christian Franke
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #
@@ -247,6 +247,7 @@ function download($url, $file, [ref]$errmsg)
   if ($script:DryRun) {
     echo "Invoke-WebRequest $(echo @req)"
   } else {
+    vecho "Invoke-WebRequest $(echo @req)"
     try {
       Invoke-WebRequest @req
     } catch {

--- a/smartmontools/os_win32/update-smart-drivedb.ps1.in
+++ b/smartmontools/os_win32/update-smart-drivedb.ps1.in
@@ -390,7 +390,7 @@ pnILDDMBUNQMBm/XlCYQUetyrJnAVzFGXurtjEXQ/DDnbfy2Z8efoG8rtq7v3fxS
 '
     }
 
-    '^RELEASE_7_[023]_DRIVEDB$' {
+    '^RELEASE_7_[0235]_DRIVEDB$' {
 # Smartmontools Signing Key (through 2025) <smartmontools-database@listi.jpberlin.de>
 # Smartmontools Signing Key (through 2020) <smartmontools-database@listi.jpberlin.de>
 # Key ID 721042C5

--- a/smartmontools/os_win32/wmiquery.cpp
+++ b/smartmontools/os_win32/wmiquery.cpp
@@ -79,7 +79,7 @@ bool wbem_enumerator::next(wbem_object & obj)
     return false;
 
   ULONG n = 0;
-  HRESULT rc = m_intf->Next(5000 /*5s*/, 1 /*count*/, obj.m_intf.replace(), &n);
+  HRESULT rc = m_intf->Next(60000, 1 /*count*/, obj.m_intf.replace(), &n);
   if (FAILED(rc) || n != 1)
     return false;
   return true;

--- a/smartmontools/popen_as_ugid.cpp
+++ b/smartmontools/popen_as_ugid.cpp
@@ -22,6 +22,8 @@ const char * popen_as_ugid_cvsid = "$Id$"
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#include "config.h"
+
 static FILE * s_popen_file /* = 0 */;
 static pid_t s_popen_pid /* = 0 */;
 

--- a/smartmontools/scsicmds.cpp
+++ b/smartmontools/scsicmds.cpp
@@ -755,6 +755,7 @@ scsi_decode_lu_dev_id(const unsigned char * b, int blen, char * s, int slen,
         return -1;
     }
 
+#define SLEN(a, b) ((a) > (b) ? ((a) - (b)) : 0)
     s[0] = '\0';
     int si = 0;
     int have_scsi_ns = 0;
@@ -764,7 +765,7 @@ scsi_decode_lu_dev_id(const unsigned char * b, int blen, char * s, int slen,
         const unsigned char * ucp = b + off;
         int i_len = ucp[3];
         if ((off + i_len + 4) > blen) {
-            snprintf(s+si, slen-si, "error: designator length");
+            snprintf(s+si, SLEN(slen, si), "error: designator length");
             return -1;
         }
         int assoc = ((ucp[1] >> 4) & 0x3);
@@ -783,52 +784,52 @@ scsi_decode_lu_dev_id(const unsigned char * b, int blen, char * s, int slen,
             break;
         case 2: /* EUI-64 based */
             if ((8 != i_len) && (12 != i_len) && (16 != i_len)) {
-                snprintf(s+si, slen-si, "error: EUI-64 length");
+                snprintf(s+si, SLEN(slen, si), "error: EUI-64 length");
                 return -1;
             }
             if (have_scsi_ns)
                 si = 0;
-            si += snprintf(s+si, slen-si, "0x");
+            si += snprintf(s+si, SLEN(slen, si), "0x");
             for (int m = 0; m < i_len; ++m)
-                si += snprintf(s+si, slen-si, "%02x", (unsigned int)ip[m]);
+                si += snprintf(s+si, SLEN(slen, si), "%02x", (unsigned int)ip[m]);
             break;
         case 3: /* NAA */
             if (1 != c_set) {
-                snprintf(s+si, slen-si, "error: NAA bad code_set");
+                snprintf(s+si, SLEN(slen, si), "error: NAA bad code_set");
                 return -1;
             }
             naa = (ip[0] >> 4) & 0xff;
             if ((naa < 2) || (naa > 6) || (4 == naa)) {
-                snprintf(s+si, slen-si, "error: unexpected NAA");
+                snprintf(s+si, SLEN(slen, si), "error: unexpected NAA");
                 return -1;
             }
             if (have_scsi_ns)
                 si = 0;
             if (2 == naa) {             /* NAA IEEE Extended */
                 if (8 != i_len) {
-                    snprintf(s+si, slen-si, "error: NAA 2 length");
+                    snprintf(s+si, SLEN(slen, si), "error: NAA 2 length");
                     return -1;
                 }
-                si += snprintf(s+si, slen-si, "0x");
+                si += snprintf(s+si, SLEN(slen, si), "0x");
                 for (int m = 0; m < 8; ++m)
-                    si += snprintf(s+si, slen-si, "%02x", (unsigned int)ip[m]);
+                    si += snprintf(s+si, SLEN(slen, si), "%02x", (unsigned int)ip[m]);
             } else if ((3 == naa ) || (5 == naa)) {
                 /* NAA=3 Locally assigned; NAA=5 IEEE Registered */
                 if (8 != i_len) {
-                    snprintf(s+si, slen-si, "error: NAA 3 or 5 length");
+                    snprintf(s+si, SLEN(slen, si), "error: NAA 3 or 5 length");
                     return -1;
                 }
-                si += snprintf(s+si, slen-si, "0x");
+                si += snprintf(s+si, SLEN(slen, si), "0x");
                 for (int m = 0; m < 8; ++m)
-                    si += snprintf(s+si, slen-si, "%02x", (unsigned int)ip[m]);
+                    si += snprintf(s+si, SLEN(slen, si), "%02x", (unsigned int)ip[m]);
             } else if (6 == naa) {      /* NAA IEEE Registered extended */
                 if (16 != i_len) {
-                    snprintf(s+si, slen-si, "error: NAA 6 length");
+                    snprintf(s+si, SLEN(slen, si), "error: NAA 6 length");
                     return -1;
                 }
-                si += snprintf(s+si, slen-si, "0x");
+                si += snprintf(s+si, SLEN(slen, si), "0x");
                 for (int m = 0; m < 16; ++m)
-                    si += snprintf(s+si, slen-si, "%02x", (unsigned int)ip[m]);
+                    si += snprintf(s+si, SLEN(slen, si), "%02x", (unsigned int)ip[m]);
             }
             break;
         case 4: /* Relative target port */
@@ -838,12 +839,12 @@ scsi_decode_lu_dev_id(const unsigned char * b, int blen, char * s, int slen,
             break;
         case 8: /* SCSI name string */
             if (3 != c_set) {
-                snprintf(s+si, slen-si, "error: SCSI name string");
+                snprintf(s+si, SLEN(slen, si), "error: SCSI name string");
                 return -1;
             }
             /* does %s print out UTF-8 ok?? */
             if (si == 0) {
-                si += snprintf(s+si, slen-si, "%s", (const char *)ip);
+                si += snprintf(s+si, SLEN(slen, si), "%s", (const char *)ip);
                 ++have_scsi_ns;
             }
             break;
@@ -852,10 +853,11 @@ scsi_decode_lu_dev_id(const unsigned char * b, int blen, char * s, int slen,
         }
     }
     if (-2 == u) {
-        snprintf(s+si, slen-si, "error: bad structure");
+        snprintf(s+si, SLEN(slen, si), "error: bad structure");
         return -1;
     }
     return 0;
+#undef SLEN
 }
 
 /* Sends LOG SENSE command. Returns 0 if ok, 1 if device NOT READY, 2 if

--- a/smartmontools/scsinvme.cpp
+++ b/smartmontools/scsinvme.cpp
@@ -70,7 +70,7 @@ bool sntasmedia_device::nvme_pass_through(const nvme_cmd_in & in, nvme_cmd_out &
       }
       return set_err(ENOSYS, "NVMe Identify with CDW10=0x%08x not supported", in.cdw10);
     case smartmontools::nvme_admin_get_log_page:
-      if (!(in.nsid == 0xffffffff || !in.nsid))
+      if (!(in.nsid == nvme_broadcast_nsid || !in.nsid))
         return set_err(ENOSYS, "NVMe Get Log Page with NSID=0x%x not supported", in.nsid);
       break;
     default:
@@ -165,7 +165,7 @@ bool sntjmicron_device::open()
   // cannot detect e.g. /dev/sdX is NSID 2.
   // Set to broadcast if not available
   if (!get_nsid()) {
-    set_nsid(0xFFFFFFFF);
+    set_nsid(nvme_broadcast_nsid);
   }
 
   return true;
@@ -353,7 +353,7 @@ bool sntrealtek_device::nvme_pass_through(const nvme_cmd_in & in, nvme_cmd_out &
       }
       return set_err(ENOSYS, "NVMe Identify with CDW10=0x%08x not supported", in.cdw10);
     case smartmontools::nvme_admin_get_log_page:
-      if (!(in.nsid == 0xffffffff || !in.nsid))
+      if (!(in.nsid == nvme_broadcast_nsid || !in.nsid))
         return set_err(ENOSYS, "NVMe Get Log Page with NSID=0x%x not supported", in.nsid);
       if (size > 0x200) { // Reading more apparently returns old data from previous command
         // TODO: Add ability to return short reads to caller
@@ -413,7 +413,7 @@ nvme_device * smart_interface::get_snt_device(const char * type, scsi_device * s
 
   if (!strcmp(type, "sntasmedia")) {
     // No namespace supported
-    sntdev = new sntasmedia_device(this, scsidev, type, 0xffffffff);
+    sntdev = new sntasmedia_device(this, scsidev, type, nvme_broadcast_nsid);
   }
 
   else if (!strncmp(type, "sntjmicron", 10)) {
@@ -429,7 +429,7 @@ nvme_device * smart_interface::get_snt_device(const char * type, scsi_device * s
 
   else if (!strcmp(type, "sntrealtek")) {
     // No namespace supported
-    sntdev = new sntrealtek_device(this, scsidev, type, 0xffffffff);
+    sntdev = new sntrealtek_device(this, scsidev, type, nvme_broadcast_nsid);
   }
 
   else {

--- a/smartmontools/scsinvme.cpp
+++ b/smartmontools/scsinvme.cpp
@@ -190,6 +190,17 @@ bool sntjmicron_device::nvme_pass_through(const nvme_cmd_in & in, nvme_cmd_out &
 
   // 1: "NVM Command Set Payload"
   {
+  // for whatever reason selftest log causing controller to hang if size is set > 0x230b
+  // see GH issue #256 for the details. Patching it to include last 19 log records instead
+    unsigned cdw10 = in.cdw10;
+    if (in.opcode == smartmontools::nvme_admin_get_log_page) {
+      unsigned int lid = in.cdw10 & 0xFF;
+      if (lid == 0x6 && in.size > 0x218) {
+        unsigned size = 0x218;
+        cdw10 = lid | ((size/4 - 1) << 16);
+        pout("Warning: self-test output truncated to 19 items to workaround controller bug\n");
+      }
+    }
     unsigned char cdb[SNT_JMICRON_CDB_LEN] = { 0 };
     cdb[0] = SAT_ATA_PASSTHROUGH_12;
     cdb[1] = (admin ? 0x80 : 0x00) | proto_nvm_cmd;
@@ -203,7 +214,7 @@ bool sntjmicron_device::nvme_pass_through(const nvme_cmd_in & in, nvme_cmd_out &
     // nvm_cmd[4-5]: reserved
     // nvm_cmd[6-7]: metadata pointer
     // nvm_cmd[8-11]: data ptr (?)
-    nvm_cmd[12] = in.cdw10;
+    nvm_cmd[12] = cdw10;
     nvm_cmd[13] = in.cdw11;
     nvm_cmd[14] = in.cdw12;
     nvm_cmd[15] = in.cdw13;

--- a/smartmontools/scsinvme.cpp
+++ b/smartmontools/scsinvme.cpp
@@ -132,8 +132,6 @@ public:
 
   virtual ~sntjmicron_device();
 
-  virtual bool open() override;
-
   virtual bool nvme_pass_through(const nvme_cmd_in & in, nvme_cmd_out & out) override;
 
 private:
@@ -153,22 +151,6 @@ sntjmicron_device::sntjmicron_device(smart_interface * intf, scsi_device * scsid
 
 sntjmicron_device::~sntjmicron_device()
 {
-}
-
-bool sntjmicron_device::open()
-{
-  // Open USB first
-  if (!tunnelled_device<nvme_device, scsi_device>::open())
-    return false;
-
-  // No sure how multiple namespaces come up on device so we
-  // cannot detect e.g. /dev/sdX is NSID 2.
-  // Set to broadcast if not available
-  if (!get_nsid()) {
-    set_nsid(nvme_broadcast_nsid);
-  }
-
-  return true;
 }
 
 // cdb[0]: ATA PASS THROUGH (12) SCSI command opcode byte (0xa1)
@@ -413,21 +395,19 @@ nvme_device * smart_interface::get_snt_device(const char * type, scsi_device * s
 
   // Take temporary ownership of 'scsidev' to delete it on error
   scsi_device_auto_ptr scsidev_holder(scsidev);
-  nvme_device * sntdev = 0;
+  nvme_device * sntdev = nullptr;
 
   if (!strcmp(type, "sntasmedia")) {
     // No namespace supported
     sntdev = new sntasmedia_device(this, scsidev, type, nvme_broadcast_nsid);
   }
 
-  else if (!strncmp(type, "sntjmicron", 10)) {
+  else if (str_starts_with(type, "sntjmicron")) {
     int n1 = -1, n2 = -1, len = strlen(type);
-    unsigned nsid = 0; // invalid namespace id -> use default
+    unsigned nsid = nvme_broadcast_nsid;
     sscanf(type, "sntjmicron%n,0x%x%n", &n1, &nsid, &n2);
-    if (!(n1 == len || n2 == len)) {
-      set_err(EINVAL, "Invalid NVMe namespace id in '%s'", type);
-      return 0;
-    }
+    if (!(n1 == len || n2 == len))
+      return set_err_np(EINVAL, "Invalid NVMe namespace id in '%s'", type);
     sntdev = new sntjmicron_device(this, scsidev, type, nsid);
   }
 
@@ -437,8 +417,7 @@ nvme_device * smart_interface::get_snt_device(const char * type, scsi_device * s
   }
 
   else {
-    set_err(EINVAL, "Unknown SNT device type '%s'", type);
-    return 0;
+    return set_err_np(EINVAL, "Unknown SNT device type '%s'", type);
   }
 
   // 'scsidev' is now owned by 'sntdev'

--- a/smartmontools/scsinvme.cpp
+++ b/smartmontools/scsinvme.cpp
@@ -3,7 +3,7 @@
  *
  * Home page of code is: https://www.smartmontools.org
  *
- * Copyright (C) 2020-21 Christian Franke
+ * Copyright (C) 2020-25 Christian Franke
  * Copyright (C) 2018 Harry Mallon <hjmallon@gmail.com>
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
@@ -414,13 +414,6 @@ nvme_device * smart_interface::get_snt_device(const char * type, scsi_device * s
   // Take temporary ownership of 'scsidev' to delete it on error
   scsi_device_auto_ptr scsidev_holder(scsidev);
   nvme_device * sntdev = 0;
-
-  // TODO: Remove this and adjust drivedb entry accordingly when no longer EXPERIMENTAL
-  if (!strcmp(type, "sntjmicron#please_try")) {
-    set_err(EINVAL, "USB to NVMe bridge [please try '-d sntjmicron' and report result to: "
-            PACKAGE_BUGREPORT "]");
-    return 0;
-  }
 
   if (!strcmp(type, "sntasmedia")) {
     // No namespace supported

--- a/smartmontools/scsinvme.cpp
+++ b/smartmontools/scsinvme.cpp
@@ -26,17 +26,61 @@ const char * scsinvme_cpp_svnid = "$Id$";
 namespace snt {
 
 /////////////////////////////////////////////////////////////////////////////
-// sntasmedia_device
+// nvme_or_sat_device: Common base class for NVMe/SATA -> USB bridges
 
-class sntasmedia_device
+class nvme_or_sat_device
 : public tunnelled_device<
     /*implements*/ nvme_device,
     /*by tunnelling through a*/ scsi_device
   >
 {
 public:
+  nvme_or_sat_device(scsi_device * scsidev, unsigned nsid, bool maybe_sat);
+
+  virtual smart_device * autodetect_open() override;
+
+private:
+  bool m_maybe_sat;
+};
+
+nvme_or_sat_device::nvme_or_sat_device(scsi_device * scsidev, unsigned nsid, bool maybe_sat)
+: smart_device(never_called),
+  tunnelled_device<nvme_device, scsi_device>(scsidev, nsid),
+  m_maybe_sat(maybe_sat)
+{
+}
+
+smart_device * nvme_or_sat_device::autodetect_open()
+{
+  if (!open() || !m_maybe_sat)
+    return this;
+
+  // SAT not tried first because some USB bridges emulate ATA IDENTIFY via SAT
+  // if a NVMe device is connected.
+  // TODO: Preserve id_ctrl for next nvme_read_id_ctrl() call
+  smartmontools::nvme_id_ctrl id_ctrl;
+  if (nvme_read_id_ctrl(this, id_ctrl))
+    return this;
+
+  // NVMe Identify Controller failed, use the already opened SCSI device for SAT.
+  // IMPORTANT for derived classes: this->close() not called before delete.
+  // TODO: preserve requested 'type'.
+  scsi_device * scsidev = get_tunnel_dev();
+  ata_device * satdev = smi()->get_sat_device("sat", scsidev);
+  release(scsidev); // 'scsidev' is now owned by 'satdev'
+  delete this;
+  return satdev;
+}
+
+/////////////////////////////////////////////////////////////////////////////
+// sntasmedia_device
+
+class sntasmedia_device
+: public nvme_or_sat_device
+{
+public:
   sntasmedia_device(smart_interface * intf, scsi_device * scsidev,
-                    const char * req_type, unsigned nsid);
+                    const char * req_type, unsigned nsid, bool maybe_sat);
 
   virtual ~sntasmedia_device();
 
@@ -44,9 +88,9 @@ public:
 };
 
 sntasmedia_device::sntasmedia_device(smart_interface * intf, scsi_device * scsidev,
-                                     const char * req_type, unsigned nsid)
+                                     const char * req_type, unsigned nsid, bool maybe_sat)
 : smart_device(intf, scsidev->get_dev_name(), "sntasmedia", req_type),
-  tunnelled_device<nvme_device, scsi_device>(scsidev, nsid)
+  nvme_or_sat_device(scsidev, nsid, maybe_sat)
 {
   set_info().info_name = strprintf("%s [USB NVMe ASMedia]", scsidev->get_info_name());
 }
@@ -121,14 +165,11 @@ bool sntasmedia_device::nvme_pass_through(const nvme_cmd_in & in, nvme_cmd_out &
 #define SNT_JMICRON_NVM_CMD_LEN 512
 
 class sntjmicron_device
-: public tunnelled_device<
-    /*implements*/ nvme_device,
-    /*by tunnelling through a*/ scsi_device
-  >
+: public nvme_or_sat_device
 {
 public:
   sntjmicron_device(smart_interface * intf, scsi_device * scsidev,
-                    const char * req_type, unsigned nsid);
+                    const char * req_type, unsigned nsid, bool maybe_sat);
 
   virtual ~sntjmicron_device();
 
@@ -142,9 +183,9 @@ private:
 };
 
 sntjmicron_device::sntjmicron_device(smart_interface * intf, scsi_device * scsidev,
-                                     const char * req_type, unsigned nsid)
+                                     const char * req_type, unsigned nsid, bool maybe_sat)
 : smart_device(intf, scsidev->get_dev_name(), "sntjmicron", req_type),
-  tunnelled_device<nvme_device, scsi_device>(scsidev, nsid)
+  nvme_or_sat_device(scsidev, nsid, maybe_sat)
 {
   set_info().info_name = strprintf("%s [USB NVMe JMicron]", scsidev->get_info_name());
 }
@@ -306,14 +347,11 @@ bool sntjmicron_device::nvme_pass_through(const nvme_cmd_in & in, nvme_cmd_out &
 // sntrealtek_device
 
 class sntrealtek_device
-: public tunnelled_device<
-    /*implements*/ nvme_device,
-    /*by tunnelling through a*/ scsi_device
-  >
+: public nvme_or_sat_device
 {
 public:
   sntrealtek_device(smart_interface * intf, scsi_device * scsidev,
-                    const char * req_type, unsigned nsid);
+                    const char * req_type, unsigned nsid, bool maybe_sat);
 
   virtual ~sntrealtek_device();
 
@@ -321,9 +359,9 @@ public:
 };
 
 sntrealtek_device::sntrealtek_device(smart_interface * intf, scsi_device * scsidev,
-                                     const char * req_type, unsigned nsid)
+                                     const char * req_type, unsigned nsid, bool maybe_sat)
 : smart_device(intf, scsidev->get_dev_name(), "sntrealtek", req_type),
-  tunnelled_device<nvme_device, scsi_device>(scsidev, nsid)
+  nvme_or_sat_device(scsidev, nsid, maybe_sat)
 {
   set_info().info_name = strprintf("%s [USB NVMe Realtek]", scsidev->get_info_name());
 }
@@ -393,27 +431,37 @@ nvme_device * smart_interface::get_snt_device(const char * type, scsi_device * s
   if (!scsidev)
     throw std::logic_error("smart_interface: get_snt_device() called with scsidev=0");
 
+  // Check for "snt*/sat"
+  bool maybe_sat = false;
+  char snt_type[32];
+  snprintf(snt_type, sizeof(snt_type), "%s", type);
+  int len = strlen(snt_type);
+  if (len > 4 && !strcmp(snt_type + len - 4, "/sat")) {
+    snt_type[len -= 4] = 0;
+    maybe_sat = true;
+  }
+
   // Take temporary ownership of 'scsidev' to delete it on error
   scsi_device_auto_ptr scsidev_holder(scsidev);
   nvme_device * sntdev = nullptr;
 
-  if (!strcmp(type, "sntasmedia")) {
+  if (!strcmp(snt_type, "sntasmedia")) {
     // No namespace supported
-    sntdev = new sntasmedia_device(this, scsidev, type, nvme_broadcast_nsid);
+    sntdev = new sntasmedia_device(this, scsidev, type, nvme_broadcast_nsid, maybe_sat);
   }
 
-  else if (str_starts_with(type, "sntjmicron")) {
-    int n1 = -1, n2 = -1, len = strlen(type);
+  else if (str_starts_with(snt_type, "sntjmicron")) {
+    int n1 = -1, n2 = -1;
     unsigned nsid = nvme_broadcast_nsid;
-    sscanf(type, "sntjmicron%n,0x%x%n", &n1, &nsid, &n2);
+    sscanf(snt_type, "sntjmicron%n,0x%x%n", &n1, &nsid, &n2);
     if (!(n1 == len || n2 == len))
-      return set_err_np(EINVAL, "Invalid NVMe namespace id in '%s'", type);
-    sntdev = new sntjmicron_device(this, scsidev, type, nsid);
+      return set_err_np(EINVAL, "Invalid NVMe namespace id in '%s'", snt_type);
+    sntdev = new sntjmicron_device(this, scsidev, type, nsid, maybe_sat);
   }
 
-  else if (!strcmp(type, "sntrealtek")) {
+  else if (!strcmp(snt_type, "sntrealtek")) {
     // No namespace supported
-    sntdev = new sntrealtek_device(this, scsidev, type, nvme_broadcast_nsid);
+    sntdev = new sntrealtek_device(this, scsidev, type, nvme_broadcast_nsid, maybe_sat);
   }
 
   else {

--- a/smartmontools/scsiprint.cpp
+++ b/smartmontools/scsiprint.cpp
@@ -2880,14 +2880,17 @@ scsiGetDriveInfo(scsi_device * device, uint8_t * peripheral_type,
         scsi_format_id_string(scsi_vendor, &gBuf[8], 8);
         scsi_format_id_string(product, &gBuf[16], 16);
         scsi_format_id_string(revision, &gBuf[32], 4);
+        char model_name[sizeof(scsi_vendor) + sizeof(product)];
+        snprintf(model_name, sizeof(model_name), "%s%s%s",
+          scsi_vendor, (*scsi_vendor && *product ? " " : ""), product);
 
         pout("=== START OF INFORMATION SECTION ===\n");
         jout("Vendor:               %.8s\n", scsi_vendor);
         jglb["scsi_vendor"] = scsi_vendor;
         jout("Product:              %.16s\n", product);
         jglb["scsi_product"] = product;
-        jglb["scsi_model_name"] = strprintf("%s%s%s",
-          scsi_vendor, (*scsi_vendor && *product ? " " : ""), product);
+        jglb["model_name"] = model_name; // Also provided for ATA and NVMe devices
+        jglb["scsi_model_name"] = model_name;
         if (gBuf[32] >= ' ') {
             jout("Revision:             %.4s\n", revision);
             // jglb["firmware_version"] = revision;

--- a/smartmontools/scsiprint.cpp
+++ b/smartmontools/scsiprint.cpp
@@ -1769,6 +1769,7 @@ scsiPrintSSMedia(scsi_device * device)
             q = "Percentage used endurance indicator";
             jout("%s: %d%%\n", q, ucp[7]);
             jglb[std::string("scsi_") + json::str2key(q)] = ucp[7];
+            jglb["endurance_used"]["current_percent"] = ucp[7];
         default:        /* ignore other parameter codes */
             break;
         }

--- a/smartmontools/smartctl.8.in
+++ b/smartmontools/smartctl.8.in
@@ -233,11 +233,9 @@ in the smartmontools database (see \*(Aq\-v\*(Aq options below).  If so, the
 drive model family may also be printed.
 If \*(Aq\-n\*(Aq (see below) is specified, the power mode of the drive is
 printed.
-.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 [NVMe] For NVMe devices the information is obtained from the Identify
 Controller and the Identify Namespace data structure.
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .TP
 .B \-\-identify[=[w][nvb]]
 [ATA only] Prints an annotated table of the IDENTIFY DEVICE data.
@@ -266,12 +264,10 @@ the SMART options which require support for 48-bit ATA commands
 For SCSI, this is equivalent to
 .br
 \*(Aq\-H \-i \-A \-l error \-l selftest\*(Aq.
-.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 For NVMe, this is equivalent to
 .br
 \*(Aq\-H \-i \-c \-A \-l error \-l selftest\*(Aq.
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .TP
 .B \-x, \-\-xall
 Prints all SMART and non-SMART information about the device.
@@ -294,12 +290,10 @@ For SCSI disks, this is equivalent to
 \-l defects \-l envrep \-l genstats \-l ssd \-l zdevstat\*(Aq
 .br
 and for SCSI tape drives and changers, add \*(Aq\-l tapedevstat\*(Aq.
-.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 For NVMe, this is equivalent to
 .br
 \*(Aq\-H \-i \-c \-A \-l error \-l selftest\*(Aq.
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .TP
 .B \-\-scan
 Scans for devices and prints each device name, device type and protocol
@@ -432,7 +426,6 @@ from issuing SCSI commands to an ATA device.
 from issuing ATA commands to a SCSI device.
 .Sp
 .\" %ENDIF NOT OS Darwin
-.\" %IF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
 .I nvme[,NSID]
 \- the device type is NVM Express (NVMe).
 The optional parameter NSID specifies the namespace id (in hex) passed
@@ -440,7 +433,6 @@ to the driver.
 Use 0xffffffff for the broadcast namespace id.
 The default for NSID is the namespace id addressed by the device name.
 .Sp
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
 .\" %IF NOT OS Darwin
 .I sat[,auto][,N]
 \- the device type is SCSI to ATA Translation (SAT).
@@ -878,11 +870,9 @@ Invoking this once shows the SCSI commands in hex and the corresponding status.
 Invoking it a second time adds a hex listing of the first 64 bytes of data
 send to, or received from the device.
 .Sp
-.\" %IF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
 .I nvmeioctl
 \- report only ioctl() transactions with NVMe devices.
 .Sp
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
 Any argument may include a positive integer to specify the level of detail
 that should be reported.  The argument should be followed by a comma then
 the integer with no spaces.  For example,
@@ -1201,11 +1191,9 @@ Prefailure SMART Attribute value is less than or equal to its threshold
 [SCSI tape drive or changer] The TapeAlert status is obtained by reading the
 TapeAlert log page, but only if this option is given twice (see
 \fBTAPE DRIVES\fP for the rationale).
-.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 [NVMe] NVMe status is obtained by reading the "Critical Warning" byte from
 the SMART/Health Information log.
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .TP
 .B \-c, \-\-capabilities
 [ATA] Prints only the generic SMART capabilities.  These
@@ -1214,11 +1202,9 @@ respond to some of the different SMART commands.  For example it
 shows if the device logs errors, if it supports offline surface
 scanning, and so on.  If the device can carry out self-tests, this
 option also shows the estimated time required to run those tests.
-.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 [NVMe] Prints various NVMe device capabilities obtained from the Identify
 Controller and the Identify Namespace data structure.
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .TP
 .B \-A, \-\-attributes
 [ATA] Prints only the vendor specific SMART Attributes.  The Attributes
@@ -1315,7 +1301,6 @@ and start-stop cycle counter log pages.
 Certain vendor specific attributes are listed if recognised.
 The attributes are output in a relatively free format (compared with ATA
 disk attributes).
-.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 [NVMe] For NVMe devices the attributes are obtained from the SMART/Health
 Information log.
@@ -1324,7 +1309,6 @@ Information log.
 If the device indicates support for SMART/Health Information per namespace,
 the id of the namespace addressed by the device name is used, otherwise
 the id of the broadcast namespace.
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .TP
 .B \-f FORMAT, \-\-format=FORMAT
 [ATA only] Selects the output format of the attributes:
@@ -1429,7 +1413,6 @@ receives a command which is not implemented or is not valid.
 \- [SCSI] prints the error counter log pages for reads, write and verifies.
 The verify row is only output if it has an element other than zero.
 .Sp
-.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .I error[,NUM]
 \- [NVMe] prints the NVMe Error Information log.
 Only the 16 most recent log entries are printed by default.
@@ -1441,7 +1424,6 @@ Note that the contents of this log is not preserved across power cycles or
 controller resets, but the value of \*(AqError Information Log Entries\*(Aq
 from SMART/Health Information log is.
 .Sp
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .I xerror[,NUM][,error]
 \- [ATA only] prints the Extended Comprehensive SMART error log
 (General Purpose Log address 0x03).  Unlike the Summary SMART error
@@ -1494,7 +1476,6 @@ If provided, the SCSI Sense Key (SK), Additional Sense Code (ASC) and
 Additional Sense Code Qualifier (ASCQ) are also printed.  The self tests
 can be run using the \*(Aq\-t\*(Aq option described below (using the ATA
 test terminology).
-.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 .I selftest
 \- [NVMe: NEW EXPERIMENTAL SMARTCTL 7.4 FEATURE]
@@ -1503,7 +1484,6 @@ prints the NVMe self-test log.
 [NEW EXPERIMENTAL SMARTCTL 7.5 FIX]
 This always uses the broadcast namespace.
 Self-test results from individual namespaces appear in this single log.
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 .I xselftest[,NUM][,selftest]
 \- [ATA only] prints the Extended SMART self-test log (General Purpose
@@ -1688,7 +1668,6 @@ This command:
 writes a binary representation of the one sector log 0x11
 (SATA Phy Event Counters) to file log.bin.
 .Sp
-.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .I nvmelog,PAGE,SIZE
 \- [NVMe only] prints a hex dump of the first SIZE bytes from the NVMe
 log with identifier PAGE.
@@ -1697,7 +1676,6 @@ SIZE is a hexadecimal number in the range from 0x4 to 0x4000 (16 KiB).
 \fBWARNING: Do not specify the identifier of an unknown log page.
 Reading a log page may have undesirable side effects.\fP
 .Sp
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .I ssd
 \- [ATA] prints the Solid State Device Statistics log page.
 This has the same effect as \*(Aq\-l devstat,7\*(Aq, see above.
@@ -2155,12 +2133,10 @@ with other disks use the \*(Aq\-c\*(Aq option to monitor progress.
 .Sp
 .I short
 \- [SCSI] runs the "Background short" self-test.
-.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 .I short
 \- [NVMe: NEW EXPERIMENTAL SMARTCTL 7.4 FEATURE]
 runs the "Short" self-test for current namespace.
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 .I long
 \- [ATA] runs SMART Extended Self Test (tens of minutes to several hours).
@@ -2171,12 +2147,10 @@ below).
 .Sp
 .I long
 \- [SCSI] runs the "Background long" self-test.
-.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 .I long
 \- [NVMe: NEW EXPERIMENTAL SMARTCTL 7.4 FEATURE]
 runs the "Extended" self-test for current namespace.
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 .I conveyance
 \- [ATA only] runs a SMART Conveyance Self Test (minutes).  This

--- a/smartmontools/smartctl.8.in
+++ b/smartmontools/smartctl.8.in
@@ -1300,6 +1300,11 @@ disk attributes).
 .Sp
 [NVMe] For NVMe devices the attributes are obtained from the SMART/Health
 Information log.
+.br
+[NEW EXPERIMENTAL SMARTCTL 7.5 FEATURE]
+If the device indicates support for SMART/Health Information per namespace,
+the id of the namespace addressed by the device name is used, otherwise
+the id of the broadcast namespace.
 .\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
 .TP
 .B \-f FORMAT, \-\-format=FORMAT

--- a/smartmontools/smartctl.8.in
+++ b/smartmontools/smartctl.8.in
@@ -1,6 +1,6 @@
 .ig
 Copyright (C) 2002-10 Bruce Allen
-Copyright (C) 2004-24 Christian Franke
+Copyright (C) 2004-25 Christian Franke
 
 SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -494,20 +494,27 @@ PL2571/2771/2773/2775 USB to SATA bridge.
 \- this device type is for SATA disks that are behind a SunplusIT USB to SATA
 bridge.
 .Sp
-.I sntasmedia
+.I sntasmedia[/sat]
 \- this device type is for NVMe disks that are behind an ASMedia USB to NVMe
 bridge.
+.br
+[NEW EXPERIMENTAL SMARTCTL 7.5 FEATURE]
+If the \*(Aq/sat\*(Aq suffix is specified and the NVMe Identify Controller
+command fails, the device type is changed to \*(Aq\-d sat\*(Aq.
+This is useful for USB M.2 adapters which support NVMe and SATA devices.
 .Sp
-.I sntjmicron[,NSID]
+.I sntjmicron[,NSID][/sat]
 \- this device type is for NVMe disks that are behind a JMicron USB to NVMe
 bridge.
 The optional parameter NSID specifies the namespace id (in hex) passed
 to the driver.
 The default namespace id is the broadcast namespace id (0xffffffff).
+See also \*(Aq\-d sntasmedia\*(Aq for the \*(Aq/sat\*(Aq suffix.
 .Sp
-.I sntrealtek
+.I sntrealtek[/sat]
 \- this device type is for NVMe disks that are behind a Realtek USB to NVMe
 bridge.
+See also \*(Aq\-d sntasmedia\*(Aq for the \*(Aq/sat\*(Aq suffix.
 .Sp
 .\" %ENDIF NOT OS Darwin
 .\" %IF OS Linux

--- a/smartmontools/smartctl.8.in
+++ b/smartmontools/smartctl.8.in
@@ -747,12 +747,16 @@ SCSI bus number.
 .I intelliprop,N[+TYPE]
 \- (deprecated and subject to remove).
 .Sp
-.I jmb39x[\-q],N[,sLBA][,force][+TYPE]
+.I jmb39x[\-q[2]],N[,sLBA][,force][+TYPE]
 \- the device consists of multiple SATA disks connected to a JMicron JMB39x
 RAID port multiplier.
 The suffix \*(Aq\-q\*(Aq selects a slightly different command variant used by
-some QNAP NAS devices.
+QNAP TR-004 NAS devices.
 The integer N is the port number from 0 to 4.
+.br
+[NEW EXPERIMENTAL SMARTCTL 7.5 FEATURE]
+The suffix \*(Aq\-q2\*(Aq selects another command variant used by QNAP TR-002
+NAS devices.
 .br
 \fBWARNING: The ATA pass-through commands are issued via READ/WRITE commands
 to a LBA of the RAID volume.

--- a/smartmontools/smartctl.8.in
+++ b/smartmontools/smartctl.8.in
@@ -1526,7 +1526,7 @@ arguments to this option.
 If your version of smartctl supports 48-bit ATA commands, both the
 General Purpose Log (GPL) and SMART Log (SL) directories are printed in
 one combined table.  The output can be restricted to the GPL directory or
-SL directory by \*(Aq\-l directory,q\*(Aq or \*(Aq\-l directory,s\*(Aq
+SL directory by \*(Aq\-l directory,g\*(Aq or \*(Aq\-l directory,s\*(Aq
 respectively.
 .Sp
 .I background

--- a/smartmontools/smartctl.8.in
+++ b/smartmontools/smartctl.8.in
@@ -400,6 +400,10 @@ Note: This is not the case in SCSI debug output.
 .br
 [NEW EXPERIMENTAL SMARTCTL 7.4 FEATURE]
 The Namespace IEEE EUI-64 (NVMe) is also suppressed.
+.br
+[NEW EXPERIMENTAL SMARTCTL 7.5 FEATURE]
+The Serial Number and World Wide Name from the FARM log (see
+\*(Aq\-l farm\*(Aq below) are also suppressed, except for the debug output.
 .TP
 .B \-d TYPE, \-\-device=TYPE
 Specifies the type of the device.

--- a/smartmontools/smartctl.8.in
+++ b/smartmontools/smartctl.8.in
@@ -233,11 +233,11 @@ in the smartmontools database (see \*(Aq\-v\*(Aq options below).  If so, the
 drive model family may also be printed.
 If \*(Aq\-n\*(Aq (see below) is specified, the power mode of the drive is
 printed.
-.\" %IF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 [NVMe] For NVMe devices the information is obtained from the Identify
 Controller and the Identify Namespace data structure.
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .TP
 .B \-\-identify[=[w][nvb]]
 [ATA only] Prints an annotated table of the IDENTIFY DEVICE data.
@@ -266,12 +266,12 @@ the SMART options which require support for 48-bit ATA commands
 For SCSI, this is equivalent to
 .br
 \*(Aq\-H \-i \-A \-l error \-l selftest\*(Aq.
-.\" %IF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 For NVMe, this is equivalent to
 .br
 \*(Aq\-H \-i \-c \-A \-l error \-l selftest\*(Aq.
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .TP
 .B \-x, \-\-xall
 Prints all SMART and non-SMART information about the device.
@@ -290,12 +290,12 @@ For SCSI disks, this is equivalent to
 \-l defects \-l envrep \-l genstats \-l ssd \-l zdevstat\*(Aq
 .br
 and for SCSI tape drives and changers, add \*(Aq\-l tapedevstat\*(Aq.
-.\" %IF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 For NVMe, this is equivalent to
 .br
 \*(Aq\-H \-i \-c \-A \-l error \-l selftest\*(Aq.
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .TP
 .B \-\-scan
 Scans for devices and prints each device name, device type and protocol
@@ -1182,11 +1182,11 @@ Prefailure SMART Attribute value is less than or equal to its threshold
 [SCSI tape drive or changer] The TapeAlert status is obtained by reading the
 TapeAlert log page, but only if this option is given twice (see
 \fBTAPE DRIVES\fP for the rationale).
-.\" %IF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 [NVMe] NVMe status is obtained by reading the "Critical Warning" byte from
 the SMART/Health Information log.
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .TP
 .B \-c, \-\-capabilities
 [ATA] Prints only the generic SMART capabilities.  These
@@ -1195,11 +1195,11 @@ respond to some of the different SMART commands.  For example it
 shows if the device logs errors, if it supports offline surface
 scanning, and so on.  If the device can carry out self-tests, this
 option also shows the estimated time required to run those tests.
-.\" %IF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 [NVMe] Prints various NVMe device capabilities obtained from the Identify
 Controller and the Identify Namespace data structure.
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .TP
 .B \-A, \-\-attributes
 [ATA] Prints only the vendor specific SMART Attributes.  The Attributes
@@ -1296,7 +1296,7 @@ and start-stop cycle counter log pages.
 Certain vendor specific attributes are listed if recognised.
 The attributes are output in a relatively free format (compared with ATA
 disk attributes).
-.\" %IF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 [NVMe] For NVMe devices the attributes are obtained from the SMART/Health
 Information log.
@@ -1305,7 +1305,7 @@ Information log.
 If the device indicates support for SMART/Health Information per namespace,
 the id of the namespace addressed by the device name is used, otherwise
 the id of the broadcast namespace.
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .TP
 .B \-f FORMAT, \-\-format=FORMAT
 [ATA only] Selects the output format of the attributes:
@@ -1410,7 +1410,7 @@ receives a command which is not implemented or is not valid.
 \- [SCSI] prints the error counter log pages for reads, write and verifies.
 The verify row is only output if it has an element other than zero.
 .Sp
-.\" %IF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .I error[,NUM]
 \- [NVMe] prints the NVMe Error Information log.
 Only the 16 most recent log entries are printed by default.
@@ -1422,7 +1422,7 @@ Note that the contents of this log is not preserved across power cycles or
 controller resets, but the value of \*(AqError Information Log Entries\*(Aq
 from SMART/Health Information log is.
 .Sp
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .I xerror[,NUM][,error]
 \- [ATA only] prints the Extended Comprehensive SMART error log
 (General Purpose Log address 0x03).  Unlike the Summary SMART error
@@ -1475,7 +1475,7 @@ If provided, the SCSI Sense Key (SK), Additional Sense Code (ASC) and
 Additional Sense Code Qualifier (ASCQ) are also printed.  The self tests
 can be run using the \*(Aq\-t\*(Aq option described below (using the ATA
 test terminology).
-.\" %IF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 .I selftest
 \- [NVMe: NEW EXPERIMENTAL SMARTCTL 7.4 FEATURE]
@@ -1484,7 +1484,7 @@ prints the NVMe self-test log.
 [NEW EXPERIMENTAL SMARTCTL 7.5 FIX]
 This always uses the broadcast namespace.
 Self-test results from individual namespaces appear in this single log.
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 .I xselftest[,NUM][,selftest]
 \- [ATA only] prints the Extended SMART self-test log (General Purpose
@@ -1669,7 +1669,7 @@ This command:
 writes a binary representation of the one sector log 0x11
 (SATA Phy Event Counters) to file log.bin.
 .Sp
-.\" %IF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .I nvmelog,PAGE,SIZE
 \- [NVMe only] prints a hex dump of the first SIZE bytes from the NVMe
 log with identifier PAGE.
@@ -1678,7 +1678,7 @@ SIZE is a hexadecimal number in the range from 0x4 to 0x4000 (16 KiB).
 \fBWARNING: Do not specify the identifier of an unknown log page.
 Reading a log page may have undesirable side effects.\fP
 .Sp
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .I ssd
 \- [ATA] prints the Solid State Device Statistics log page.
 This has the same effect as \*(Aq\-l devstat,7\*(Aq, see above.
@@ -2136,12 +2136,12 @@ with other disks use the \*(Aq\-c\*(Aq option to monitor progress.
 .Sp
 .I short
 \- [SCSI] runs the "Background short" self-test.
-.\" %IF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 .I short
 \- [NVMe: NEW EXPERIMENTAL SMARTCTL 7.4 FEATURE]
 runs the "Short" self-test for current namespace.
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 .I long
 \- [ATA] runs SMART Extended Self Test (tens of minutes to several hours).
@@ -2152,12 +2152,12 @@ below).
 .Sp
 .I long
 \- [SCSI] runs the "Background long" self-test.
-.\" %IF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 .I long
 \- [NVMe: NEW EXPERIMENTAL SMARTCTL 7.4 FEATURE]
 runs the "Extended" self-test for current namespace.
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .Sp
 .I conveyance
 \- [ATA only] runs a SMART Conveyance Self Test (minutes).  This

--- a/smartmontools/smartctl.8.in
+++ b/smartmontools/smartctl.8.in
@@ -278,11 +278,15 @@ Prints all SMART and non-SMART information about the device.
 .Sp
 For ATA, this is equivalent to
 .br
-\*(Aq\-H \-i \-g all \-g wcreorder \-c \-A \-f brief \-l xerror,error
+\*(Aq\-H \-i \-g all \-c \-A \-f brief \-l xerror,error
 \-l xselftest,selftest \-l selective \-l directory \-l scttemp \-l scterc
 \-l devstat \-l defects \-l sataphy\*(Aq.
 .br
 If \*(Aq\-a\*(Aq is also specified, add \*(Aq\-l error \-l selftest\*(Aq.
+.br
+[NEW EXPERIMENTAL SMARTCTL 7.5 FIX]
+\*(Aq\-g wcreorder\*(Aq is no longer included because it is not possible
+to check whether this feature is supported by the drive.
 .Sp
 For SCSI disks, this is equivalent to
 .br

--- a/smartmontools/smartctl.8.in
+++ b/smartmontools/smartctl.8.in
@@ -1476,12 +1476,9 @@ test terminology).
 \- [NVMe: NEW EXPERIMENTAL SMARTCTL 7.4 FEATURE]
 prints the NVMe self-test log.
 .br
-[NEW EXPERIMENTAL SMARTCTL 7.5 FEATURE]
-If the device does not support multiple namespaces, the broadcast namespace
-is always used to read the self-test log and to start the tests (see
-\*(Aq\-t TEST\*(Aq below).
-This is because some single namespace devices return failure if namespace 1
-is used to address self-tests.
+[NEW EXPERIMENTAL SMARTCTL 7.5 FIX]
+This always uses the broadcast namespace.
+Self-test results from individual namespaces appear in this single log.
 .\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
 .Sp
 .I xselftest[,NUM][,selftest]

--- a/smartmontools/smartctl.cpp
+++ b/smartmontools/smartctl.cpp
@@ -4,7 +4,7 @@
  * Home page of code is: https://www.smartmontools.org
  *
  * Copyright (C) 2002-11 Bruce Allen
- * Copyright (C) 2008-23 Christian Franke
+ * Copyright (C) 2008-25 Christian Franke
  * Copyright (C) 2000 Michael Cornwell <cornwell@acm.org>
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
@@ -746,7 +746,10 @@ static int parse_options(int argc, char** argv, const char * & type,
       ataopts.smart_logdir = ataopts.gp_logdir = true;
       ataopts.sct_temp_sts = ataopts.sct_temp_hist = true;
       ataopts.sct_erc_get = 1;
-      ataopts.sct_wcache_reorder_get = true;
+      // Don't include '-g wcreorder' because the next ATA command (SMART READ DATA) may fail
+      // if support of SCT FEATURE CONTROL is indicated but the GET WRITE CACHE REORDERING
+      // subcommand fails (ticket #1702).
+      // ataopts.sct_wcache_reorder_get = true;
       ataopts.devstat_all_pages = true;
       ataopts.pending_defects_log = 31;
       ataopts.sataphy = true;

--- a/smartmontools/smartd.8.in
+++ b/smartmontools/smartd.8.in
@@ -448,11 +448,11 @@ this option are:
 .I scsiioctl
 \- report only ioctl() transactions with SCSI devices.
 .Sp
-.\" %IF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .I nvmeioctl
 \- report only ioctl() transactions with NVMe devices.
 .Sp
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
+.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 Any argument may include a positive integer to specify the level of
 detail that should be reported.  The argument should be followed by a
 comma then the integer with no spaces.  For example, \fIataioctl,2\fP

--- a/smartmontools/smartd.8.in
+++ b/smartmontools/smartd.8.in
@@ -1,6 +1,6 @@
 .ig
 Copyright (C) 2002-10 Bruce Allen
-Copyright (C) 2004-23 Christian Franke
+Copyright (C) 2004-25 Christian Franke
 
 SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -181,34 +181,39 @@ Directive in the configuration file; see the \fBsmartd.conf\fP(5) man page).
 .SH OPTIONS
 .TP
 .B \-A PREFIX, \-\-attributelog=PREFIX
-Writes \fBsmartd\fP attribute information (normalized and raw
-attribute values) to files \*(AqPREFIX\*(Aq\*(AqMODEL\-SERIAL.ata.csv\*(Aq
-or \*(AqPREFIX\*(Aq\*(AqVENDOR\-MODEL\-SERIAL.scsi.csv\*(Aq.
-At each check cycle attributes are logged as a line of semicolon separated
-triplets of the form "attribute-ID;attribute-norm-value;attribute-raw-value;".
-For SCSI devices error counters and temperature recorded in the form
-"counter-name;counter-value;".
-Each line is led by a date string of the form "yyyy-mm-dd HH:MM:SS"
-(in local time).
+Writes drive attribute information to files
+.br
+\*(AqPREFIX\*(Aq\*(AqMODEL\-SERIAL[\-NSID].PRT.csv\*(Aq.
+.br
+PREFIX specifies the destination directory if it includes a trailing slash.
+Otherwise its last path component specifies the prefix of the filename.
+The path must be absolute, except if debug mode is enabled.
+MODEL and SERIAL are build from drive identify information, invalid
+characters are replaced by underline.
+NSID is the NVMe namespace id if an individual namespace is addressed.
+PRT is one of \*(Aqata\*(Aq, \*(Aqscsi\*(Aq or \*(Aqnvme\*(Aq.
 .Sp
 .\" %IF ENABLE_ATTRIBUTELOG
 If this option is not specified, attribute information is written to files
-\*(Aq/usr/local/var/lib/smartmontools/attrlog.MODEL\-SERIAL.ata.csv\*(Aq.
+.br
+\*(Aq/usr/local/var/lib/smartmontools/attrlog.MODEL\-SERIAL[\-NSID].PRT.csv\*(Aq.
+.br
 If \*(Aq\-\*(Aq is specified as the argument, attribute log files are
 disabled.
 .Sp
 .\" %ENDIF ENABLE_ATTRIBUTELOG
-MODEL and SERIAL are build from drive identify information, invalid
-characters are replaced by underline.
-.Sp
-If the PREFIX has the form \*(Aq/path/dir/\*(Aq (e.g.\&
-\*(Aq/var/lib/smartd/\*(Aq), then files \*(AqMODEL\-SERIAL.ata.csv\*(Aq are
-created in directory \*(Aq/path/dir\*(Aq.
-If the PREFIX has the form \*(Aq/path/name\*(Aq (e.g.\&
-\*(Aq/var/lib/misc/attrlog\-\*(Aq),
-then files \*(AqnameMODEL\-SERIAL.ata.csv\*(Aq are created in directory
-\*(Aq/path/\*(Aq.
-The path must be absolute, except if debug mode is enabled.
+At each check cycle, attributes are logged as a line of tab separated
+tuples which consists of semicolon separated names or values.
+Each line is led by a date string of the form "yyyy-mm-dd HH:MM:SS"
+(in local time).
+The remaining part is protocol-specific:
+.br
+[ATA] Writes ATA SMART attributes as "id;normalized-value;raw-value;".
+.br
+[SCSI] Writes SCSI error counters and temperature as "name;value;".
+.br
+[NVMe][NEW EXPERIMENTAL SMARTD 7.5 FEATURE]
+Writes NVMe SMART/Health information as "name;value;".
 .TP
 .B \-B [+]FILE, \-\-drivedb=[+]FILE
 [ATA only] Read the drive database from FILE.  The new database replaces
@@ -461,33 +466,26 @@ The default level is 1, so \*(Aq\-r ataioctl,1\*(Aq and
 .TP
 .B \-s PREFIX, \-\-savestates=PREFIX
 Reads/writes \fBsmartd\fP state information from/to files
-\*(AqPREFIX\*(Aq\*(AqMODEL\-SERIAL.ata.state\*(Aq or
-\*(AqPREFIX\*(Aq\*(AqVENDOR\-MODEL\-SERIAL.scsi.state\*(Aq.
-This preserves SMART attributes, drive min and max temperatures (\-W directive),
-info about last sent warning email
-(\-m directive), and the time of next check of the self-test REGEXP
-(\-s directive) across boot cycles.
+.br
+\*(AqPREFIX\*(Aq\*(AqMODEL\-SERIAL[\-NSID].PRT.state\*(Aq.
+.br
+For PREFIX, MODEL, SERIAL, NSID and PRT, see the \*(Aq-A\*(Aq option above.
 .Sp
 .\" %IF ENABLE_SAVESTATES
 If this option is not specified, state information is maintained in files
-\*(Aq/usr/local/var/lib/smartmontools/smartd.MODEL\-SERIAL.ata.state\*(Aq
-for ATA devices and
-\*(Aq/usr/local/var/lib/smartmontools/smartd.VENDOR\-MODEL\-SERIAL.scsi.state\*(Aq
-for SCSI devices.
+.br
+\*(Aq/usr/local/var/lib/smartmontools/smartd.MODEL\-SERIAL[\-NSID].PRT.state\*(Aq.
+.br
 If \*(Aq\-\*(Aq is specified as the argument, state files are disabled.
 .Sp
 .\" %ENDIF ENABLE_SAVESTATES
-MODEL and SERIAL are build from drive identify information, invalid
-characters are replaced by underline.
-.Sp
-If the PREFIX has the form \*(Aq/path/dir/\*(Aq (e.g.\&
-\*(Aq/var/lib/smartd/\*(Aq), then files \*(AqMODEL\-SERIAL.ata.state\*(Aq are
-created in directory \*(Aq/path/dir\*(Aq.
-If the PREFIX has the form \*(Aq/path/name\*(Aq (e.g.\&
-\*(Aq/var/lib/misc/smartd\-\*(Aq),
-then files \*(AqnameMODEL\-SERIAL.ata.state\*(Aq are created in directory
-\*(Aq/path/\*(Aq.
-The path must be absolute, except if debug mode is enabled.
+The state information files preserve various information across smartd
+restarts, for example:
+SMART attributes, drive min and max temperatures (\*(Aq\-W\*(Aq directive),
+info about last sent warning email (\*(Aq\-m\*(Aq directive),
+the time of next check of the self-test REGEXP (\*(Aq\-s\*(Aq directive),
+and info about the last reported error log entries
+(\*(Aq\-l [x]error\*(Aq directives).
 .Sp
 The state information files are read on smartd startup.  The files are
 always (re)written after reading the configuration file, before rereading

--- a/smartmontools/smartd.8.in
+++ b/smartmontools/smartd.8.in
@@ -453,11 +453,9 @@ this option are:
 .I scsiioctl
 \- report only ioctl() transactions with SCSI devices.
 .Sp
-.\" %IF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 .I nvmeioctl
 \- report only ioctl() transactions with NVMe devices.
 .Sp
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD OpenBSD Windows Cygwin
 Any argument may include a positive integer to specify the level of
 detail that should be reported.  The argument should be followed by a
 comma then the integer with no spaces.  For example, \fIataioctl,2\fP

--- a/smartmontools/smartd.8.in
+++ b/smartmontools/smartd.8.in
@@ -212,7 +212,7 @@ The remaining part is protocol-specific:
 .br
 [SCSI] Writes SCSI error counters and temperature as "name;value;".
 .br
-[NVMe][NEW EXPERIMENTAL SMARTD 7.5 FEATURE]
+[NVMe: NEW EXPERIMENTAL SMARTD 7.5 FEATURE]
 Writes NVMe SMART/Health information as "name;value;".
 .TP
 .B \-B [+]FILE, \-\-drivedb=[+]FILE

--- a/smartmontools/smartd.conf.5.in
+++ b/smartmontools/smartd.conf.5.in
@@ -364,7 +364,6 @@ from issuing SCSI commands to an ATA device.
 from issuing ATA commands to a SCSI device.
 .Sp
 .\" %ENDIF NOT OS Darwin
-.\" %IF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
 .I nvme[,NSID]
 \- the device type is NVM Express (NVMe).
 The optional parameter NSID specifies the namespace id (in hex) passed
@@ -372,7 +371,6 @@ to the driver.
 Use 0xffffffff for the broadcast namespace id.
 The default for NSID is the namespace id addressed by the device name.
 .Sp
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
 .\" %IF NOT OS Darwin
 .I sat[,auto][,N]
 \- the device type is SCSI to ATA Translation (SAT).
@@ -708,13 +706,11 @@ Qualifier (ASCQ) from Informal Exceptions (IE) log page (if supported)
 and/or from SCSI sense data.
 Note: for historical reasons, this check is always done for SCSI devices,
 regardless of the \*(Aq-H\*(Aq directive.
-.\" %IF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
 .Sp
 [NVMe] Checks the "Critical Warning" byte from the SMART/Health
 Information log.
 If any warning bit is set, a message at loglevel LOG_CRIT will be logged to
 syslog.
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
 .TP
 .B \-l TYPE
 Reports increases in the number of errors in one of three SMART logs.  The
@@ -724,7 +720,6 @@ valid arguments to this Directive are:
 \- [ATA] report if the number of ATA errors reported in the Summary SMART
 error log has increased since the last check.
 .Sp
-.\" %IF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
 .I error
 \- [NVMe] report if the "Number of Error Information Log Entries" from the
 SMART/Health Information log has increased since the last check.
@@ -743,7 +738,6 @@ message is generated instead.
 This avoids misleading warnings if the operating system issues unsupported
 commands and the device firmware also logs these kind of errors.
 .Sp
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
 .I xerror
 \- [ATA] report if the number of ATA errors reported in the Extended
 Comprehensive SMART error log has increased since the last check.
@@ -753,10 +747,8 @@ checks the maximum of both values.
 .Sp
 [Please see the \fBsmartctl \-l xerror\fP command-line option.]
 .Sp
-.\" %IF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
 .I xerror
 \- [NVMe] same as \*(Aq\-l error\*(Aq.
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
 .Sp
 .I selftest
 \- [ATA] [SCSI] [NVMe: NEW EXPERIMENTAL SMARTD 7.5 FEATURE]
@@ -1595,7 +1587,6 @@ To combine all of the above reports, use:
 default.
 This can be changed to Attribute 9 or 220 by the drive database or by
 the \*(Aq\-v 9,temp\*(Aq or \*(Aq\-v 220,temp\*(Aq directive.
-.\" %IF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
 .Sp
 [NVMe] smartd checks the Composite Temperature value reported by the
 SMART/HealthInformation log.
@@ -1603,7 +1594,6 @@ SMART/HealthInformation log.
 [NEW EXPERIMENTAL SMARTD 7.5 FIX]
 The individual Temperature Sensor values are no longer checked because
 some devices use these to report other values like maximum temperature.
-.\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
 .TP
 .B \-F TYPE
 [ATA only] Modifies the behavior of \fBsmartd\fP to compensate for some

--- a/smartmontools/smartd.conf.5.in
+++ b/smartmontools/smartd.conf.5.in
@@ -291,6 +291,11 @@ Symbolic links are resolved before this check is done.
 A device name is also ignored if another device with same identify
 information (vendor, model, firmware version, serial number, WWN) already
 exists.
+.PP
+[NVMe: NEW EXPERIMENTAL SMARTD 7.5 FEATURE]
+If a device only supports a single namespace and a configuration line
+which addresses its namespace id already exists, a DEVICESCAN result which
+does not address a namespace is also ignored (and vice versa).
 .Sp
 .SH DEFAULT SETTINGS
 If an entry in the configuration file starts with

--- a/smartmontools/smartd.conf.5.in
+++ b/smartmontools/smartd.conf.5.in
@@ -692,7 +692,7 @@ starts up and has no further effect.  The valid arguments to this
 Directive are \fIon\fP and \fIoff\fP.  Also affects SCSI devices.
 [Please see the \fBsmartctl \-S\fP command-line option.]
 .TP
-.B \-H
+.B \-H [MASK]
 Check the health status of the disk.
 If the disk reports a failing health status, a message at loglevel LOG_CRIT
 will be logged to syslog.
@@ -700,17 +700,28 @@ will be logged to syslog.
 .Sp
 [ATA] Checks the (boolean) result returned by the SMART RETURN STATUS
 command.
+The optional parameter MASK is ignored.
 .Sp
 [SCSI] Checks the Additional Sense Code (ASC) and Additional Sense Code
 Qualifier (ASCQ) from Informal Exceptions (IE) log page (if supported)
 and/or from SCSI sense data.
+The optional parameter MASK is ignored.
+.br
 Note: for historical reasons, this check is always done for SCSI devices,
-regardless of the \*(Aq-H\*(Aq directive.
+regardless of the \*(Aq\-H\*(Aq directive.
 .Sp
 [NVMe] Checks the "Critical Warning" byte from the SMART/Health
 Information log.
 If any warning bit is set, a message at loglevel LOG_CRIT will be logged to
 syslog.
+.br
+[NVMe: NEW EXPERIMENTAL SMARTD 7.5 FEATURE]
+If the optional parameter MASK (hexadecimal) is specified, the check is
+limited to the warning bits set in MASK.
+For example if \*(Aq\-H 0xf9\*(Aq is specified, the warning bit 1
+("temperature out of range") and bit 2 ("reliability degraded") will be
+ignored.
+\*(Aq\-H 0xff\*(Aq is the same as \*(Aq\-H\*(Aq without a parameter.
 .TP
 .B \-l TYPE
 Reports increases in the number of errors in one of three SMART logs.  The

--- a/smartmontools/smartd.conf.5.in
+++ b/smartmontools/smartd.conf.5.in
@@ -1,6 +1,6 @@
 .ig
 Copyright (C) 2002-10 Bruce Allen
-Copyright (C) 2004-23 Christian Franke
+Copyright (C) 2004-24 Christian Franke
 
 SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -768,11 +768,12 @@ checks the maximum of both values.
 .\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
 .Sp
 .I selftest
-\- report if the number of failed tests reported in the SMART
-Self-Test Log has increased since the last check, or if the timestamp
-associated with the most recent failed test has increased.  Note that
-such errors will \fBonly\fP be logged if you run self-tests on the
-disk (and it fails a test!).  Self-Tests can be run automatically by
+\- [ATA] [SCSI] [NVMe: NEW EXPERIMENTAL SMARTD 7.5 FEATURE]
+report if the number of failed tests reported in the SMART Self-Test Log
+has increased since the last check, or if the timestamp associated with
+the most recent failed test has increased.
+Note that such errors will \fBonly\fP be logged if you run self-tests on
+the disk (and it fails a test!).  Self-Tests can be run automatically by
 \fBsmartd\fP: please see the \*(Aq\-s\*(Aq Directive below.
 Self-Tests can also be run manually by using the \*(Aq\-t short\*(Aq
 and \fB\*(Aq\-t\ long\*(Aq\fP options of \fBsmartctl\fP and the results of
@@ -781,10 +782,18 @@ command-line option.
 [Please see the \fBsmartctl \-l\fP and \fB\-t\fP command-line
 options.]
 .Sp
-[ATA only] Failed self-tests outdated by a newer successful extended
-self-test are ignored.  The warning email counter is reset if the
-number of failed self tests dropped to 0.  This typically happens when
-an extended self-test is run after all bad sectors have been reallocated.
+[ATA] [NVMe: NEW EXPERIMENTAL SMARTD 7.5 FEATURE]
+Failed self-tests outdated by a newer successful extended self-test
+are ignored.
+The warning email counter is reset if the number of failed self tests
+dropped to 0.
+This typically happens when an extended self-test is run after all bad
+blocks have been reallocated.
+.Sp
+[NVMe: NEW EXPERIMENTAL SMARTD 7.5 FEATURE]
+If the device name addresses an individual namespace, log entries with
+different namespace ids are ignored.
+Entries with unspecified or broadcast namespace id are always checked.
 .Sp
 .I offlinests[,ns]
 \- [ATA only] report if the Offline Data Collection status has changed
@@ -803,22 +812,23 @@ Data Collection is in progress.  See \*(Aq\-l selfteststs,ns\*(Aq below.
 .\" %ENDIF OS Cygwin Windows
 .Sp
 .I selfteststs[,ns]
-\- [ATA only] report if the Self-Test execution status has changed
-since the last check.  The report will be logged as LOG_CRIT if the new
-status indicates an error.
+\- [ATA] [NVMe: NEW EXPERIMENTAL SMARTD 7.5 FEATURE]
+report if the Self-Test execution status has changed since the last check.
+The report will be logged as LOG_CRIT if the new status indicates an error.
 .\" %IF NOT OS Cygwin Windows
 .\"! Appending ',ns' (no standby) to this directive is not implemented
 .\"! on OS_MAN_FILTER.
 .\" %ENDIF NOT OS Cygwin Windows
 .\" %IF OS Cygwin Windows
 .Sp
-[Windows and Cygwin only] If \*(Aq,ns\*(Aq (no standby) is appended to this
-directive, smartd disables system auto standby as long as a Self-Test
-is in progress.  This prevents that a Self-Test is aborted because the
-OS sets the system to a standby/sleep mode when idle.  Smartd check
-interval (\*(Aq\-i\*(Aq option) should be shorter than the configured idle
-timeout.  Auto standby is not disabled if the system is running on
-battery.
+[ATA only] [Windows and Cygwin only]
+If \*(Aq,ns\*(Aq (no standby) is appended to this directive, smartd disables
+system auto standby as long as a Self-Test is in progress.
+This prevents that a Self-Test is aborted because the OS sets the system to
+a standby/sleep mode when idle.
+Smartd check interval (\*(Aq\-i\*(Aq option) should be shorter than the
+configured idle timeout.
+Auto standby is not disabled if the system is running on battery.
 .\" %ENDIF OS Cygwin Windows
 .Sp
 .I scterc,READTIME,WRITETIME
@@ -871,6 +881,13 @@ only), and \*(AqO\*(Aq for an \fBO\fPffline Immediate Test (ATA only).  As
 soon as a match is found, the test will be started and no additional
 matches will be sought for that device and that polling cycle.
 .Sp
+[NVMe: NEW EXPERIMENTAL SMARTD 7.5 FEATURE]
+For NVMe devices with Self-Test support, use \*(AqL\*(Aq to start an
+"Extended" NVMe Self-Test and \*(AqS\*(Aq for a \fBS\fPhort NVMe Self-Test.
+If the device name addresses an individial namespace, the test will be started
+using this namespace id, otherwise using the broadcast namespace id.
+.Sp
+[ATA only]
 To run scheduled Selective Self-Tests, use \*(Aqn\*(Aq for \fBn\fPext span,
 \*(Aqr\*(Aq to \fBr\fPedo last span, or \*(Aqc\*(Aq to \fBc\fPontinue with
 next span or redo last span based on status of last test.

--- a/smartmontools/smartd.conf.5.in
+++ b/smartmontools/smartd.conf.5.in
@@ -339,38 +339,8 @@ configuration file.  Note that
 The Directives below may appear in any order, following the device
 name.
 .PP
-.B For an ATA device,
-if no Directives appear, then the device will be monitored
-as if the \*(Aq\-a\*(Aq Directive (monitor all SMART properties) had been given.
-.PP
-.B If a SCSI disk is listed,
-it will be monitored at the maximum implemented level: roughly
-equivalent to using the \*(Aq\-H \-l selftest\*(Aq options for an ATA disk.
-So with the exception of \*(Aq\-d\*(Aq, \*(Aq\-m\*(Aq, \*(Aq\-l selftest\*(Aq,
-\*(Aq\-s\*(Aq, and \*(Aq\-M\*(Aq, the Directives below are ignored for SCSI disks.
-For SCSI disks, the \*(Aq\-m\*(Aq Directive sends a warning email if the SMART
-status indicates a disk failure or problem, if the SCSI inquiry about disk
-status fails, or if new errors appear in the self-test log.
-.\" %IF OS FreeBSD Linux
-.PP
-.B If a 3ware controller is used
-then the corresponding SCSI (/dev/sd?) or character device (/dev/twe?,
-/dev/twa?, /dev/twl? or /dev/tws?) must be listed, along with the
-\*(Aq\-d 3ware,N\*(Aq Directive (see below).
-The individual ATA disks hosted by the 3ware controller appear to \fBsmartd\fP
-as normal ATA devices.
-Hence all the ATA directives can be used for these disks (but see note below).
-.PP
-.B If an Areca controller is used
-then the corresponding device (SCSI /dev/sg? on Linux or /dev/arcmsr0 on
-FreeBSD) must be listed, along with the \*(Aq\-d areca,N\*(Aq Directive
-(see below).
-The individual SATA disks hosted by the Areca controller appear to \fBsmartd\fP
-as normal ATA devices.  Hence all the ATA directives can be used for
-these disks.  Areca firmware version 1.46 or later which supports
-smartmontools must be used; Please see the \fBsmartctl\fP(8) man page
-for further details.
-.\" %ENDIF OS FreeBSD Linux
+If no Directives appear, then the device will be monitored as if the \*(Aq\-a\*(Aq
+Directive had been given.
 .TP
 .B \-d TYPE
 Specifies the type of the device.

--- a/smartmontools/smartd.conf.5.in
+++ b/smartmontools/smartd.conf.5.in
@@ -1591,13 +1591,18 @@ To combine all of the above reports, use:
 .br
 .B \-W 2,40,45
 .Sp
-For ATA devices, smartd interprets Attribute 194 or 190 as Temperature Celsius
-by default.  This can be changed to Attribute 9 or 220 by the drive
-database or by the \*(Aq\-v 9,temp\*(Aq or \*(Aq\-v 220,temp\*(Aq directive.
+[ATA] smartd interprets Attribute 194 or 190 as Temperature Celsius by
+default.
+This can be changed to Attribute 9 or 220 by the drive database or by
+the \*(Aq\-v 9,temp\*(Aq or \*(Aq\-v 220,temp\*(Aq directive.
 .\" %IF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
 .Sp
-For NVMe devices, smartd checks the maximum of the Composite Temperature value
-and all Temperature Sensor values reported by SMART/Health Information log.
+[NVMe] smartd checks the Composite Temperature value reported by the
+SMART/HealthInformation log.
+.br
+[NEW EXPERIMENTAL SMARTD 7.5 FIX]
+The individual Temperature Sensor values are no longer checked because
+some devices use these to report other values like maximum temperature.
 .\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
 .TP
 .B \-F TYPE

--- a/smartmontools/smartd.conf.5.in
+++ b/smartmontools/smartd.conf.5.in
@@ -725,20 +725,25 @@ Directive are \fIon\fP and \fIoff\fP.  Also affects SCSI devices.
 [Please see the \fBsmartctl \-S\fP command-line option.]
 .TP
 .B \-H
-[ATA] Check the health status of the disk with the SMART RETURN
-STATUS command.
-If this command reports a failing health status, then disk
-failure is predicted in less than 24 hours, and a message at loglevel
-.B \*(AqLOG_CRIT\*(Aq
-will be logged to syslog.  [Please see the
-.B smartctl \-H
-command-line option.]
+Check the health status of the disk.
+If the disk reports a failing health status, a message at loglevel LOG_CRIT
+will be logged to syslog.
+[Please see the \fBsmartctl \-H\fP command-line option.]
+.Sp
+[ATA] Checks the (boolean) result returned by the SMART RETURN STATUS
+command.
+.Sp
+[SCSI] Checks the Additional Sense Code (ASC) and Additional Sense Code
+Qualifier (ASCQ) from Informal Exceptions (IE) log page (if supported)
+and/or from SCSI sense data.
+Note: for historical reasons, this check is always done for SCSI devices,
+regardless of the \*(Aq-H\*(Aq directive.
 .\" %IF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
 .Sp
 [NVMe] Checks the "Critical Warning" byte from the SMART/Health
 Information log.
-If any warning bit is set, a message at loglevel \fB\*(AqLOG_CRIT\*(Aq\fP
-will be logged to syslog.
+If any warning bit is set, a message at loglevel LOG_CRIT will be logged to
+syslog.
 .\" %ENDIF OS Darwin FreeBSD Linux NetBSD Windows Cygwin
 .TP
 .B \-l TYPE
@@ -1425,29 +1430,37 @@ SMARTD_SUBJECT and SMARTD_FULLMESSAGE
 are set by the script before running the executable.
 .TP
 .B \-f
-[ATA only] Check for \*(Aqfailure\*(Aq of any Usage Attributes.  If these
+[ATA] Check for \*(Aqfailure\*(Aq of any Usage Attributes.  If these
 Attributes are less than or equal to the threshold, it does NOT indicate
 imminent disk failure.  It "indicates an advisory condition where the usage
 or age of the device has exceeded its intended design life period."
 [Please see the \fBsmartctl \-A\fP command-line option.]
+.Sp
+[NVMe] Log a message with LOG_CRIT level and send a warning email if the
+SMART/Health value "Percentage Used" has changed and exceeds 95 percent
+or "Media and Data Integrity Errors" has increased.
 .TP
 .B \-p
-[ATA only] Report anytime that a Prefail Attribute has changed
-its value since the last check.  [Please see the
-.B smartctl \-A
-command-line option.]
+[ATA] Report anytime that a Prefail Attribute has changed its value since the
+last check.
+[Please see the \fBsmartctl \-A\fP command-line option.]
+.Sp
+[NVMe] Report anytime that the SMART/Health value "Available Spare" has
+changed its value since the last check.
+This will be logged with LOG_CRIT level and a warning email will be sent if
+the value is below "Available Spare Threshold".
 .TP
 .B \-u
-[ATA only] Report anytime that a Usage Attribute has changed its value
-since the last check.  [Please see the
-.B smartctl \-A
-command-line option.]
+[ATA] Report anytime that a Usage Attribute has changed its value since the
+last check.
+[Please see the \fBsmartctl \-A\fP command-line option.]
+.Sp
+[NVMe] Report anytime that the SMART/Health value "Percentage Used" or "Media
+and Data Integrity Errors" has changed its value since the last check.
 .TP
 .B \-t
-[ATA only] Equivalent to turning on the two previous flags \*(Aq\-p\*(Aq
-and \*(Aq\-u\*(Aq.
-Tracks changes in \fIall\fP device Attributes (both Prefailure and
-Usage).  [Please see the \fBsmartctl\fP \-A command-line option.]
+Equivalent to turning on the two previous flags \*(Aq\-p\*(Aq and
+\*(Aq\-u\*(Aq.
 .TP
 .B \-i ID
 [ATA only] Ignore device Attribute number \fBID\fP when checking for failure
@@ -1574,10 +1587,11 @@ Report if the current temperature had changed by at least \fBDIFF\fP
 degrees since last report, or if new min or max temperature is detected.
 Report or Warn if the temperature is greater or equal than one of
 \fBINFO\fP or \fBCRIT\fP degrees Celsius.
-If the limit \fBCRIT\fP is reached, a message with loglevel
-\fB\*(AqLOG_CRIT\*(Aq\fP will be logged to syslog and a warning email
-will be send if \*(Aq\-m\*(Aq is specified.  If only the limit \fBINFO\fP is
-reached, a message with loglevel \fB\*(AqLOG_INFO\*(Aq\fP will be logged.
+If the limit \fBCRIT\fP is reached, a message with loglevel LOG_CRIT will be
+logged to syslog and a warning email will be send if \*(Aq\-m\*(Aq is
+specified.
+If only the limit \fBINFO\fP is reached, a message with loglevel LOG_INFO
+will be logged.
 .Sp
 The warning email counter is reset if the temperature dropped below
 \fBINFO\fP or \fBCRIT\fP-5 if \fBINFO\fP is not specified.
@@ -1703,25 +1717,13 @@ command-line option.]
 .TP
 .B \-a
 Equivalent to turning on all of the following Directives:
-.B \*(Aq\-H\*(Aq
-to check the SMART health status,
-.B \*(Aq\-f\*(Aq
-to report failures of Usage (rather than Prefail) Attributes,
-.B \*(Aq\-t\*(Aq
-to track changes in both Prefailure and Usage Attributes,
-.B \*(Aq\-l\ error\*(Aq
-to report increases in the number of ATA errors,
-.B \*(Aq\-l\ selftest\*(Aq
-to report increases in the number of Self-Test Log errors,
-.B \*(Aq\-l\ selfteststs\*(Aq
-to report changes of Self-Test execution status,
-.B \*(Aq\-C 197\*(Aq
-to report nonzero values of the current pending sector count, and
-.B \*(Aq\-U 198\*(Aq
-to report nonzero values of the offline pending sector count.
+.br
+\*(Aq\-H \-f \-t \-l error \-l selftest \-l selfteststs\*(Aq
+.br
+If none of the above is given, then \*(Aq\-a\*(Aq is assumed.
 .Sp
-Note that \-a is the default for ATA devices.  If none of these other
-Directives is given, then \-a is assumed.
+[ATA only] Note: for historical reasons, \*(Aq-C 197 -U 198\*(Aq are also set
+by default.
 .TP
 .B \-c OPTION=VALUE
 Allows one to override \fBsmartd\fP command line options for specific devices.

--- a/smartmontools/smartd.conf.5.in
+++ b/smartmontools/smartd.conf.5.in
@@ -579,12 +579,16 @@ Please see the \fBsmartctl\fP(8) man page for further details.
 .I intelliprop,N[+TYPE]
 \- (deprecated and subject to remove).
 .Sp
-.I jmb39x[\-q],N[,sLBA][,force][+TYPE]
+.I jmb39x[\-q[2]],N[,sLBA][,force][+TYPE]
 \- the device consists of multiple SATA disks connected to a JMicron JMB39x
 RAID port multiplier.
 The suffix \*(Aq\-q\*(Aq selects a slightly different command variant used by
-some QNAP NAS devices.
+QNAP TR-004 NAS devices.
 The integer N is the port number from 0 to 4.
+.br
+[NEW EXPERIMENTAL SMARTD 7.5 FEATURE]
+The suffix \*(Aq\-q2\*(Aq selects another command variant used by QNAP TR-002
+NAS devices.
 Please see the \fBsmartctl\fP(8) man page for further details.
 .Sp
 .I jms56x,N[,sLBA][,force][+TYPE]

--- a/smartmontools/smartd.conf.5.in
+++ b/smartmontools/smartd.conf.5.in
@@ -1,6 +1,6 @@
 .ig
 Copyright (C) 2002-10 Bruce Allen
-Copyright (C) 2004-24 Christian Franke
+Copyright (C) 2004-25 Christian Franke
 
 SPDX-License-Identifier: GPL-2.0-or-later
 
@@ -464,20 +464,27 @@ PL2571/2771/2773/2775 USB to SATA bridge.
 \- this device type is for SATA disks that are behind a SunplusIT USB to SATA
 bridge.
 .Sp
-.I sntasmedia
+.I sntasmedia[/sat]
 \- this device type is for NVMe disks that are behind an ASMedia USB to NVMe
 bridge.
+.br
+[NEW EXPERIMENTAL SMARTD 7.5 FEATURE]
+If the \*(Aq/sat\*(Aq suffix is specified and the NVMe Identify Controller
+command fails, the device type is changed to \*(Aq\-d sat\*(Aq.
+This is useful for USB M.2 adapters which support NVMe and SATA devices.
 .Sp
-.I sntjmicron[,NSID]
+.I sntjmicron[,NSID][/sat]
 \- this device type is for NVMe disks that are behind a JMicron USB to NVMe
 bridge.
 The optional parameter NSID specifies the namespace id (in hex) passed
 to the driver.
 The default namespace id is the broadcast namespace id (0xffffffff).
+See also \*(Aq\-d sntasmedia\*(Aq for the \*(Aq/sat\*(Aq suffix.
 .Sp
-.I sntrealtek
+.I sntrealtek[/sat]
 \- this device type is for NVMe disks that are behind a Realtek USB to NVMe
 bridge.
+See also \*(Aq\-d sntasmedia\*(Aq for the \*(Aq/sat\*(Aq suffix.
 .Sp
 .\" %ENDIF NOT OS Darwin
 .\" %IF OS Linux

--- a/smartmontools/smartd.conf.5.in
+++ b/smartmontools/smartd.conf.5.in
@@ -1398,7 +1398,8 @@ imminent disk failure.  It "indicates an advisory condition where the usage
 or age of the device has exceeded its intended design life period."
 [Please see the \fBsmartctl \-A\fP command-line option.]
 .Sp
-[NVMe] Log a message with LOG_CRIT level and send a warning email if the
+[NVMe: NEW EXPERIMENTAL SMARTD 7.5 FEATURE]
+Log a message with LOG_CRIT level and send a warning email if the
 SMART/Health value "Percentage Used" has changed and exceeds 95 percent
 or "Media and Data Integrity Errors" has increased.
 .TP
@@ -1407,7 +1408,8 @@ or "Media and Data Integrity Errors" has increased.
 last check.
 [Please see the \fBsmartctl \-A\fP command-line option.]
 .Sp
-[NVMe] Report anytime that the SMART/Health value "Available Spare" has
+[NVMe: NEW EXPERIMENTAL SMARTD 7.5 FEATURE]
+Report anytime that the SMART/Health value "Available Spare" has
 changed its value since the last check.
 This will be logged with LOG_CRIT level and a warning email will be sent if
 the value is below "Available Spare Threshold".
@@ -1417,7 +1419,8 @@ the value is below "Available Spare Threshold".
 last check.
 [Please see the \fBsmartctl \-A\fP command-line option.]
 .Sp
-[NVMe] Report anytime that the SMART/Health value "Percentage Used" or "Media
+[NVMe: NEW EXPERIMENTAL SMARTD 7.5 FEATURE]
+Report anytime that the SMART/Health value "Percentage Used" or "Media
 and Data Integrity Errors" has changed its value since the last check.
 .TP
 .B \-t

--- a/smartmontools/smartd.cpp
+++ b/smartmontools/smartd.cpp
@@ -4421,7 +4421,7 @@ static void ToggleDebugMode()
 }
 #endif
 
-time_t calc_next_wakeuptime(time_t wakeuptime, time_t timenow, int ct)
+static time_t calc_next_wakeuptime(time_t wakeuptime, time_t timenow, int ct)
 {
   if (timenow < wakeuptime)
     return wakeuptime;

--- a/smartmontools/smartd.cpp
+++ b/smartmontools/smartd.cpp
@@ -3946,7 +3946,14 @@ static int SCSICheckDevice(const dev_config & cfg, dev_state & state, scsi_devic
     if (testtype)
       DoSCSISelfTest(cfg, state, scsidev, testtype);
   }
+
   if (!cfg.attrlog_file.empty()){
+    state.scsi_error_counters[0] = {};
+    state.scsi_error_counters[1] = {};
+    state.scsi_error_counters[2] = {};
+    state.scsi_nonmedium_error = {};
+    bool found = false;
+
     // saving error counters to state
     uint8_t tBuf[252];
     if (state.ReadECounterPageSupported && (0 == scsiLogSense(scsidev,
@@ -3954,31 +3961,38 @@ static int SCSICheckDevice(const dev_config & cfg, dev_state & state, scsi_devic
       scsiDecodeErrCounterPage(tBuf, &state.scsi_error_counters[0].errCounter,
                                scsiLogRespLen);
       state.scsi_error_counters[0].found=1;
+      found = true;
     }
     if (state.WriteECounterPageSupported && (0 == scsiLogSense(scsidev,
       WRITE_ERROR_COUNTER_LPAGE, 0, tBuf, sizeof(tBuf), 0))) {
       scsiDecodeErrCounterPage(tBuf, &state.scsi_error_counters[1].errCounter,
                                scsiLogRespLen);
       state.scsi_error_counters[1].found=1;
+      found = true;
     }
     if (state.VerifyECounterPageSupported && (0 == scsiLogSense(scsidev,
       VERIFY_ERROR_COUNTER_LPAGE, 0, tBuf, sizeof(tBuf), 0))) {
       scsiDecodeErrCounterPage(tBuf, &state.scsi_error_counters[2].errCounter,
                                scsiLogRespLen);
       state.scsi_error_counters[2].found=1;
+      found = true;
     }
     if (state.NonMediumErrorPageSupported && (0 == scsiLogSense(scsidev,
       NON_MEDIUM_ERROR_LPAGE, 0, tBuf, sizeof(tBuf), 0))) {
       scsiDecodeNonMediumErrPage(tBuf, &state.scsi_nonmedium_error.nme,
                                  scsiLogRespLen);
       state.scsi_nonmedium_error.found=1;
+      found = true;
     }
     // store temperature if not done by CheckTemperature() above
     if (!(cfg.tempdiff || cfg.tempinfo || cfg.tempcrit))
       state.temperature = currenttemp;
+
+    if (found || state.temperature)
+      state.attrlog_valid = 2; // SCSI attributes valid
   }
+
   CloseDevice(scsidev, name);
-  state.attrlog_valid = 2; // SCSI attributes valid
   return 0;
 }
 

--- a/smartmontools/smartd.cpp
+++ b/smartmontools/smartd.cpp
@@ -873,11 +873,11 @@ static void write_nvme_attrlog(FILE * f, const dev_state & state)
   const nvme_smart_log & s = state.nvme_smartval;
   // Names similar to smartctl JSON output with '-' instead of '_'
   fprintf(f,
-    "\tcritical-warning;%u;"
-    "\ttemperature;%u;"
-    "\tavailable-spare;%u;"
-    "\tavailable-spare-threshold;%u;"
-    "\tpercent-used;%u;"
+    "\tcritical-warning;%d;"
+    "\ttemperature;%d;"
+    "\tavailable-spare;%d;"
+    "\tavailable-spare-threshold;%d;"
+    "\tpercentage-used;%d;"
     "\tdata-units-read;%" PRIu64 ";"
     "\tdata-units-written;%" PRIu64 ";"
     "\thost-reads;%" PRIu64 ";"

--- a/smartmontools/smartd.cpp
+++ b/smartmontools/smartd.cpp
@@ -502,6 +502,10 @@ struct persistent_dev_state
 
   // NVMe only
   uint64_t nvme_err_log_entries{};
+
+  // NVMe SMART/Health information: only the fields avail_spare,
+  // percent_used and media_errors are persistent.
+  nvme_smart_log nvme_smartval{};
 };
 
 /// Non-persistent state data for a device.
@@ -553,8 +557,6 @@ struct temp_dev_state
   // NVMe only
   uint8_t selftest_op{};                  // last self-test operation
   uint8_t selftest_compl{};               // last self-test completion
-
-  nvme_smart_log nvme_smartval{};         // NVMe SMART/Health information for attrlog
 };
 
 /// Runtime state data for a device.
@@ -619,6 +621,21 @@ void dev_state::update_temp_state()
   }
 }
 
+// Convert 128 bit LE integer to uint64_t or its max value on overflow.
+static uint64_t le128_to_uint64(const unsigned char (& val)[16])
+{
+  if (sg_get_unaligned_le64(val + 8))
+    return ~(uint64_t)0;
+  return sg_get_unaligned_le64(val);
+}
+
+// Convert uint64_t to 128 bit LE integer
+static void uint64_to_le128(unsigned char (& destval)[16], uint64_t srcval)
+{
+  sg_put_unaligned_le64(0, destval + 8);
+  sg_put_unaligned_le64(srcval, destval);
+}
+
 // Parse a line from a state file.
 static bool parse_dev_state_line(const char * line, persistent_dev_state & state)
 {
@@ -647,11 +664,14 @@ static bool parse_dev_state_line(const char * line, persistent_dev_state & state
        ")" // 18)
       ")" // 16)
      "|(nvme-err-log-entries)" // (24)
+     "|(nvme-available-spare)" // (25)
+     "|(nvme-percentage-used)" // (26)
+     "|(nvme-media-errors)" // (27)
      ")" // 1)
-     " *= *([0-9]+)[ \n]*$" // (25)
+     " *= *([0-9]+)[ \n]*$" // (28)
   );
 
-  const int nmatch = 1+25;
+  constexpr int nmatch = 1+28;
   regular_expression::match_range match[nmatch];
   if (!regex.execute(line, nmatch, match))
     return false;
@@ -709,8 +729,14 @@ static bool parse_dev_state_line(const char * line, persistent_dev_state & state
     else
       return false;
   }
-  else if (match[m+7].rm_so >= 0)
+  else if (match[m+=7].rm_so >= 0)
     state.nvme_err_log_entries = val;
+  else if (match[++m].rm_so >= 0)
+    state.nvme_smartval.avail_spare = val;
+  else if (match[++m].rm_so >= 0)
+    state.nvme_smartval.percent_used = val;
+  else if (match[++m].rm_so >= 0)
+    uint64_to_le128(state.nvme_smartval.media_errors, val);
   else
     return false;
   return true;
@@ -817,6 +843,9 @@ static bool write_dev_state(const char * path, const persistent_dev_state & stat
 
   // NVMe only
   write_dev_state_line(f, "nvme-err-log-entries", state.nvme_err_log_entries);
+  write_dev_state_line(f, "nvme-available-spare", state.nvme_smartval.avail_spare);
+  write_dev_state_line(f, "nvme-percentage-used", state.nvme_smartval.percent_used);
+  write_dev_state_line(f, "nvme-media-errors", le128_to_uint64(state.nvme_smartval.media_errors));
 
   return true;
 }
@@ -858,14 +887,6 @@ static void write_scsi_attrlog(FILE * f, const dev_state & state)
   // write SCSI current temperature if it is monitored
   if (state.temperature)
     fprintf(f, "\ttemperature;%d;", state.temperature);
-}
-
-// Convert 128 bit LE integer to uint64_t or its max value on overflow.
-static uint64_t le128_to_uint64(const unsigned char (& val)[16])
-{
-  if (sg_get_unaligned_le64(val + 8))
-    return ~(uint64_t)0;
-  return sg_get_unaligned_le64(val);
 }
 
 static void write_nvme_attrlog(FILE * f, const dev_state & state)
@@ -2854,7 +2875,7 @@ static int NVMeDeviceScan(dev_config & cfg, dev_state & state, nvme_device * nvm
 
   // Read SMART/Health log
   // TODO: Support per namespace SMART/Health log
-  nvme_smart_log smart_log;
+  nvme_smart_log & smart_log = state.nvme_smartval;
   if (!nvme_read_smart_log(nvmedev, nvme_broadcast_nsid, smart_log)) {
     PrintOut(LOG_INFO, "Device: %s, failed to read NVMe SMART/Health Information\n", name);
     CloseDevice(nvmedev, name);
@@ -2902,9 +2923,10 @@ static int NVMeDeviceScan(dev_config & cfg, dev_state & state, nvme_device * nvm
   }
 
   // If no supported tests selected, return
-  if (!(   cfg.smartcheck || cfg.errorlog || cfg.xerrorlog
+  if (!(   cfg.smartcheck || cfg.prefail
+        || cfg.errorlog   || cfg.xerrorlog
         || cfg.selftest   || cfg.selfteststs || !cfg.test_regex.empty()
-        || cfg.tempdiff   || cfg.tempinfo || cfg.tempcrit )            ) {
+        || cfg.tempdiff   || cfg.tempinfo || cfg.tempcrit              )) {
     CloseDevice(nvmedev, name);
     return 3;
   }
@@ -3959,6 +3981,25 @@ static int SCSICheckDevice(const dev_config & cfg, dev_state & state, scsi_devic
   return 0;
 }
 
+// Log changes of a NVMe SMART/Health value
+static void log_nvme_smart_change(const dev_config & cfg, dev_state & state,
+  const char * valname, uint64_t oldval, uint64_t newval, bool critical)
+{
+  if (newval == oldval)
+    return;
+
+  std::string msg = strprintf("Device: %s, SMART/Health value: %s changed "
+                              "from %" PRIu64 " to %" PRIu64,
+                              cfg.name.c_str(), valname, oldval, newval);
+  if (!critical)
+    PrintOut(LOG_INFO, "%s\n", msg.c_str());
+  else {
+    PrintOut(LOG_CRIT, "%s\n", msg.c_str());
+    MailWarning(cfg, state, 2, "%s", msg.c_str());
+  }
+  state.must_write = true;
+}
+
 // Log NVMe self-test execution status changes
 static void log_nvme_self_test_exec_status(const char * name, dev_state & state, bool firstpass,
                                            const nvme_self_test_log & self_test_log)
@@ -4108,7 +4149,7 @@ static int NVMeCheckDevice(const dev_config & cfg, dev_state & state, nvme_devic
 
   // Read SMART/Health log
   // TODO: Support per namespace SMART/Health log
-  nvme_smart_log & smart_log = state.nvme_smartval;
+  nvme_smart_log smart_log;
   if (!nvme_read_smart_log(nvmedev, nvme_broadcast_nsid, smart_log)) {
       CloseDevice(nvmedev, name);
       PrintOut(LOG_INFO, "Device: %s, failed to read NVMe SMART/Health Information\n", name);
@@ -4141,6 +4182,24 @@ static int NVMeCheckDevice(const dev_config & cfg, dev_state & state, nvme_devic
     PrintOut(LOG_CRIT, "Device: %s, Critical Warning (0x%02x): %s\n", name, w, msg.c_str());
     MailWarning(cfg, state, 1, "Device: %s, Critical Warning (0x%02x): %s", name, w, msg.c_str());
     state.must_write = true;
+  }
+
+  // Check SMART/Health pre-failure values
+  if (cfg.prefail) {
+    // Names similar to smartctl plaintext output
+    log_nvme_smart_change(cfg, state, "Available Spare",
+      state.nvme_smartval.avail_spare, smart_log.avail_spare,
+      (   smart_log.avail_spare < smart_log.spare_thresh
+       && smart_log.spare_thresh <= 100 /* 101-255: "reserved" */));
+
+    log_nvme_smart_change(cfg, state, "Percentage Used",
+      state.nvme_smartval.percent_used, smart_log.percent_used,
+      (smart_log.percent_used > 95));
+
+    uint64_t old_me = le128_to_uint64(state.nvme_smartval.media_errors);
+    uint64_t new_me = le128_to_uint64(smart_log.media_errors);
+    log_nvme_smart_change(cfg, state, "Media and Data Integrity Errors",
+      old_me, new_me, (new_me > old_me));
   }
 
   // Check temperature limits
@@ -4201,6 +4260,9 @@ static int NVMeCheckDevice(const dev_config & cfg, dev_state & state, nvme_devic
     start_nvme_self_test(cfg, state, nvmedev, testtype, self_test_log);
 
   CloseDevice(nvmedev, name);
+
+  // Preserve new SMART/Health info for state file and attribute log
+  state.nvme_smartval = smart_log;
   state.attrlog_valid = 3; // NVMe attributes valid
   return 0;
 }

--- a/smartmontools/smartd.cpp
+++ b/smartmontools/smartd.cpp
@@ -2,7 +2,7 @@
  * Home page of code is: https://www.smartmontools.org
  *
  * Copyright (C) 2002-11 Bruce Allen
- * Copyright (C) 2008-24 Christian Franke
+ * Copyright (C) 2008-25 Christian Franke
  * Copyright (C) 2000    Michael Cornwell <cornwell@acm.org>
  * Copyright (C) 2008    Oliver Bock <brevilo@users.sourceforge.net>
  *
@@ -3072,7 +3072,7 @@ static char next_scheduled_test(const dev_config & cfg, dev_state & state, time_
 
   // Check interval [state.scheduled_test_next_check, now] for scheduled tests
   char testtype = 0;
-  time_t testtime = 0; int testhour = 0;
+  time_t testtime = 0;
   int maxtest = num_test_types-1;
 
   for (time_t t = state.scheduled_test_next_check; ; ) {
@@ -3110,7 +3110,7 @@ static char next_scheduled_test(const dev_config & cfg, dev_state & state, time_
         if (cfg.test_regex.full_match(pattern)) {
           // Test found
           testtype = pattern[0];
-          testtime = t; testhour = tms->tm_hour;
+          testtime = t;
           // Limit further matches to higher priority self-tests
           maxtest = j-1;
           break;
@@ -3135,7 +3135,7 @@ static char next_scheduled_test(const dev_config & cfg, dev_state & state, time_
   if (testtype) {
     state.must_write = true;
     // Tell user if an old test was found.
-    if (!usetime && !(testhour == tmnow->tm_hour && testtime + 3600 > now)) {
+    if (!usetime && (testtime / 3600) < (now / 3600)) {
       char datebuf[DATEANDEPOCHLEN]; dateandtimezoneepoch(datebuf, testtime);
       PrintOut(LOG_INFO, "Device: %s, old test of type %c not run at %s, starting now.\n",
         cfg.name.c_str(), testtype, datebuf);

--- a/smartmontools/smartd.cpp
+++ b/smartmontools/smartd.cpp
@@ -103,30 +103,18 @@ static void set_signal_if_not_ignored(int sig, signal_handler_type handler)
   // signal() emulation
   daemon_signal(sig, handler);
 
-#elif defined(HAVE_SIGACTION)
-  // SVr4, POSIX.1-2001, POSIX.1-2008
+#else
+  // SVr4, POSIX.1-2001, ..., POSIX.1-2024
   struct sigaction sa;
   sa.sa_handler = SIG_DFL;
   sigaction(sig, (struct sigaction *)0, &sa);
   if (sa.sa_handler == SIG_IGN)
     return;
 
-  memset(&sa, 0, sizeof(sa));
+  sa = {};
   sa.sa_handler = handler;
   sa.sa_flags = SA_RESTART; // BSD signal() semantics
   sigaction(sig, &sa, (struct sigaction *)0);
-
-#elif defined(HAVE_SIGSET)
-  // SVr4, POSIX.1-2001, obsoleted in POSIX.1-2008
-  if (sigset(sig, handler) == SIG_IGN)
-    sigset(sig, SIG_IGN);
-
-#else
-  // POSIX.1-2001, POSIX.1-2008, C89, C99, undefined semantics.
-  // Important: BSD semantics is required.  Traditional signal()
-  // resets the handler to SIG_DFL after the first signal is caught.
-  if (signal(sig, handler) == SIG_IGN)
-    signal(sig, SIG_IGN);
 #endif
 }
 

--- a/smartmontools/smartd.cpp
+++ b/smartmontools/smartd.cpp
@@ -2784,7 +2784,7 @@ static int NVMeDeviceScan(dev_config & cfg, dev_state & state, nvme_device * nvm
   // Format device id string for warning emails
   char nsstr[32] = "", capstr[32] = "";
   unsigned nsid = nvmedev->get_nsid();
-  if (nsid != 0xffffffff)
+  if (nsid != nvme_broadcast_nsid)
     snprintf(nsstr, sizeof(nsstr), ", NSID:%u", nsid);
   uint64_t capacity = le128_to_uint64(id_ctrl.tnvmcap);
   if (capacity)
@@ -2851,7 +2851,7 @@ static int NVMeDeviceScan(dev_config & cfg, dev_state & state, nvme_device * nvm
     std::replace_if(model, model+strlen(model), not_allowed_in_filename, '_');
     std::replace_if(serial, serial+strlen(serial), not_allowed_in_filename, '_');
     nsstr[0] = 0;
-    if (nsid != 0xffffffff)
+    if (nsid != nvme_broadcast_nsid)
       snprintf(nsstr, sizeof(nsstr), "-n%u", nsid);
     cfg.state_file = strprintf("%s%s-%s%s.nvme.state", state_path_prefix.c_str(), model, serial, nsstr);
     // Read previous state

--- a/smartmontools/smartd.cpp
+++ b/smartmontools/smartd.cpp
@@ -527,8 +527,8 @@ struct temp_dev_state
   int powerskipcnt{};                     // Number of checks skipped due to idle or standby mode
   int lastpowermodeskipped{};             // the last power mode that was skipped
 
-  bool attrlog_dirty{};                   // true if persistent part has new attr values that
-                                          // need to be written to attrlog
+  int attrlog_valid{};                    // nonzero if data is valid for protocol specific
+                                          // attribute log: 1=ATA, 2=SCSI, 3=NVMe
 
   // SCSI ONLY
   // TODO: change to bool
@@ -553,6 +553,8 @@ struct temp_dev_state
   // NVMe only
   uint8_t selftest_op{};                  // last self-test operation
   uint8_t selftest_compl{};               // last self-test completion
+
+  nvme_smart_log nvme_smartval{};         // NVMe SMART/Health information for attrlog
 };
 
 /// Runtime state data for a device.
@@ -819,28 +821,17 @@ static bool write_dev_state(const char * path, const persistent_dev_state & stat
   return true;
 }
 
-// Write to the attrlog file
-static bool write_dev_attrlog(const char * path, const dev_state & state)
+static void write_ata_attrlog(FILE * f, const dev_state & state)
 {
-  stdio_file f(path, "a");
-  if (!f) {
-    pout("Cannot create attribute log file \"%s\"\n", path);
-    return false;
-  }
-
-  
-  time_t now = time(nullptr);
-  struct tm tmbuf, * tms = time_to_tm_local(&tmbuf, now);
-  fprintf(f, "%d-%02d-%02d %02d:%02d:%02d;",
-             1900+tms->tm_year, 1+tms->tm_mon, tms->tm_mday,
-             tms->tm_hour, tms->tm_min, tms->tm_sec);
-  // ATA ONLY
   for (const auto & pa : state.ata_attributes) {
     if (!pa.id)
       continue;
     fprintf(f, "\t%d;%d;%" PRIu64 ";", pa.id, pa.val, pa.raw);
   }
-  // SCSI ONLY
+}
+
+static void write_scsi_attrlog(FILE * f, const dev_state & state)
+{
   const struct scsiErrorCounter * ecp;
   const char * pageNames[3] = {"read", "write", "verify"};
   for (int k = 0; k < 3; ++k) {
@@ -867,7 +858,75 @@ static bool write_dev_attrlog(const char * path, const dev_state & state)
   // write SCSI current temperature if it is monitored
   if (state.temperature)
     fprintf(f, "\ttemperature;%d;", state.temperature);
-  // end of line
+}
+
+// Convert 128 bit LE integer to uint64_t or its max value on overflow.
+static uint64_t le128_to_uint64(const unsigned char (& val)[16])
+{
+  if (sg_get_unaligned_le64(val + 8))
+    return ~(uint64_t)0;
+  return sg_get_unaligned_le64(val);
+}
+
+static void write_nvme_attrlog(FILE * f, const dev_state & state)
+{
+  const nvme_smart_log & s = state.nvme_smartval;
+  // Names similar to smartctl JSON output with '-' instead of '_'
+  fprintf(f,
+    "\tcritical-warning;%u;"
+    "\ttemperature;%u;"
+    "\tavailable-spare;%u;"
+    "\tavailable-spare-threshold;%u;"
+    "\tpercent-used;%u;"
+    "\tdata-units-read;%" PRIu64 ";"
+    "\tdata-units-written;%" PRIu64 ";"
+    "\thost-reads;%" PRIu64 ";"
+    "\thost-writes;%" PRIu64 ";"
+    "\tcontroller-busy-time;%" PRIu64 ";"
+    "\tpower-cycles;%" PRIu64 ";"
+    "\tpower-on-hours;%" PRIu64 ";"
+    "\tunsafe-shutdowns;%" PRIu64 ";"
+    "\tmedia-errors;%" PRIu64 ";"
+    "\tnum-err-log-entries;%" PRIu64 ";",
+    s.critical_warning,
+    (int)sg_get_unaligned_le16(s.temperature) - 273,
+    s.avail_spare,
+    s.spare_thresh,
+    s.percent_used,
+    le128_to_uint64(s.data_units_read),
+    le128_to_uint64(s.data_units_written),
+    le128_to_uint64(s.host_reads),
+    le128_to_uint64(s.host_writes),
+    le128_to_uint64(s.ctrl_busy_time),
+    le128_to_uint64(s.power_cycles),
+    le128_to_uint64(s.power_on_hours),
+    le128_to_uint64(s.unsafe_shutdowns),
+    le128_to_uint64(s.media_errors),
+    le128_to_uint64(s.num_err_log_entries)
+  );
+}
+
+// Write to the attrlog file
+static bool write_dev_attrlog(const char * path, const dev_state & state)
+{
+  stdio_file f(path, "a");
+  if (!f) {
+    pout("Cannot create attribute log file \"%s\"\n", path);
+    return false;
+  }
+
+  time_t now = time(nullptr);
+  struct tm tmbuf, * tms = time_to_tm_local(&tmbuf, now);
+  fprintf(f, "%d-%02d-%02d %02d:%02d:%02d;",
+             1900+tms->tm_year, 1+tms->tm_mon, tms->tm_mday,
+             tms->tm_hour, tms->tm_min, tms->tm_sec);
+
+  switch (state.attrlog_valid) {
+    case 1: write_ata_attrlog(f, state); break;
+    case 2: write_scsi_attrlog(f, state); break;
+    case 3: write_nvme_attrlog(f, state); break;
+  }
+
   fprintf(f, "\n");
   return true;
 }
@@ -903,10 +962,13 @@ static void write_all_dev_attrlogs(const dev_config_vector & configs,
     if (cfg.attrlog_file.empty())
       continue;
     dev_state & state = states[i];
-    if (state.attrlog_dirty) {
-      write_dev_attrlog(cfg.attrlog_file.c_str(), state);
-      state.attrlog_dirty = false;
-    }
+    if (!state.attrlog_valid)
+      continue;
+    write_dev_attrlog(cfg.attrlog_file.c_str(), state);
+    state.attrlog_valid = 0;
+    if (debugmode)
+      PrintOut(LOG_INFO, "Device: %s, attribute log written to %s\n",
+               cfg.name.c_str(), cfg.attrlog_file.c_str());
   }
 }
 
@@ -2669,20 +2731,6 @@ static int SCSIDeviceScan(dev_config & cfg, dev_state & state, scsi_device * scs
   return 0;
 }
 
-// Convert 128 bit LE integer to uint64_t or its max value on overflow.
-static uint64_t le128_to_uint64(const unsigned char (& val)[16])
-{
-  for (int i = 8; i < 16; i++) {
-    if (val[i])
-      return ~(uint64_t)0;
-  }
-  uint64_t lo = val[7];
-  for (int i = 7-1; i >= 0; i--) {
-    lo <<= 8; lo += val[i];
-  }
-  return lo;
-}
-
 // Check the NVMe Error Information log for device related errors.
 static bool check_nvme_error_log(const dev_config & cfg, dev_state & state, nvme_device * nvmedev,
   uint64_t newcnt = 0)
@@ -2873,17 +2921,21 @@ static int NVMeDeviceScan(dev_config & cfg, dev_state & state, nvme_device * nvm
 
   CloseDevice(nvmedev, name);
 
-  if (!state_path_prefix.empty()) {
+  if (!state_path_prefix.empty() || !attrlog_path_prefix.empty()) {
     // Build file name for state file
     std::replace_if(model, model+strlen(model), not_allowed_in_filename, '_');
     std::replace_if(serial, serial+strlen(serial), not_allowed_in_filename, '_');
     nsstr[0] = 0;
     if (nsid != nvme_broadcast_nsid)
       snprintf(nsstr, sizeof(nsstr), "-n%u", nsid);
-    cfg.state_file = strprintf("%s%s-%s%s.nvme.state", state_path_prefix.c_str(), model, serial, nsstr);
-    // Read previous state
-    if (read_dev_state(cfg.state_file.c_str(), state))
-      PrintOut(LOG_INFO, "Device: %s, state read from %s\n", name, cfg.state_file.c_str());
+    if (!state_path_prefix.empty()) {
+      cfg.state_file = strprintf("%s%s-%s%s.nvme.state", state_path_prefix.c_str(), model, serial, nsstr);
+      // Read previous state
+      if (read_dev_state(cfg.state_file.c_str(), state))
+        PrintOut(LOG_INFO, "Device: %s, state read from %s\n", name, cfg.state_file.c_str());
+    }
+    if (!attrlog_path_prefix.empty())
+      cfg.attrlog_file = strprintf("%s%s-%s%s.nvme.csv", attrlog_path_prefix.c_str(), model, serial, nsstr);
   }
 
   finish_device_scan(cfg, state);
@@ -3766,7 +3818,7 @@ static int ATACheckDevice(const dev_config & cfg, dev_state & state, ata_device 
       // Save the new values for the next time around
       state.smartval = curval;
       state.update_persistent_state();
-      state.attrlog_dirty = true;
+      state.attrlog_valid = 1; // ATA attributes valid
     }
   }
   state.offline_started = state.selftest_started = false;
@@ -3903,7 +3955,7 @@ static int SCSICheckDevice(const dev_config & cfg, dev_state & state, scsi_devic
       state.temperature = currenttemp;
   }
   CloseDevice(scsidev, name);
-  state.attrlog_dirty = true;
+  state.attrlog_valid = 2; // SCSI attributes valid
   return 0;
 }
 
@@ -4056,7 +4108,7 @@ static int NVMeCheckDevice(const dev_config & cfg, dev_state & state, nvme_devic
 
   // Read SMART/Health log
   // TODO: Support per namespace SMART/Health log
-  nvme_smart_log smart_log;
+  nvme_smart_log & smart_log = state.nvme_smartval;
   if (!nvme_read_smart_log(nvmedev, nvme_broadcast_nsid, smart_log)) {
       CloseDevice(nvmedev, name);
       PrintOut(LOG_INFO, "Device: %s, failed to read NVMe SMART/Health Information\n", name);
@@ -4149,7 +4201,7 @@ static int NVMeCheckDevice(const dev_config & cfg, dev_state & state, nvme_devic
     start_nvme_self_test(cfg, state, nvmedev, testtype, self_test_log);
 
   CloseDevice(nvmedev, name);
-  state.attrlog_dirty = true;
+  state.attrlog_valid = 3; // NVMe attributes valid
   return 0;
 }
 

--- a/smartmontools/smartd.cpp
+++ b/smartmontools/smartd.cpp
@@ -2804,8 +2804,9 @@ static int NVMeDeviceScan(dev_config & cfg, dev_state & state, nvme_device * nvm
   }
 
   // Read SMART/Health log
+  // TODO: Support per namespace SMART/Health log
   nvme_smart_log smart_log;
-  if (!nvme_read_smart_log(nvmedev, smart_log)) {
+  if (!nvme_read_smart_log(nvmedev, nvme_broadcast_nsid, smart_log)) {
     PrintOut(LOG_INFO, "Device: %s, failed to read NVMe SMART/Health Information\n", name);
     CloseDevice(nvmedev, name);
     return 2;
@@ -3890,8 +3891,9 @@ static int NVMeCheckDevice(const dev_config & cfg, dev_state & state, nvme_devic
   const char * name = cfg.name.c_str();
 
   // Read SMART/Health log
+  // TODO: Support per namespace SMART/Health log
   nvme_smart_log smart_log;
-  if (!nvme_read_smart_log(nvmedev, smart_log)) {
+  if (!nvme_read_smart_log(nvmedev, nvme_broadcast_nsid, smart_log)) {
       CloseDevice(nvmedev, name);
       PrintOut(LOG_INFO, "Device: %s, failed to read NVMe SMART/Health Information\n", name);
       MailWarning(cfg, state, 6, "Device: %s, failed to read NVMe SMART/Health Information", name);

--- a/smartmontools/smartd.service.in
+++ b/smartmontools/smartd.service.in
@@ -8,6 +8,7 @@ ConditionVirtualization=no
 
 [Service]
 Type=notify
+Environment=smartd_opts=''
 EnvironmentFile=-/usr/local/etc/sysconfig/smartmontools
 ExecStart=/usr/local/sbin/smartd -n $smartd_opts
 ExecReload=/bin/kill -HUP $MAINPID

--- a/smartmontools/update-smart-drivedb.in
+++ b/smartmontools/update-smart-drivedb.in
@@ -396,7 +396,7 @@ pnILDDMBUNQMBm/XlCYQUetyrJnAVzFGXurtjEXQ/DDnbfy2Z8efoG8rtq7v3fxS
 "
       ;;
 
-    RELEASE_7_[023]_DRIVEDB)
+    RELEASE_7_[0235]_DRIVEDB)
 # Smartmontools Signing Key (through 2025) <smartmontools-database@listi.jpberlin.de>
 # Smartmontools Signing Key (through 2020) <smartmontools-database@listi.jpberlin.de>
 # Key ID 721042C5

--- a/smartmontools/utility.cpp
+++ b/smartmontools/utility.cpp
@@ -4,7 +4,7 @@
  * Home page of code is: https://www.smartmontools.org
  *
  * Copyright (C) 2002-12 Bruce Allen
- * Copyright (C) 2008-24 Christian Franke
+ * Copyright (C) 2008-25 Christian Franke
  * Copyright (C) 2000 Michael Cornwell <cornwell@acm.org>
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
@@ -103,7 +103,7 @@ std::string format_version_info(const char * prog_name, int lines /* = 2 */)
   if (lines <= 1)
     return info;
 
-  info += "Copyright (C) 2002-24, Bruce Allen, Christian Franke, www.smartmontools.org\n";
+  info += "Copyright (C) 2002-25, Bruce Allen, Christian Franke, www.smartmontools.org\n";
   if (lines == 2)
     return info;
 


### PR DESCRIPTION
This change adds a dedicated drive database entry for
Phison MSD210 Series SSDs and places it under
"Phison Driven SSDs" for better classification.

Database-only update; no functional code changes.